### PR TITLE
perf(dashnote): defer SDK value imports in note + contract helpers

### DIFF
--- a/example-apps/dashnote/src/dash/contract.ts
+++ b/example-apps/dashnote/src/dash/contract.ts
@@ -5,10 +5,25 @@
  *   sdk.contracts.publish({ dataContract, identityKey, signer })
  *   sdk.identities.nonce(identityId)
  */
-import { DataContract, Identifier } from "@dashevo/evo-sdk";
-
 import type { Logger } from "../lib/logger";
 import type { DashKeyManager, DashSdk } from "./types";
+
+// Defer the @dashevo/evo-sdk value import so it doesn't anchor the SDK chunk
+// to the entry graph via SessionContext + LoginModal's static imports of this
+// file. Synchronous exports below (NOTE_SCHEMAS, loadStoredContractId, etc.)
+// don't touch the SDK and stay sync because SessionContext calls them during
+// initial render. Cached after first call; cleared on failure for retry.
+type SdkModule = typeof import("@dashevo/evo-sdk");
+let sdkModulePromise: Promise<SdkModule> | null = null;
+function loadSdkModule(): Promise<SdkModule> {
+  if (!sdkModulePromise) {
+    sdkModulePromise = import("@dashevo/evo-sdk").catch((err) => {
+      sdkModulePromise = null;
+      throw err;
+    });
+  }
+  return sdkModulePromise;
+}
 
 export const NOTE_SCHEMAS = {
   note: {
@@ -78,6 +93,7 @@ export async function refreshContractCache({
   if (!contractId || typeof sdk.getWasmSdkConnected !== "function") return;
   const wasm = await sdk.getWasmSdkConnected();
   if (!wasm || typeof wasm.removeCachedContract !== "function") return;
+  const { Identifier } = await loadSdkModule();
   const identifier = new Identifier(contractId);
   try {
     wasm.removeCachedContract(identifier);
@@ -98,6 +114,7 @@ export async function registerContract({
   log?.("Registering Dashnote note contract…");
   const { identity, identityKey, signer } = await keyManager.getAuth();
   const identityNonce = await sdk.identities.nonce(identity.id.toString());
+  const { DataContract } = await loadSdkModule();
   const dataContract = new DataContract({
     ownerId: identity.id,
     identityNonce: (identityNonce || 0n) + 1n,

--- a/example-apps/dashnote/src/dash/contract.ts
+++ b/example-apps/dashnote/src/dash/contract.ts
@@ -6,24 +6,8 @@
  *   sdk.identities.nonce(identityId)
  */
 import type { Logger } from "../lib/logger";
+import { loadSdkModule } from "./sdkModule";
 import type { DashKeyManager, DashSdk } from "./types";
-
-// Defer the @dashevo/evo-sdk value import so it doesn't anchor the SDK chunk
-// to the entry graph via SessionContext + LoginModal's static imports of this
-// file. Synchronous exports below (NOTE_SCHEMAS, loadStoredContractId, etc.)
-// don't touch the SDK and stay sync because SessionContext calls them during
-// initial render. Cached after first call; cleared on failure for retry.
-type SdkModule = typeof import("@dashevo/evo-sdk");
-let sdkModulePromise: Promise<SdkModule> | null = null;
-function loadSdkModule(): Promise<SdkModule> {
-  if (!sdkModulePromise) {
-    sdkModulePromise = import("@dashevo/evo-sdk").catch((err) => {
-      sdkModulePromise = null;
-      throw err;
-    });
-  }
-  return sdkModulePromise;
-}
 
 export const NOTE_SCHEMAS = {
   note: {

--- a/example-apps/dashnote/src/dash/createNote.ts
+++ b/example-apps/dashnote/src/dash/createNote.ts
@@ -3,10 +3,23 @@
  *
  * SDK method: sdk.documents.create({ document, identityKey, signer })
  */
-import { Document } from "@dashevo/evo-sdk";
-
 import type { Logger } from "../lib/logger";
 import type { DashKeyManager, DashSdk } from "./types";
+
+// Defer the @dashevo/evo-sdk value import so it doesn't anchor the SDK chunk
+// to the entry graph via NotesWorkspace's static import of this file. Cached
+// after first call; cleared on failure so a transient chunk fetch can retry.
+type SdkModule = typeof import("@dashevo/evo-sdk");
+let sdkModulePromise: Promise<SdkModule> | null = null;
+function loadSdkModule(): Promise<SdkModule> {
+  if (!sdkModulePromise) {
+    sdkModulePromise = import("@dashevo/evo-sdk").catch((err) => {
+      sdkModulePromise = null;
+      throw err;
+    });
+  }
+  return sdkModulePromise;
+}
 
 export interface CreateNoteParams {
   sdk: DashSdk;
@@ -27,6 +40,7 @@ export async function createNote({
 }: CreateNoteParams): Promise<string> {
   log?.("Creating note…");
   const { identity, identityKey, signer } = await keyManager.getAuth();
+  const { Document } = await loadSdkModule();
   const trimmedTitle = title?.trim();
   const document = new Document({
     properties: {

--- a/example-apps/dashnote/src/dash/createNote.ts
+++ b/example-apps/dashnote/src/dash/createNote.ts
@@ -4,22 +4,8 @@
  * SDK method: sdk.documents.create({ document, identityKey, signer })
  */
 import type { Logger } from "../lib/logger";
+import { loadSdkModule } from "./sdkModule";
 import type { DashKeyManager, DashSdk } from "./types";
-
-// Defer the @dashevo/evo-sdk value import so it doesn't anchor the SDK chunk
-// to the entry graph via NotesWorkspace's static import of this file. Cached
-// after first call; cleared on failure so a transient chunk fetch can retry.
-type SdkModule = typeof import("@dashevo/evo-sdk");
-let sdkModulePromise: Promise<SdkModule> | null = null;
-function loadSdkModule(): Promise<SdkModule> {
-  if (!sdkModulePromise) {
-    sdkModulePromise = import("@dashevo/evo-sdk").catch((err) => {
-      sdkModulePromise = null;
-      throw err;
-    });
-  }
-  return sdkModulePromise;
-}
 
 export interface CreateNoteParams {
   sdk: DashSdk;

--- a/example-apps/dashnote/src/dash/sdkModule.ts
+++ b/example-apps/dashnote/src/dash/sdkModule.ts
@@ -1,0 +1,17 @@
+// Defer the @dashevo/evo-sdk value import so it doesn't anchor the SDK chunk
+// to the entry graph via files statically imported by SessionContext /
+// LoginModal / NotesWorkspace. Cached after first call; cleared on failure
+// so a transient chunk fetch can retry.
+export type SdkModule = typeof import("@dashevo/evo-sdk");
+
+let sdkModulePromise: Promise<SdkModule> | null = null;
+
+export function loadSdkModule(): Promise<SdkModule> {
+  if (!sdkModulePromise) {
+    sdkModulePromise = import("@dashevo/evo-sdk").catch((err) => {
+      sdkModulePromise = null;
+      throw err;
+    });
+  }
+  return sdkModulePromise;
+}

--- a/example-apps/dashnote/src/dash/updateNote.ts
+++ b/example-apps/dashnote/src/dash/updateNote.ts
@@ -7,22 +7,8 @@
  *   sdk.documents.replace({ document, identityKey, signer })
  */
 import type { Logger } from "../lib/logger";
+import { loadSdkModule } from "./sdkModule";
 import type { DashKeyManager, DashSdk } from "./types";
-
-// Defer the @dashevo/evo-sdk value import so it doesn't anchor the SDK chunk
-// to the entry graph via NotesWorkspace's static import of this file. Cached
-// after first call; cleared on failure so a transient chunk fetch can retry.
-type SdkModule = typeof import("@dashevo/evo-sdk");
-let sdkModulePromise: Promise<SdkModule> | null = null;
-function loadSdkModule(): Promise<SdkModule> {
-  if (!sdkModulePromise) {
-    sdkModulePromise = import("@dashevo/evo-sdk").catch((err) => {
-      sdkModulePromise = null;
-      throw err;
-    });
-  }
-  return sdkModulePromise;
-}
 
 export interface UpdateNoteParams {
   sdk: DashSdk;

--- a/example-apps/dashnote/src/dash/updateNote.ts
+++ b/example-apps/dashnote/src/dash/updateNote.ts
@@ -6,10 +6,23 @@
  *   sdk.documents.get(contractId, documentTypeName, documentId)
  *   sdk.documents.replace({ document, identityKey, signer })
  */
-import { Document } from "@dashevo/evo-sdk";
-
 import type { Logger } from "../lib/logger";
 import type { DashKeyManager, DashSdk } from "./types";
+
+// Defer the @dashevo/evo-sdk value import so it doesn't anchor the SDK chunk
+// to the entry graph via NotesWorkspace's static import of this file. Cached
+// after first call; cleared on failure so a transient chunk fetch can retry.
+type SdkModule = typeof import("@dashevo/evo-sdk");
+let sdkModulePromise: Promise<SdkModule> | null = null;
+function loadSdkModule(): Promise<SdkModule> {
+  if (!sdkModulePromise) {
+    sdkModulePromise = import("@dashevo/evo-sdk").catch((err) => {
+      sdkModulePromise = null;
+      throw err;
+    });
+  }
+  return sdkModulePromise;
+}
 
 export interface UpdateNoteParams {
   sdk: DashSdk;
@@ -37,6 +50,7 @@ export async function updateNote({
     throw new Error(`Note ${noteId} not found.`);
   }
 
+  const { Document } = await loadSdkModule();
   const revision = BigInt(existingDoc.revision ?? 0) + 1n;
   const trimmedTitle = title?.trim();
   const document = new Document({


### PR DESCRIPTION
## Summary

- `contract.ts`, `createNote.ts`, and `updateNote.ts` had top-level `import { Document, DataContract, Identifier } from "@dashevo/evo-sdk"`. Reachable from the entry graph via `SessionContext`, `LoginModal`, and `NotesWorkspace`, this anchored the 8 MB SDK chunk to the boot critical path with a hoisted static import — the `modulePreload` filter in `vite.config.ts` only suppressed the `<link>` tag, not the dependency edge.
- Move each value import behind a per-module lazy cache (matching the `loginWithPrivateKey` pattern from #75 / 2b2c5a0). The synchronous exports of `contract.ts` (`NOTE_SCHEMAS`, `loadStoredContractId`, etc.) stay sync since `SessionContext` calls them during initial render.
- Verified: post-build, `dist/assets/index-*.js` no longer contains `from "./evo-sdk.module-*.js"`; only three dynamic `import()` calls remain.

### Throttled Lighthouse (Slow 4G + 4× CPU, simulated mobile)

| Metric | Before | After |
| --- | --- | --- |
| First Contentful Paint | 16.1 s | 1.7 s |
| Largest Contentful Paint | 30.8 s | 2.0 s |
| Speed Index | 16.1 s | 1.7 s |
| Performance score | 0.55 | 0.98 |

Total bytes transferred is unchanged — the win isn't fewer bytes, it's that those bytes no longer block first paint. The SDK now downloads only when an authenticated path (login, save note, register contract, switch contract ID) actually needs it.

<img width="1466" height="623" alt="image" src="https://github.com/user-attachments/assets/3c8eae59-ad76-49bf-becd-fe22c611a38b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal module loading strategy to enhance startup performance across note management features while preserving all existing functionality and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->