### PR TITLE
fix(dashproof-lab): clear error when crypto.subtle is unavailable

### DIFF
--- a/example-apps/dashproof-lab/public/dashproof-lite.html
+++ b/example-apps/dashproof-lab/public/dashproof-lite.html
@@ -217,6 +217,11 @@
     // SHA-256 via WebCrypto. Runs entirely in the browser; the file never
     // leaves the page.
     async function hashFile(file) {
+      if (typeof crypto === 'undefined' || !crypto.subtle) {
+        throw new Error(
+          'SHA-256 hashing requires a secure context. Open this page over HTTPS or via http://localhost — the browser disables crypto.subtle on plain http:// origins.',
+        );
+      }
       const buf = await file.arrayBuffer();
       return new Uint8Array(await crypto.subtle.digest('SHA-256', buf));
     }

--- a/example-apps/dashproof-lab/src/lib/hash.ts
+++ b/example-apps/dashproof-lab/src/lib/hash.ts
@@ -1,4 +1,9 @@
 export async function hashFile(file: File): Promise<Uint8Array> {
+  if (typeof crypto === "undefined" || !crypto.subtle) {
+    throw new Error(
+      "SHA-256 hashing requires a secure context. Open this app over HTTPS or via http://localhost — the browser disables crypto.subtle on plain http:// origins.",
+    );
+  }
   const buffer =
     typeof file.arrayBuffer === "function"
       ? await file.arrayBuffer()

--- a/example-apps/dashproof-lab/test/hashFile.test.ts
+++ b/example-apps/dashproof-lab/test/hashFile.test.ts
@@ -3,11 +3,21 @@
 // which would make this regression test useless. Node 20+ provides a working
 // global File backed by Undici's Blob implementation.
 
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 
 import { bytesToHex, hashFile } from "../src/lib/hash";
 
 describe("hashFile", () => {
+  const originalSubtle = globalThis.crypto?.subtle;
+  afterEach(() => {
+    if (globalThis.crypto) {
+      Object.defineProperty(globalThis.crypto, "subtle", {
+        configurable: true,
+        value: originalSubtle,
+      });
+    }
+  });
+
   it("hashes binary (non-UTF-8) bytes correctly", async () => {
     // 0xFF 0xFE is invalid UTF-8 — a TextEncoder-based fallback would
     // corrupt these bytes into the U+FFFD replacement character before
@@ -28,6 +38,17 @@ describe("hashFile", () => {
     const digest = await hashFile(file);
     expect(bytesToHex(digest)).toBe(
       "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    );
+  });
+
+  it("throws a clear Secure Context error when crypto.subtle is missing", async () => {
+    Object.defineProperty(globalThis.crypto, "subtle", {
+      configurable: true,
+      value: undefined,
+    });
+    const file = new File([Uint8Array.from([0x00])], "x.bin");
+    await expect(hashFile(file)).rejects.toThrow(
+      "SHA-256 hashing requires a secure context. Open this app over HTTPS or via http://localhost — the browser disables crypto.subtle on plain http:// origins.",
     );
   });
 });


### PR DESCRIPTION
## Summary
- Loading the app over plain `http://` (e.g. bare-IP hosting, non-HTTPS IPFS gateways) crashed with `Cannot read properties of undefined (reading 'digest')` because `crypto.subtle` is only exposed in [Secure Contexts](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts).
- `hashFile` now checks for `crypto.subtle` up front and throws a clear message pointing the user to HTTPS or `http://localhost`. Applied to both the React app ([src/lib/hash.ts](example-apps/dashproof-lab/src/lib/hash.ts)) and the zero-build companion ([public/dashproof-lite.html](example-apps/dashproof-lab/public/dashproof-lite.html)).
- Existing callers in `AnchorForm` and `VerifyPanel` already pipe thrown errors through `errorMessage(err)` into the status UI, so the new message surfaces inline instead of crashing.
- Added a regression test that stubs `crypto.subtle = undefined` and asserts the **exact** error string, so any future reword fails the test rather than silently degrading the diagnostic.

## Test plan
- [x] `npm run test` — 138/138 pass (20 files)
- [x] `npm run format` — clean
- [x] `npm run build` — typecheck + bundle clean
- [ ] Manually load the built app over `http://` and confirm the inline error replaces the cryptic crash
- [ ] Manually load over `https://` / `http://localhost` and confirm hashing still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for non-secure contexts. Users now receive clear instructions to use HTTPS or `http://localhost` instead of encountering cryptic failures during file operations.

* **Tests**
  * Added regression test for secure context validation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dashpay/platform-tutorials/pull/78)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->