### PR TITLE
fix(example-apps): clear eslint issues in dashproof-lab and dashmint-lab

### DIFF
--- a/example-apps/dashmint-lab/test/e2e/fixtures.ts
+++ b/example-apps/dashmint-lab/test/e2e/fixtures.ts
@@ -21,14 +21,14 @@ interface AppFixture {
 export { base as rawTest };
 
 export const test = base.extend<AppFixture>({
-  page: async ({ page }, use) => {
+  page: async ({ page }, provide) => {
     await page.goto("/");
     // Wait until the SDK has connected (sidebar shows "Connected") so any
     // Collection query the spec triggers has a live SDK to talk to.
     await expect(page.getByText("Connected").first()).toBeVisible({
       timeout: 60_000,
     });
-    await use(page);
+    await provide(page);
   },
 });
 

--- a/example-apps/dashproof-lab/eslint.config.js
+++ b/example-apps/dashproof-lab/eslint.config.js
@@ -6,7 +6,7 @@ import tseslint from "typescript-eslint";
 import { defineConfig, globalIgnores } from "eslint/config";
 
 export default defineConfig([
-  globalIgnores(["dist", "playwright-report", "test-results"]),
+  globalIgnores(["coverage", "dist", "playwright-report", "test-results"]),
   {
     files: ["**/*.{ts,tsx}"],
     extends: [

--- a/example-apps/dashproof-lab/src/components/HistoryPanel.tsx
+++ b/example-apps/dashproof-lab/src/components/HistoryPanel.tsx
@@ -53,6 +53,27 @@ export function HistoryPanel({
   const [errorState, setErrorState] = useState<string | null>(null);
   const [toast, setToast] = useState<string | null>(null);
   const toastTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [prevRequestToken, setPrevRequestToken] = useState<number | undefined>(
+    undefined,
+  );
+
+  // Reset state in response to a new parent-issued request (monotonic
+  // requestToken). React docs recommend doing this during render rather than
+  // in an effect — see https://react.dev/learn/you-might-not-need-an-effect.
+  // The sentinel-undefined initial value ensures the reset fires on first
+  // render too (the parent mounts this panel fresh with the token already
+  // bumped).
+  if (prevRequestToken !== requestToken) {
+    setPrevRequestToken(requestToken);
+    const trimmed = requestedChainId?.trim();
+    if (trimmed) {
+      setMode("chain");
+      setChainInput(trimmed);
+      setActiveChainId(trimmed);
+      setAnchors([]);
+      setErrorState(null);
+    }
+  }
 
   const effectiveMode = session.status === "authenticated" ? mode : "chain";
   const canQueryOwner =
@@ -78,16 +99,6 @@ export function HistoryPanel({
     },
     [],
   );
-
-  useEffect(() => {
-    const trimmed = requestedChainId?.trim();
-    if (!trimmed) return;
-    setMode("chain");
-    setChainInput(trimmed);
-    setActiveChainId(trimmed);
-    setAnchors([]);
-    setErrorState(null);
-  }, [requestedChainId, requestToken]);
 
   useEffect(() => {
     if (canQueryOwner) {

--- a/example-apps/dashproof-lab/test/HistoryPanel.test.tsx
+++ b/example-apps/dashproof-lab/test/HistoryPanel.test.tsx
@@ -125,6 +125,96 @@ describe("HistoryPanel", () => {
     expect(chainSections).toHaveLength(1);
   });
 
+  it("loads the parent-requested chainId when requestToken bumps", async () => {
+    // Regression for the render-time prop-reset that replaced the previous
+    // setState-in-useEffect. Parent dispatches a new chainId by bumping
+    // requestToken; the panel should switch to chain mode, populate the
+    // input, and load that chain.
+    mockUseSession.mockReturnValue({
+      status: "readonly",
+      sdk: {},
+      identityId: null,
+      log: vi.fn(),
+    });
+    mockListAnchorsByChain.mockResolvedValue([
+      {
+        id: "anchor-req",
+        ownerId: "owner-x",
+        createdAt: 1710000000000,
+        entryHash: Uint8Array.from([3]),
+        entryHashHex: "03",
+        chainId: "requested-chain",
+        filename: "requested.txt",
+      },
+    ]);
+
+    const { rerender } = render(
+      <HistoryPanel contractId="contract-1" refreshKey={0} requestToken={0} />,
+    );
+
+    rerender(
+      <HistoryPanel
+        contractId="contract-1"
+        refreshKey={0}
+        requestedChainId="requested-chain"
+        requestToken={1}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(mockListAnchorsByChain).toHaveBeenCalledWith(
+        expect.objectContaining({ chainId: "requested-chain" }),
+      );
+    });
+    await screen.findByText("requested.txt");
+    expect(screen.getByDisplayValue("requested-chain")).toBeTruthy();
+  });
+
+  it("does not re-fire the parent-requested reset when requestToken is unchanged", async () => {
+    // The render-time guard (prevRequestToken !== requestToken) must
+    // fire-once-per-token; otherwise unrelated re-renders would clobber any
+    // edit the user made to the chain input after the initial dispatch.
+    mockUseSession.mockReturnValue({
+      status: "readonly",
+      sdk: {},
+      identityId: null,
+      log: vi.fn(),
+    });
+    mockListAnchorsByChain.mockResolvedValue([]);
+
+    const { rerender } = render(
+      <HistoryPanel
+        contractId="contract-1"
+        refreshKey={0}
+        requestedChainId="requested-chain"
+        requestToken={1}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue("requested-chain")).toBeTruthy();
+    });
+
+    // User edits the chain input after the parent's dispatch.
+    fireEvent.change(screen.getByPlaceholderText("invoice-2026-04"), {
+      target: { value: "user-edited" },
+    });
+    expect(screen.getByDisplayValue("user-edited")).toBeTruthy();
+
+    // Unrelated re-render with the same requestToken — must NOT reset the
+    // input back to requestedChainId.
+    rerender(
+      <HistoryPanel
+        contractId="contract-1"
+        refreshKey={1}
+        requestedChainId="requested-chain"
+        requestToken={1}
+      />,
+    );
+
+    expect(screen.getByDisplayValue("user-edited")).toBeTruthy();
+  });
+
   it("loads chain history in read-only mode", async () => {
     mockUseSession.mockReturnValue({
       status: "readonly",


### PR DESCRIPTION
## Summary

- **dashproof-lab** — Add `coverage` to ESLint `globalIgnores` (matches dashnote), replace `HistoryPanel`'s prop-watching `useEffect` with the React-recommended "reset state during render" pattern to fix `react-hooks/set-state-in-effect`, and add two regression tests for the chain deep-link path.
- **dashmint-lab** — Rename the Playwright fixture-API callback parameter from `use` to `provide` so `eslint-plugin-react-hooks` v6 stops flagging `await use(page)` as a misplaced React Hook call.

## Notes

- The `HistoryPanel` change also fixes a subtle latent bug: the new `prevRequestToken` is initialized to `undefined` (not to `requestToken`) so the panel still fires its reset on first render — the parent mounts a fresh panel with the token already bumped, so a same-value initializer would silently swallow the dispatch.
- Root-level `npm run lint` (tsc) errors in `setupDashClient.mjs` are intentionally out of scope for this PR.

## Test plan

- [x] `cd example-apps/dashproof-lab && npm run lint` — zero errors and warnings
- [x] `cd example-apps/dashproof-lab && npm run test` — 139/139 pass (was 137; two new regression tests)
- [x] `cd example-apps/dashproof-lab && npm run build` — clean
- [x] `cd example-apps/dashmint-lab && npm run lint` — zero errors
- [x] `cd example-apps/dashmint-lab && npm run test` — 88/88 pass
- [x] `cd example-apps/dashmint-lab && npm run build` — clean
- [ ] e2e: `cd example-apps/dashproof-lab && npm run test:e2e` — manual run if you want to confirm the "View chain history" deep link still works against testnet

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved history panel state synchronization when switching tokens or chains.
  * Fixed user input preservation in history panel interactions.

* **Tests**
  * Added test coverage for history panel chain mode behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dashpay/platform-tutorials/pull/79)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->