### PR TITLE
ci: update dependency check for correct package

### DIFF
--- a/.github/workflows/dependency-update.yml
+++ b/.github/workflows/dependency-update.yml
@@ -34,23 +34,21 @@ jobs:
         run: |
           set -e  # Stop execution on any error
 
-          # Get the current version of Dash in package.json
+          # Get the installed version from the lockfile (not the declared specifier)
+          INSTALLED_VERSION=$(npm ls @dashevo/evo-sdk --json | jq -r '.dependencies["@dashevo/evo-sdk"].version')
           CURRENT_DASH_VERSION=$(jq -r '.dependencies["@dashevo/evo-sdk"] // .devDependencies["@dashevo/evo-sdk"]' package.json)
-          
-          # Extract the version prefix (e.g., ^, ~, or empty)
           DASH_PREFIX=$(echo "$CURRENT_DASH_VERSION" | grep -o '^[^0-9]*')
-          DASH_VERSION_NUMBER=$(echo "$CURRENT_DASH_VERSION" | grep -o '[0-9].*')
 
           # Get the latest version of Dash
           LATEST_DASH_VERSION=$(npm show @dashevo/evo-sdk version)
           LATEST_MINOR_PATCH=$(echo "$LATEST_DASH_VERSION" | cut -d. -f2,3)
 
-          echo "Current @dashevo/evo-sdk version: $CURRENT_DASH_VERSION"
+          echo "Installed @dashevo/evo-sdk version: $INSTALLED_VERSION"
           echo "Latest @dashevo/evo-sdk version: $LATEST_DASH_VERSION"
 
-          # Only update if the latest stable version is strictly higher than current
+          # Only update if the latest stable version is strictly higher than installed
           # npx semver returns the version if it satisfies the range, empty otherwise
-          IS_HIGHER=$(npx -y semver "$LATEST_DASH_VERSION" -r ">$DASH_VERSION_NUMBER" || true)
+          IS_HIGHER=$(npx -y semver "$LATEST_DASH_VERSION" -r ">$INSTALLED_VERSION" || true)
 
           if [ -n "$IS_HIGHER" ]; then
             jq '.dependencies["@dashevo/evo-sdk"] = "'"$DASH_PREFIX$LATEST_DASH_VERSION"'"' package.json > package.json.tmp && mv package.json.tmp package.json


### PR DESCRIPTION
Checks for @dashevo/evo-sdk now and only opens PR if the stable version is a higher version than currently installed version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow to target and manage the @dashevo/evo-sdk package (renamed job, branch, PR and logs to reference the SDK).
  * Improved version-checking to use semver comparisons so updates are applied only when a newer stable SDK is available.
  * Streamlined automated install, package.json updates, commit messages, and PR creation to reference the SDK and produce clearer update logs and PRs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->