### PR TITLE
refactor: client => dapi

### DIFF
--- a/1-Identities-and-Names/identity-register.js
+++ b/1-Identities-and-Names/identity-register.js
@@ -3,7 +3,7 @@ const Dash = require('dash');
 const dotenv = require('dotenv');
 dotenv.config();
 
-const clientOpts = {
+const dapiOpts = {
   network: 'testnet',
   wallet: {
     mnemonic: process.env.MNEMONIC, // A Dash wallet mnemonic with testnet funds
@@ -12,13 +12,13 @@ const clientOpts = {
     },
   },
 };
-const client = new Dash.Client(clientOpts);
+const dapi = new Dash.Client(dapiOpts);
 
 const createIdentity = async () => {
-  return client.platform.identities.register();
+  return dapi.platform.identities.register();
 };
 
 createIdentity()
   .then((d) => console.log('Identity:\n', d.toJSON()))
   .catch((e) => console.error('Something went wrong:\n', e))
-  .finally(() => client.disconnect());
+  .finally(() => dapi.disconnect());

--- a/1-Identities-and-Names/identity-retrieve-account-ids.js
+++ b/1-Identities-and-Names/identity-retrieve-account-ids.js
@@ -3,7 +3,7 @@ const Dash = require('dash');
 const dotenv = require('dotenv');
 dotenv.config();
 
-const client = new Dash.Client({
+const dapi = new Dash.Client({
   network: 'testnet',
   wallet: {
     mnemonic: process.env.MNEMONIC, // A Dash wallet mnemonic with testnet funds
@@ -14,11 +14,11 @@ const client = new Dash.Client({
 });
 
 const retrieveIdentityIds = async () => {
-  const account = await client.getWalletAccount();
+  const account = await dapi.getWalletAccount();
   return account.identities.getIdentityIds();
 };
 
 retrieveIdentityIds()
   .then((d) => console.log('Mnemonic identities:\n', d))
   .catch((e) => console.error('Something went wrong:\n', e))
-  .finally(() => client.disconnect());
+  .finally(() => dapi.disconnect());

--- a/1-Identities-and-Names/identity-retrieve.js
+++ b/1-Identities-and-Names/identity-retrieve.js
@@ -3,13 +3,13 @@ const Dash = require('dash');
 const dotenv = require('dotenv');
 dotenv.config();
 
-const client = new Dash.Client();
+const dapi = new Dash.Client();
 
 const retrieveIdentity = async () => {
-  return client.platform.identities.get(process.env.IDENTITY_ID); // Your identity ID
+  return dapi.platform.identities.get(process.env.IDENTITY_ID); // Your identity ID
 };
 
 retrieveIdentity()
   .then((d) => console.log('Identity retrieved:\n', d.toJSON()))
   .catch((e) => console.error('Something went wrong:\n', e))
-  .finally(() => client.disconnect());
+  .finally(() => dapi.disconnect());

--- a/1-Identities-and-Names/identity-topup.js
+++ b/1-Identities-and-Names/identity-topup.js
@@ -3,7 +3,7 @@ const Dash = require('dash');
 const dotenv = require('dotenv');
 dotenv.config();
 
-const clientOpts = {
+const dapiOpts = {
   network: 'testnet',
   wallet: {
     mnemonic: process.env.MNEMONIC, // A Dash wallet mnemonic with testnet funds
@@ -12,17 +12,17 @@ const clientOpts = {
     },
   },
 };
-const client = new Dash.Client(clientOpts);
+const dapi = new Dash.Client(dapiOpts);
 
 const topupIdentity = async () => {
   const identityId = process.env.IDENTITY_ID; // Your identity ID
   const topUpAmount = 1000; // Number of duffs
 
-  await client.platform.identities.topUp(identityId, topUpAmount);
-  return client.platform.identities.get(identityId);
+  await dapi.platform.identities.topUp(identityId, topUpAmount);
+  return dapi.platform.identities.get(identityId);
 };
 
 topupIdentity()
   .then((d) => console.log('Identity credit balance: ', d.balance))
   .catch((e) => console.error('Something went wrong:\n', e))
-  .finally(() => client.disconnect());
+  .finally(() => dapi.disconnect());

--- a/1-Identities-and-Names/name-register-alias.js
+++ b/1-Identities-and-Names/name-register-alias.js
@@ -5,7 +5,7 @@ dotenv.config();
 
 const aliasToRegister = ''; // Enter alias to register
 
-const clientOpts = {
+const dapiOpts = {
   wallet: {
     mnemonic: process.env.MNEMONIC,  // A Dash wallet mnemonic with testnet funds
     unsafeOptions: {
@@ -13,10 +13,10 @@ const clientOpts = {
     },
   },
 };
-const client = new Dash.Client(clientOpts);
+const dapi = new Dash.Client(dapiOpts);
 
 const registerAlias = async () => {
-  const platform = client.platform;
+  const platform = dapi.platform;
   const identity = await platform.identities.get(process.env.IDENTITY_ID); // Your identity ID
   const aliasRegistration = await platform.names.register(
     `${aliasToRegister}.dash`,
@@ -30,4 +30,4 @@ const registerAlias = async () => {
 registerAlias()
   .then((d) => console.log('Alias registered:\n', d.toJSON()))
   .catch((e) => console.error('Something went wrong:\n', e))
-  .finally(() => client.disconnect());
+  .finally(() => dapi.disconnect());

--- a/1-Identities-and-Names/name-register.js
+++ b/1-Identities-and-Names/name-register.js
@@ -5,7 +5,7 @@ dotenv.config();
 
 const nameToRegister = ''; // Enter name to register
 
-const clientOpts = {
+const dapiOpts = {
   wallet: {
     mnemonic: process.env.MNEMONIC,  // A Dash wallet mnemonic with testnet funds
     unsafeOptions: {
@@ -13,10 +13,10 @@ const clientOpts = {
     },
   },
 };
-const client = new Dash.Client(clientOpts);
+const dapi = new Dash.Client(dapiOpts);
 
 const registerName = async () => {
-  const { platform } = client;
+  const { platform } = dapi;
 
   const identity = await platform.identities.get(process.env.IDENTITY_ID); // Your identity ID
   const nameRegistration = await platform.names.register(
@@ -31,4 +31,4 @@ const registerName = async () => {
 registerName()
   .then((d) => console.log('Name registered:\n', d.toJSON()))
   .catch((e) => console.error('Something went wrong:\n', e))
-  .finally(() => client.disconnect());
+  .finally(() => dapi.disconnect());

--- a/1-Identities-and-Names/name-resolve-by-name.js
+++ b/1-Identities-and-Names/name-resolve-by-name.js
@@ -1,16 +1,16 @@
 // See https://dashplatform.readme.io/docs/tutorial-retrieve-a-name
 const Dash = require('dash');
 
-const client = new Dash.Client();
+const dapi = new Dash.Client();
 
 const nameToRetrieve = ''; // Enter name to retrieve
 
 const retrieveName = async () => {
   // Retrieve by full name (e.g., myname.dash)
-  return client.platform.names.resolve(`${nameToRetrieve}.dash`);
+  return dapi.platform.names.resolve(`${nameToRetrieve}.dash`);
 };
 
 retrieveName()
   .then((d) => console.log('Name retrieved:\n', d.toJSON()))
   .catch((e) => console.error('Something went wrong:\n', e))
-  .finally(() => client.disconnect());
+  .finally(() => dapi.disconnect());

--- a/1-Identities-and-Names/name-resolve-by-record.js
+++ b/1-Identities-and-Names/name-resolve-by-record.js
@@ -3,11 +3,11 @@ const Dash = require('dash');
 const dotenv = require('dotenv');
 dotenv.config();
 
-const client = new Dash.Client();
+const dapi = new Dash.Client();
 
 const retrieveNameByRecord = async () => {
   // Retrieve by a name's identity ID
-  return client.platform.names.resolveByRecord(
+  return dapi.platform.names.resolveByRecord(
     'dashUniqueIdentityId',
     process.env.IDENTITY_ID, // Your identity ID
   );
@@ -16,4 +16,4 @@ const retrieveNameByRecord = async () => {
 retrieveNameByRecord()
   .then((d) => console.log('Name retrieved:\n', d[0].toJSON()))
   .catch((e) => console.error('Something went wrong:\n', e))
-  .finally(() => client.disconnect());
+  .finally(() => dapi.disconnect());

--- a/1-Identities-and-Names/name-search-by-name.js
+++ b/1-Identities-and-Names/name-search-by-name.js
@@ -5,11 +5,11 @@ dotenv.config();
 
 const searchPrefix = 'a'; // Enter prefix character(s) to search for
 
-const client = new Dash.Client();
+const dapi = new Dash.Client();
 
 const retrieveNameBySearch = async () => {
   // Search for names (e.g. `user*`)
-  return client.platform.names.search(searchPrefix, 'dash');
+  return dapi.platform.names.search(searchPrefix, 'dash');
 };
 
 retrieveNameBySearch()
@@ -19,4 +19,4 @@ retrieveNameBySearch()
     }
   })
   .catch((e) => console.error('Something went wrong:\n', e))
-  .finally(() => client.disconnect());
+  .finally(() => dapi.disconnect());

--- a/2-Contracts-and-Documents/contract-register-minimal.js
+++ b/2-Contracts-and-Documents/contract-register-minimal.js
@@ -3,7 +3,7 @@ const Dash = require('dash');
 const dotenv = require('dotenv');
 dotenv.config();
 
-const clientOpts = {
+const dapiOpts = {
   wallet: {
     mnemonic: process.env.MNEMONIC, // A Dash wallet mnemonic with testnet funds
     unsafeOptions: {
@@ -11,10 +11,10 @@ const clientOpts = {
     },
   },
 };
-const client = new Dash.Client(clientOpts);
+const dapi = new Dash.Client(dapiOpts);
 
 const registerContract = async () => {
-  const { platform } = client;
+  const { platform } = dapi;
   const identity = await platform.identities.get(process.env.IDENTITY_ID); // Your identity ID
 
   const contractDocuments = {
@@ -48,4 +48,4 @@ const registerContract = async () => {
 registerContract()
   .then((d) => console.log('Contract registered:\n', d.toJSON()))
   .catch((e) => console.error('Something went wrong:\n', e))
-  .finally(() => client.disconnect());
+  .finally(() => dapi.disconnect());

--- a/2-Contracts-and-Documents/contract-retrieve.js
+++ b/2-Contracts-and-Documents/contract-retrieve.js
@@ -3,14 +3,14 @@ const Dash = require('dash');
 const dotenv = require('dotenv');
 dotenv.config();
 
-const client = new Dash.Client();
+const dapi = new Dash.Client();
 
 const retrieveContract = async () => {
   const contractId = process.env.CONTRACT_ID; // Your contract ID
-  return client.platform.contracts.get(contractId);
+  return dapi.platform.contracts.get(contractId);
 };
 
 retrieveContract()
   .then((d) => console.dir(d.toJSON(), { depth: 5 }))
   .catch((e) => console.error('Something went wrong:\n', e))
-  .finally(() => client.disconnect());
+  .finally(() => dapi.disconnect());

--- a/2-Contracts-and-Documents/contract-update-minimal.js
+++ b/2-Contracts-and-Documents/contract-update-minimal.js
@@ -3,7 +3,7 @@ const Dash = require('dash');
 const dotenv = require('dotenv');
 dotenv.config();
 
-const clientOpts = {
+const dapiOpts = {
   wallet: {
     mnemonic: process.env.MNEMONIC, // A Dash wallet mnemonic with testnet funds
     unsafeOptions: {
@@ -11,10 +11,10 @@ const clientOpts = {
     },
   },
 };
-const client = new Dash.Client(clientOpts);
+const dapi = new Dash.Client(dapiOpts);
 
 const updateContract = async () => {
-  const { platform } = client;
+  const { platform } = dapi;
   const identity = await platform.identities.get(process.env.IDENTITY_ID); // Your identity ID
 
   const existingDataContract = await platform.contracts.get(process.env.CONTRACT_ID);
@@ -42,4 +42,4 @@ const updateContract = async () => {
 updateContract()
   .then((d) => console.log('Contract updated:\n', d.toJSON()))
   .catch((e) => console.error('Something went wrong:\n', e))
-  .finally(() => client.disconnect());
+  .finally(() => dapi.disconnect());

--- a/2-Contracts-and-Documents/document-delete.js
+++ b/2-Contracts-and-Documents/document-delete.js
@@ -3,7 +3,7 @@ const Dash = require('dash');
 const dotenv = require('dotenv');
 dotenv.config();
 
-const clientOpts = {
+const dapiOpts = {
   wallet: {
     mnemonic: process.env.MNEMONIC, // A Dash wallet mnemonic with testnet funds
     unsafeOptions: {
@@ -16,15 +16,15 @@ const clientOpts = {
     },
   },
 };
-const client = new Dash.Client(clientOpts);
+const dapi = new Dash.Client(dapiOpts);
 
 const deleteNoteDocument = async () => {
-  const { platform } = client;
+  const { platform } = dapi;
   const identity = await platform.identities.get(process.env.IDENTITY_ID); // Your identity ID
   const documentId = process.env.DOCUMENT_ID; // An existing document
 
   // Retrieve the existing document
-  const [document] = await client.platform.documents.get(
+  const [document] = await dapi.platform.documents.get(
     'tutorialContract.note',
     { where: [['$id', '==', documentId]] },
   );
@@ -36,4 +36,4 @@ const deleteNoteDocument = async () => {
 deleteNoteDocument()
   .then((d) => console.log('Document deleted:\n', d))
   .catch((e) => console.error('Something went wrong:\n', e))
-  .finally(() => client.disconnect());
+  .finally(() => dapi.disconnect());

--- a/2-Contracts-and-Documents/document-retrieve.js
+++ b/2-Contracts-and-Documents/document-retrieve.js
@@ -3,17 +3,17 @@ const Dash = require('dash');
 const dotenv = require('dotenv');
 dotenv.config();
 
-const clientOpts = {
+const dapiOpts = {
   apps: {
     tutorialContract: {
       contractId: process.env.CONTRACT_ID, // Your contract ID
     },
   },
 };
-const client = new Dash.Client(clientOpts);
+const dapi = new Dash.Client(dapiOpts);
 
 const getDocuments = async () => {
-  return client.platform.documents.get(
+  return dapi.platform.documents.get(
     'tutorialContract.note',
     {
       limit: 2, // Only retrieve 2 document
@@ -28,4 +28,4 @@ getDocuments()
     }
   })
   .catch((e) => console.error('Something went wrong:\n', e))
-  .finally(() => client.disconnect());
+  .finally(() => dapi.disconnect());

--- a/2-Contracts-and-Documents/document-submit.js
+++ b/2-Contracts-and-Documents/document-submit.js
@@ -3,7 +3,7 @@ const Dash = require('dash');
 const dotenv = require('dotenv');
 dotenv.config();
 
-const clientOpts = {
+const dapiOpts = {
   network: 'testnet',
   wallet: {
     mnemonic: process.env.MNEMONIC, // A Dash wallet mnemonic with testnet funds
@@ -17,10 +17,10 @@ const clientOpts = {
     },
   },
 };
-const client = new Dash.Client(clientOpts);
+const dapi = new Dash.Client(dapiOpts);
 
 const submitNoteDocument = async () => {
-  const { platform } = client;
+  const { platform } = dapi;
   const identity = await platform.identities.get(process.env.IDENTITY_ID); // Your identity ID
 
   const docProperties = {
@@ -46,4 +46,4 @@ const submitNoteDocument = async () => {
 submitNoteDocument()
   .then((d) => console.log(d.toJSON()))
   .catch((e) => console.error('Something went wrong:\n', e))
-  .finally(() => client.disconnect());
+  .finally(() => dapi.disconnect());

--- a/2-Contracts-and-Documents/document-update.js
+++ b/2-Contracts-and-Documents/document-update.js
@@ -3,7 +3,7 @@ const Dash = require('dash');
 const dotenv = require('dotenv');
 dotenv.config();
 
-const clientOpts = {
+const dapiOpts = {
   wallet: {
     mnemonic: process.env.MNEMONIC, // A Dash wallet mnemonic with testnet funds
     unsafeOptions: {
@@ -16,15 +16,15 @@ const clientOpts = {
     },
   },
 };
-const client = new Dash.Client(clientOpts);
+const dapi = new Dash.Client(dapiOpts);
 
 const updateNoteDocument = async () => {
-  const { platform } = client;
+  const { platform } = dapi;
   const identity = await platform.identities.get(process.env.IDENTITY_ID); // Your identity ID
   const documentId = process.env.DOCUMENT_ID; // An existing document
 
   // Retrieve the existing document
-  const [document] = await client.platform.documents.get(
+  const [document] = await dapi.platform.documents.get(
     'tutorialContract.note',
     { where: [['$id', '==', documentId]] },
   );
@@ -39,4 +39,4 @@ const updateNoteDocument = async () => {
 updateNoteDocument()
   .then((d) => console.log('Document updated:\n', d))
   .catch((e) => console.error('Something went wrong:\n', e))
-  .finally(() => client.disconnect());
+  .finally(() => dapi.disconnect());

--- a/connect.js
+++ b/connect.js
@@ -1,13 +1,13 @@
 // See https://dashplatform.readme.io/docs/tutorial-connecting-to-testnet
 const Dash = require('dash');
 
-const client = new Dash.Client();
+const dapi = new Dash.Client();
 
 async function connect() {
-  return await client.getDAPIClient().core.getBestBlockHash();
+  return await dapi.getDAPIClient().core.getBestBlockHash();
 }
 
 connect()
   .then((d) => console.log('Connected. Best block hash:\n', d))
   .catch((e) => console.error('Something went wrong:\n', e))
-  .finally(() => client.disconnect());
+  .finally(() => dapi.disconnect());

--- a/create-wallet.js
+++ b/create-wallet.js
@@ -1,7 +1,7 @@
 // See https://dashplatform.readme.io/docs/tutorial-create-and-fund-a-wallet
 const Dash = require('dash');
 
-const clientOpts = {
+const dapiOpts = {
   network: 'testnet',
   wallet: {
     mnemonic: null, // this indicates that we want a new wallet to be generated
@@ -12,12 +12,12 @@ const clientOpts = {
   },
 };
 
-const client = new Dash.Client(clientOpts);
+const dapi = new Dash.Client(dapiOpts);
 
 const createWallet = async () => {
-  const account = await client.getWalletAccount();
+  const account = await dapi.getWalletAccount();
 
-  const mnemonic = client.wallet.exportWallet();
+  const mnemonic = dapi.wallet.exportWallet();
   const address = account.getUnusedAddress();
   console.log('Mnemonic:', mnemonic);
   console.log('Unused address:', address.address);
@@ -25,10 +25,10 @@ const createWallet = async () => {
 
 createWallet()
   .catch((e) => console.error('Something went wrong:\n', e))
-  .finally(() => client.disconnect());
+  .finally(() => dapi.disconnect());
 
 // Handle wallet async errors
-client.on('error', (error, context) => {
+dapi.on('error', (error, context) => {
   console.error(`Client error: ${error.name}`);
   console.error(context);
 });

--- a/send-funds.js
+++ b/send-funds.js
@@ -3,7 +3,7 @@ const Dash = require('dash');
 const dotenv = require('dotenv');
 dotenv.config();
 
-const clientOpts = {
+const dapiOpts = {
   network: 'testnet',
   wallet: {
     mnemonic: process.env.MNEMONIC, // A Dash wallet mnemonic with testnet funds
@@ -12,10 +12,10 @@ const clientOpts = {
     },
   },
 };
-const client = new Dash.Client(clientOpts);
+const dapi = new Dash.Client(dapiOpts);
 
 const sendFunds = async () => {
-  const account = await client.getWalletAccount();
+  const account = await dapi.getWalletAccount();
 
   const transaction = account.createTransaction({
     recipient: 'yP8A3cbdxRtLRduy5mXDsBnJtMzHWs6ZXr', // Testnet faucet
@@ -27,10 +27,10 @@ const sendFunds = async () => {
 sendFunds()
   .then((d) => console.log('Transaction broadcast!\nTransaction ID:', d))
   .catch((e) => console.error('Something went wrong:\n', e))
-  .finally(() => client.disconnect());
+  .finally(() => dapi.disconnect());
 
 // Handle wallet async errors
-client.on('error', (error, context) => {
+dapi.on('error', (error, context) => {
   console.error(`Client error: ${error.name}`);
   console.error(context);
 });

--- a/use-dapi-client-methods.js
+++ b/use-dapi-client-methods.js
@@ -1,17 +1,17 @@
-// See https://dashplatform.readme.io/docs/tutorial-use-dapi-client-methods
+// See https://dashplatform.readme.io/docs/tutorial-use-dapi-dapi-methods
 const Dash = require('dash');
 
-const client = new Dash.Client();
+const dapi = new Dash.Client();
 
 async function dapiClientMethods() {
-  console.log(await client.getDAPIClient().core.getBlockHash(1));
-  console.log(await client.getDAPIClient().core.getBestBlockHash());
-  console.log(await client.getDAPIClient().core.getBlockByHeight(1));
+  console.log(await dapi.getDAPIClient().core.getBlockHash(1));
+  console.log(await dapi.getDAPIClient().core.getBestBlockHash());
+  console.log(await dapi.getDAPIClient().core.getBlockByHeight(1));
 
-  return client.getDAPIClient().core.getStatus();
+  return dapi.getDAPIClient().core.getStatus();
 }
 
 dapiClientMethods()
   .then((d) => console.log('Core status:\n', d))
   .catch((e) => console.error('Something went wrong:\n', e))
-  .finally(() => client.disconnect());
+  .finally(() => dapi.disconnect());


### PR DESCRIPTION
"client" is too generic - sounds like it could refer to a http or tcp client, however, this is highly specific to the platform, so it makes sense to call this `dapi` as to not be confused with other clients that may exist in the code and be more clear to the reader