### PR TITLE
lint: don't use lambdas for non-lambda stuff

### DIFF
--- a/connect.js
+++ b/connect.js
@@ -1,5 +1,5 @@
 // See https://dashplatform.readme.io/docs/tutorial-connecting-to-testnet
-const Dash = require('dash');
+const Dash = require("dash");
 
 const client = new Dash.Client();
 
@@ -8,6 +8,12 @@ async function connect() {
 }
 
 connect()
-  .then((d) => console.log('Connected. Best block hash:\n', d))
-  .catch((e) => console.error('Something went wrong:\n', e))
-  .finally(() => client.disconnect());
+  .then(function (d) {
+    console.log("Connected. Best block hash:\n", d);
+  })
+  .catch(function (e) {
+    console.error("Something went wrong:\n", e);
+  })
+  .then(function () {
+    client.disconnect();
+  });


### PR DESCRIPTION
It's confusing to use mathematical lambdas where you're not returning a value or doing math