### PR TITLE
fix: add simple file-based browser-like storage

### DIFF
--- a/create-wallet.js
+++ b/create-wallet.js
@@ -1,14 +1,24 @@
+"use strict";
+
 // See https://dashplatform.readme.io/docs/tutorial-create-and-fund-a-wallet
-const Dash = require('dash');
+const Dash = require("dash");
+
+const DomStorage = require("dom-storage");
+const myLocalStorage = new DomStorage("./db.json", { strict: true, ws: "  " });
+const JsonStorage = require("json-storage").JsonStorage;
+const store = JsonStorage.create(myLocalStorage, "dash", { stringify: true });
+store.getItem = store.get;
+store.setItem = store.set;
 
 const clientOpts = {
-  network: 'testnet',
+  network: "testnet",
   wallet: {
+    adapter: store,
     mnemonic: null, // this indicates that we want a new wallet to be generated
-                    // if you want to get a new address for an existing wallet
-                    // replace 'null' with an existing wallet mnemonic
-    offlineMode: true,  // this indicates we don't want to sync the chain
-                        // it can only be used when the mnemonic is set to 'null'
+    // if you want to get a new address for an existing wallet
+    // replace 'null' with an existing wallet mnemonic
+    offlineMode: true, // this indicates we don't want to sync the chain
+    // it can only be used when the mnemonic is set to 'null'
   },
 };
 
@@ -19,16 +29,16 @@ const createWallet = async () => {
 
   const mnemonic = client.wallet.exportWallet();
   const address = account.getUnusedAddress();
-  console.log('Mnemonic:', mnemonic);
-  console.log('Unused address:', address.address);
+  console.log("Mnemonic:", mnemonic);
+  console.log("Unused address:", address.address);
 };
 
 createWallet()
-  .catch((e) => console.error('Something went wrong:\n', e))
+  .catch((e) => console.error("Something went wrong:\n", e))
   .finally(() => client.disconnect());
 
 // Handle wallet async errors
-client.on('error', (error, context) => {
+client.on("error", (error, context) => {
   console.error(`Client error: ${error.name}`);
   console.error(context);
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,9 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "dash": "^3.22.7"
+        "dash": "^3.22.7",
+        "dom-storage": "^2.1.0",
+        "json-storage": "^2.1.2"
       },
       "devDependencies": {
         "dotenv": "^16.0.0",
@@ -873,6 +875,14 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/dom-storage": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/dom-storage/-/dom-storage-2.1.0.tgz",
+      "integrity": "sha512-g6RpyWXzl0RR6OTElHKBl7nwnK87GUyZMYC7JWsB/IA73vpqK2K6LT39x4VepLxlSsWBFrPVLnsSR5Jyty0+2Q==",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/dotenv": {
       "version": "16.0.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.0.tgz",
@@ -1520,6 +1530,14 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE="
+    },
+    "node_modules/json-storage": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/json-storage/-/json-storage-2.1.2.tgz",
+      "integrity": "sha512-jUCntp87bttsDzO2RCHEFtv3CabycupCcXknPkvUwWW5UBHqc6gIl2g52w9U5efxT9imNUk/R+XT2wZouKfNFQ==",
+      "engines": {
+        "node": ">= v0.2.0"
+      }
     },
     "node_modules/kuler": {
       "version": "2.0.0",
@@ -3053,6 +3071,11 @@
         "esutils": "^2.0.2"
       }
     },
+    "dom-storage": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/dom-storage/-/dom-storage-2.1.0.tgz",
+      "integrity": "sha512-g6RpyWXzl0RR6OTElHKBl7nwnK87GUyZMYC7JWsB/IA73vpqK2K6LT39x4VepLxlSsWBFrPVLnsSR5Jyty0+2Q=="
+    },
     "dotenv": {
       "version": "16.0.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.0.tgz",
@@ -3540,6 +3563,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE="
+    },
+    "json-storage": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/json-storage/-/json-storage-2.1.2.tgz",
+      "integrity": "sha512-jUCntp87bttsDzO2RCHEFtv3CabycupCcXknPkvUwWW5UBHqc6gIl2g52w9U5efxT9imNUk/R+XT2wZouKfNFQ=="
     },
     "kuler": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
   },
   "homepage": "https://github.com/dashevo/platform-readme-tutorials#readme",
   "dependencies": {
-    "dash": "^3.22.7"
+    "dash": "^3.22.7",
+    "dom-storage": "^2.1.0",
+    "json-storage": "^2.1.2"
   },
   "devDependencies": {
     "dotenv": "^16.0.0",


### PR DESCRIPTION
> warn: Running on a NodeJS env without any specified adapter. Data will not persist.

The warning is given, but there's no documentation on how to fix this. This updates the example to include a simple easy-to-replicate storage adapter.