### PR TITLE
chore: add .prettierrc.json & fmt script

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,9 @@
+{
+  "printWidth": 80,
+  "tabWidth": 2,
+  "singleQuote": false,
+  "bracketSpacing": true,
+  "proseWrap": "always",
+  "semi": true,
+  "trailingComma": "all"
+}

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,7 +1,7 @@
 {
   "printWidth": 80,
   "tabWidth": 2,
-  "singleQuote": false,
+  "singleQuote": true,
   "bracketSpacing": true,
   "proseWrap": "always",
   "semi": true,

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Tutorial code for dashplatform.readme.io",
   "main": "connect.js",
   "scripts": {
+    "fmt": "npx prettier@2 --write '**/*.{md,js}'",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {


### PR DESCRIPTION
There's a mix of code styles in this repo. It makes VSCode, vim, etc unhappy (and extremely difficult to make atomic PRs). This adds .prettierrc.json so that there's no conflicts between basic elements of code styles - quotes, spacing, etc.

The .prettierrc.json is mostly explicit defaults. Very defaulty, non-controversial stuff.