### PR TITLE
feat(dashnote): split settings into tab, menu, and focused login modal

### DIFF
--- a/example-apps/dashnote/src/App.tsx
+++ b/example-apps/dashnote/src/App.tsx
@@ -6,6 +6,7 @@ import { HowItWorks } from "./components/HowItWorks";
 import { LoginModal } from "./components/LoginModal";
 import { NotesWorkspace } from "./components/NotesWorkspace";
 import { OperationResultNotice } from "./components/OperationResultNotice";
+import { SettingsPanel } from "./components/SettingsPanel";
 import type { TopTab } from "./components/Tabs";
 import { useSession } from "./session/useSession";
 
@@ -19,6 +20,11 @@ const screenCopy: Record<TopTab, { title: string; subtitle: string }> = {
     title: "How Dashnote works",
     subtitle:
       "See how the note contract, mutation helpers, and notebook UI line up with the tutorials.",
+  },
+  settings: {
+    title: "Settings",
+    subtitle:
+      "Manage your identity, contract, and local data for this browser.",
   },
 };
 
@@ -86,9 +92,13 @@ function App() {
           )}
 
           {tab === "notes" && (
-            <NotesWorkspace onOpenSettings={() => setLoginOpen(true)} />
+            <NotesWorkspace
+              onOpenLogin={() => setLoginOpen(true)}
+              onOpenSettings={() => setTab("settings")}
+            />
           )}
           {tab === "how-it-works" && <HowItWorks />}
+          {tab === "settings" && <SettingsPanel />}
         </div>
       </AppShell>
 

--- a/example-apps/dashnote/src/components/AppShell.tsx
+++ b/example-apps/dashnote/src/components/AppShell.tsx
@@ -107,6 +107,15 @@ export function AppShell({
           closeDrawer();
         }}
       />
+      <NavButton
+        label="Settings"
+        glyph="⚙"
+        active={tab === "settings"}
+        onClick={() => {
+          onTabChange("settings");
+          closeDrawer();
+        }}
+      />
       {status !== "authenticated" && (
         <NavButton
           label="Login"
@@ -195,6 +204,10 @@ export function AppShell({
             contractId={contractId}
             onLoginClick={() => {
               onLoginOpen();
+              closeDrawer();
+            }}
+            onOpenSettings={() => {
+              onTabChange("settings");
               closeDrawer();
             }}
           />

--- a/example-apps/dashnote/src/components/IdentityCard.tsx
+++ b/example-apps/dashnote/src/components/IdentityCard.tsx
@@ -1,5 +1,8 @@
+import { useEffect, useRef, useState } from "react";
+
 import type { SessionStatus } from "../session/SessionContext";
 import { truncateId } from "../lib/format";
+import { useSession } from "../session/useSession";
 
 interface IdentityCardProps {
   status: SessionStatus;
@@ -7,6 +10,7 @@ interface IdentityCardProps {
   dpnsName: string | null;
   contractId: string | null;
   onLoginClick: () => void;
+  onOpenSettings: () => void;
 }
 
 function avatarGradient(seed: string | null): string {
@@ -26,10 +30,36 @@ export function IdentityCard({
   dpnsName,
   contractId,
   onLoginClick,
+  onOpenSettings,
 }: IdentityCardProps) {
+  const session = useSession();
   const isAuthed = status === "authenticated";
   const isBrowsing = status === "browsing";
-  const isConnected = status === "readonly" || isAuthed || isBrowsing;
+  const isReadonly = status === "readonly";
+  const isConnected = isReadonly || isAuthed || isBrowsing;
+  const hasIdentity = isAuthed || isBrowsing;
+  const [menuOpen, setMenuOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!menuOpen) return;
+    const onPointer = (event: MouseEvent | TouchEvent) => {
+      if (!containerRef.current) return;
+      if (containerRef.current.contains(event.target as Node)) return;
+      setMenuOpen(false);
+    };
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setMenuOpen(false);
+    };
+    document.addEventListener("mousedown", onPointer);
+    document.addEventListener("touchstart", onPointer);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onPointer);
+      document.removeEventListener("touchstart", onPointer);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [menuOpen]);
 
   if (!isConnected) {
     return (
@@ -63,59 +93,126 @@ export function IdentityCard({
     );
   }
 
+  // Read-only mode has nothing to put in a menu (no identity → no Settings
+  // target, no Switch identity, no Log out), so the card goes straight to
+  // the login modal on click — matching the pre-menu behavior.
+  if (isReadonly) {
+    return (
+      <button
+        type="button"
+        onClick={onLoginClick}
+        className="group w-full border-t border-line pt-3.5 text-left"
+      >
+        <div className="flex items-center justify-between">
+          <span className="text-[10px] font-semibold uppercase tracking-[0.12em] text-ink-4">
+            Connected
+          </span>
+          <span className="text-[10px] text-ink-4 opacity-0 transition-opacity group-hover:opacity-100">
+            Sign in
+          </span>
+        </div>
+        <div className="mt-2.5 flex items-center gap-1.5">
+          <span className="conn-dot connected" />
+          <span className="font-mono text-[10.5px] text-ink-3">Connected</span>
+        </div>
+      </button>
+    );
+  }
+
   return (
-    <button
-      type="button"
-      onClick={onLoginClick}
-      className="group w-full border-t border-line pt-3.5 text-left"
-    >
-      {(isAuthed || isBrowsing) && (
-        <>
-          <div className="mb-0.5 flex items-center justify-between">
-            <span className="text-[10px] font-semibold uppercase tracking-[0.12em] text-ink-4">
-              {isAuthed ? "Signed in" : "Read-only"}
-            </span>
-            <span className="text-[10px] text-ink-4 opacity-0 transition-opacity group-hover:opacity-100">
-              {isAuthed ? "Settings" : "Sign in"}
-            </span>
-          </div>
-          <div className="flex items-center gap-2">
-            <div
-              className="h-5 w-5 shrink-0 rounded-full"
-              style={{ background: avatarGradient(identityId) }}
-            />
-            <div className="min-w-0">
-              <div className="truncate text-[12px] font-medium text-ink transition-colors group-hover:text-accent">
-                {dpnsName
-                  ? `@${dpnsName}`
-                  : identityId
+    <div ref={containerRef} className="relative">
+      <button
+        type="button"
+        onClick={() => setMenuOpen((v) => !v)}
+        aria-haspopup="menu"
+        aria-expanded={menuOpen}
+        className="group w-full border-t border-line pt-3.5 text-left"
+      >
+        {hasIdentity && (
+          <>
+            <div className="mb-0.5 flex items-center justify-between">
+              <span className="text-[10px] font-semibold uppercase tracking-[0.12em] text-ink-4">
+                {isAuthed ? "Signed in" : "Read-only"}
+              </span>
+              <span className="text-[10px] text-ink-4 opacity-0 transition-opacity group-hover:opacity-100">
+                Menu
+              </span>
+            </div>
+            <div className="flex items-center gap-2">
+              <div
+                className="h-5 w-5 shrink-0 rounded-full"
+                style={{ background: avatarGradient(identityId) }}
+              />
+              <div className="min-w-0">
+                <div className="truncate text-[12px] font-medium text-ink transition-colors group-hover:text-accent">
+                  {dpnsName
+                    ? `@${dpnsName}`
+                    : identityId
+                      ? truncateId(identityId, 6)
+                      : "Identity"}
+                </div>
+                <div className="truncate font-mono text-[10px] text-ink-4">
+                  {dpnsName && identityId
                     ? truncateId(identityId, 6)
-                    : "Identity"}
-              </div>
-              <div className="truncate font-mono text-[10px] text-ink-4">
-                {dpnsName && identityId
-                  ? truncateId(identityId, 6)
-                  : contractId
-                    ? `contract ${truncateId(contractId, 6)}`
-                    : "No contract"}
+                    : contractId
+                      ? `contract ${truncateId(contractId, 6)}`
+                      : "No contract"}
+                </div>
               </div>
             </div>
-          </div>
-        </>
-      )}
+          </>
+        )}
 
-      <div
-        className={`flex items-center gap-1.5 ${isAuthed || isBrowsing ? "mt-2.5" : ""}`}
-      >
-        <span className="conn-dot connected" />
-        <span className="font-mono text-[10.5px] text-ink-3">
-          {isAuthed
-            ? "Authenticated"
-            : isBrowsing
-              ? "Browsing (read-only)"
-              : "Connected"}
-        </span>
-      </div>
-    </button>
+        <div className="mt-2.5 flex items-center gap-1.5">
+          <span className="conn-dot connected" />
+          <span className="font-mono text-[10.5px] text-ink-3">
+            {isAuthed ? "Authenticated" : "Browsing (read-only)"}
+          </span>
+        </div>
+      </button>
+
+      {menuOpen && (
+        <div
+          role="menu"
+          className="absolute bottom-full left-0 right-0 z-40 mb-2 flex flex-col gap-0.5 rounded-md border border-line bg-surface p-1 shadow-[0_12px_40px_-20px_rgba(0,0,0,0.6)]"
+        >
+          <button
+            type="button"
+            role="menuitem"
+            onClick={() => {
+              setMenuOpen(false);
+              onOpenSettings();
+            }}
+            className="rounded-md px-2 py-1.5 text-left text-[12px] font-medium text-ink-2 transition hover:bg-surface-2 hover:text-ink"
+          >
+            Settings
+          </button>
+          <button
+            type="button"
+            role="menuitem"
+            onClick={() => {
+              setMenuOpen(false);
+              onLoginClick();
+            }}
+            className="rounded-md px-2 py-1.5 text-left text-[12px] font-medium text-ink-2 transition hover:bg-surface-2 hover:text-ink"
+          >
+            Switch identity
+          </button>
+          {isAuthed && (
+            <button
+              type="button"
+              role="menuitem"
+              onClick={() => {
+                setMenuOpen(false);
+                session.logout();
+              }}
+              className="rounded-md px-2 py-1.5 text-left text-[12px] font-medium text-ink-2 transition hover:bg-surface-2 hover:text-ink"
+            >
+              Log out
+            </button>
+          )}
+        </div>
+      )}
+    </div>
   );
 }

--- a/example-apps/dashnote/src/components/LoginModal.tsx
+++ b/example-apps/dashnote/src/components/LoginModal.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useMemo, useState, type FormEvent } from "react";
 
-import { registerContract } from "../dash/contract";
 import { useWifPreview } from "../hooks/useWifPreview";
 import { detectSecretShape } from "../lib/detectSecretShape";
 import { errorMessage } from "../lib/logger";
@@ -21,10 +20,8 @@ export function LoginModal({ open, onClose }: LoginModalProps) {
   const [error, setError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
   const [showAdvanced, setShowAdvanced] = useState(false);
-  const [registering, setRegistering] = useState(false);
   const [rememberMe, setRememberMe] = useState(true);
   const [useDifferentIdentity, setUseDifferentIdentity] = useState(false);
-  const loggedIn = session.status === "authenticated";
   const showRememberedPanel = Boolean(
     session.rememberedIdentityId && !useDifferentIdentity,
   );
@@ -57,25 +54,6 @@ export function LoginModal({ open, onClose }: LoginModalProps) {
     session.setContractId(contractInput.trim() || null);
   }
 
-  async function handleRegisterContract() {
-    if (!session.sdk || !session.keyManager) return;
-    setError(null);
-    setRegistering(true);
-    try {
-      const contractId = await registerContract({
-        sdk: session.sdk,
-        keyManager: session.keyManager,
-        log: session.log,
-      });
-      session.setContractId(contractId);
-      setContractInput(contractId);
-    } catch (err) {
-      setError(errorMessage(err));
-    } finally {
-      setRegistering(false);
-    }
-  }
-
   async function handleLogin(event: FormEvent) {
     event.preventDefault();
     setError(null);
@@ -96,355 +74,234 @@ export function LoginModal({ open, onClose }: LoginModalProps) {
   }
 
   return (
-    <Modal
-      open={open}
-      onClose={onClose}
-      title={loggedIn ? "Settings" : "Login"}
-    >
-      {loggedIn ? (
-        <div className="flex flex-col gap-4 py-2">
-          <div data-testid="settings-identity-block">
-            <div className="mb-1 text-[10px] font-semibold uppercase tracking-[0.12em] text-ink-4">
+    <Modal open={open} onClose={onClose} title="Login">
+      <form onSubmit={handleLogin} className="flex flex-col gap-4 py-2">
+        {showRememberedPanel && session.rememberedIdentityId && (
+          <label
+            data-testid="remembered-identity-panel"
+            className="flex flex-col gap-1"
+          >
+            <span className="text-[10px] font-semibold uppercase tracking-[0.12em] text-ink-4">
               Identity
-            </div>
-            <div className="break-all rounded-md border border-line bg-bg px-3 py-2 font-mono text-[12px] text-accent">
-              {session.identityId ?? "—"}
-            </div>
+            </span>
+            <input
+              type="text"
+              readOnly
+              value={session.rememberedIdentityId}
+              aria-label="Remembered identity"
+              className="break-all rounded-md border border-line bg-bg/40 px-3 py-2 font-mono text-[12px] text-accent outline-none"
+            />
             {session.dpnsName && (
-              <div className="mt-1 text-[10px] text-ink-4">
+              <span className="text-[10px] text-ink-4">
                 ✓ {session.dpnsName}.dash
-              </div>
+              </span>
             )}
+          </label>
+        )}
+
+        {useDifferentIdentity && session.rememberedIdentityId && (
+          <p
+            data-testid="different-identity-notice"
+            className="rounded-md border border-line bg-bg/40 px-3 py-2 text-[11px] text-ink-3"
+          >
+            Signing in with a different identity. The remembered identity stays
+            remembered until you sign in again or forget it.
+          </p>
+        )}
+
+        <label className="flex flex-col gap-1">
+          <span className="text-[10px] font-semibold uppercase tracking-[0.12em] text-ink-4">
+            {showRememberedPanel
+              ? "Mnemonic or Private Key"
+              : "Identity Mnemonic or Private Key"}
+          </span>
+          {!showRememberedPanel && (
+            <p className="text-[11px] text-ink-3">
+              Need an identity? Use the{" "}
+              <a
+                href="https://bridge.thepasta.org/"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="font-medium text-accent-dim underline underline-offset-2 hover:text-accent"
+              >
+                Dash bridge
+              </a>{" "}
+              to create one for testing.
+            </p>
+          )}
+          <input
+            type="password"
+            autoComplete="off"
+            required
+            value={secret}
+            onChange={(event) => setSecret(event.target.value)}
+            placeholder="Mnemonic phrase or WIF private key (high/critical)"
+            className="rounded-md border border-line bg-bg px-3 py-2 text-[13px] text-ink outline-none transition focus:border-accent-dim"
+          />
+          {isWifInput && wifPreview.status !== "idle" && (
             <div
-              data-testid="settings-identity-actions"
-              className="mt-2 flex flex-wrap gap-3 text-[11px]"
+              data-testid="wif-preview"
+              aria-live="polite"
+              className="mt-1 min-h-[1.5em] text-[11px]"
             >
+              {wifPreview.status === "checking" && (
+                <span className="text-ink-4">Checking…</span>
+              )}
+              {wifPreview.status === "resolved" && (
+                <span className="text-ink-3">
+                  ✓ Identity{" "}
+                  <span className="font-mono text-accent">
+                    {wifPreview.dpnsName
+                      ? `${wifPreview.dpnsName}.dash`
+                      : `${wifPreview.identityId.slice(0, 8)}…${wifPreview.identityId.slice(-4)}`}
+                  </span>
+                </span>
+              )}
+              {wifPreview.status === "wrong-purpose" && (
+                <span className="text-[color:var(--color-danger)]">
+                  Found identity{" "}
+                  <span className="font-mono">
+                    {wifPreview.dpnsName
+                      ? `${wifPreview.dpnsName}.dash`
+                      : `${wifPreview.identityId.slice(0, 8)}…${wifPreview.identityId.slice(-4)}`}
+                  </span>
+                  , but this is a{" "}
+                  {wifPreview.purposeName === "AUTHENTICATION"
+                    ? `${wifPreview.securityLevelName} authentication`
+                    : wifPreview.purposeName}{" "}
+                  key — paste a HIGH or CRITICAL authentication key instead.
+                </span>
+              )}
+              {wifPreview.status === "key-disabled" && (
+                <span className="text-[color:var(--color-danger)]">
+                  The matching key on identity{" "}
+                  <span className="font-mono">
+                    {wifPreview.dpnsName
+                      ? `${wifPreview.dpnsName}.dash`
+                      : `${wifPreview.identityId.slice(0, 8)}…${wifPreview.identityId.slice(-4)}`}
+                  </span>{" "}
+                  has been disabled.
+                </span>
+              )}
+            </div>
+          )}
+        </label>
+
+        {session.rememberedIdentityId && (
+          <div
+            data-testid="remembered-identity-actions"
+            className="flex flex-wrap gap-3 text-[11px]"
+          >
+            {!useDifferentIdentity && (
               <button
                 type="button"
-                onClick={() => {
-                  session.logout();
-                }}
+                onClick={() => setUseDifferentIdentity(true)}
                 className="font-medium text-accent-dim underline-offset-2 hover:text-accent hover:underline"
               >
                 Use a different identity
               </button>
-              {session.rememberedIdentityId && (
-                <button
-                  type="button"
-                  onClick={() => session.forgetIdentity()}
-                  className="font-medium text-ink-3 underline-offset-2 hover:text-[color:var(--color-danger)] hover:underline"
-                >
-                  Forget this device
-                </button>
-              )}
-            </div>
-          </div>
-
-          <button
-            type="button"
-            onClick={() => setShowAdvanced(!showAdvanced)}
-            className="flex items-center gap-1 self-start text-[11px] font-medium text-ink-3 transition hover:text-ink"
-          >
-            <span
-              className={`inline-block transition-transform ${showAdvanced ? "rotate-90" : ""}`}
+            )}
+            <button
+              type="button"
+              onClick={() => session.forgetIdentity()}
+              className="font-medium text-ink-3 underline-offset-2 hover:text-[color:var(--color-danger)] hover:underline"
             >
-              ▶
-            </span>
-            Advanced settings
-          </button>
+              Forget this device
+            </button>
+          </div>
+        )}
 
-          {showAdvanced && (
-            <div className="flex flex-col gap-2 rounded-md border border-line bg-bg/40 p-3">
+        <label className="flex items-start gap-2 text-[12px] text-ink-2">
+          <input
+            type="checkbox"
+            checked={rememberMe}
+            onChange={(event) => setRememberMe(event.target.checked)}
+            className="mt-0.5 h-3.5 w-3.5 accent-[color:var(--color-accent)]"
+          />
+          <span>Remember this identity on this device</span>
+        </label>
+
+        <button
+          type="button"
+          onClick={() => setShowAdvanced(!showAdvanced)}
+          className="flex items-center gap-1 self-start text-[11px] font-medium text-ink-3 transition hover:text-ink"
+        >
+          <span
+            className={`inline-block transition-transform ${showAdvanced ? "rotate-90" : ""}`}
+          >
+            ▶
+          </span>
+          Advanced settings
+        </button>
+
+        {showAdvanced && (
+          <div className="flex flex-col gap-4 rounded-md border border-line bg-bg/40 p-3">
+            {!isWifInput && (
+              <label className="flex flex-col gap-1">
+                <span className="text-[10px] font-semibold uppercase tracking-[0.12em] text-ink-4">
+                  Identity index
+                </span>
+                <input
+                  type="number"
+                  min={0}
+                  value={identityIndex}
+                  onChange={(event) => setIdentityIndex(event.target.value)}
+                  className="w-24 rounded-md border border-line bg-bg px-3 py-2 text-[13px] text-ink outline-none transition focus:border-accent-dim"
+                />
+              </label>
+            )}
+
+            <div className="flex flex-col gap-2">
               <span className="text-[10px] font-semibold uppercase tracking-[0.12em] text-ink-4">
-                Contract ID
+                Contract ID (optional)
               </span>
               <input
                 type="text"
                 value={contractInput}
                 onChange={(event) => setContractInput(event.target.value)}
-                placeholder="Paste a note contract ID or register a new one"
+                placeholder="Paste a Dashnote note contract ID to reuse"
                 className="rounded-md border border-line bg-bg px-3 py-2 font-mono text-[12px] text-ink outline-none transition focus:border-accent-dim"
               />
-              <div className="flex flex-wrap gap-2">
-                <button
-                  type="button"
-                  onClick={applyContractId}
-                  disabled={contractInput.trim() === (session.contractId ?? "")}
-                  className="rounded-md border border-line-2 bg-transparent px-3 py-1.5 text-[12px] font-semibold text-ink-2 transition hover:border-accent-dim hover:text-ink disabled:cursor-not-allowed disabled:border-line disabled:text-ink-4"
-                >
-                  Use this ID
-                </button>
-                <button
-                  type="button"
-                  onClick={handleRegisterContract}
-                  disabled={registering || !session.sdk || !session.keyManager}
-                  className="rounded-md bg-accent px-3 py-1.5 text-[12px] font-semibold text-bg transition hover:bg-accent-dim disabled:cursor-not-allowed disabled:bg-surface-2 disabled:text-ink-4"
-                >
-                  {registering ? "Registering…" : "Register new"}
-                </button>
-              </div>
-              <p className="text-[11px] text-ink-4">
-                Register deploys a fresh note contract to testnet and switches
-                Dashnote to it immediately.
-              </p>
-            </div>
-          )}
-
-          {error && (
-            <OperationResultNotice tone="error" title="Error">
-              {error}
-            </OperationResultNotice>
-          )}
-
-          <div className="flex gap-2">
-            <button
-              type="button"
-              onClick={() => {
-                session.logout();
-                onClose();
-              }}
-              className="flex-1 rounded-md border border-line-2 bg-transparent px-4 py-2 text-[13px] font-semibold text-ink-2 transition hover:border-accent-dim hover:text-ink"
-            >
-              Logout
-            </button>
-            <button
-              type="button"
-              onClick={onClose}
-              className="flex-1 rounded-md border border-line bg-transparent px-4 py-2 text-[13px] font-semibold text-ink-3 transition hover:border-line-2 hover:text-ink-2"
-            >
-              Close
-            </button>
-          </div>
-        </div>
-      ) : (
-        <form onSubmit={handleLogin} className="flex flex-col gap-4 py-2">
-          {showRememberedPanel && session.rememberedIdentityId && (
-            <label
-              data-testid="remembered-identity-panel"
-              className="flex flex-col gap-1"
-            >
-              <span className="text-[10px] font-semibold uppercase tracking-[0.12em] text-ink-4">
-                Identity
-              </span>
-              <input
-                type="text"
-                readOnly
-                value={session.rememberedIdentityId}
-                aria-label="Remembered identity"
-                className="break-all rounded-md border border-line bg-bg/40 px-3 py-2 font-mono text-[12px] text-accent outline-none"
-              />
-              {session.dpnsName && (
-                <span className="text-[10px] text-ink-4">
-                  ✓ {session.dpnsName}.dash
-                </span>
-              )}
-            </label>
-          )}
-
-          {useDifferentIdentity && session.rememberedIdentityId && (
-            <p
-              data-testid="different-identity-notice"
-              className="rounded-md border border-line bg-bg/40 px-3 py-2 text-[11px] text-ink-3"
-            >
-              Signing in with a different identity. The remembered identity
-              stays remembered until you sign in again or forget it.
-            </p>
-          )}
-
-          <label className="flex flex-col gap-1">
-            <span className="text-[10px] font-semibold uppercase tracking-[0.12em] text-ink-4">
-              {showRememberedPanel
-                ? "Mnemonic or Private Key"
-                : "Identity Mnemonic or Private Key"}
-            </span>
-            {!showRememberedPanel && (
-              <p className="text-[11px] text-ink-3">
-                Need an identity? Use the{" "}
-                <a
-                  href="https://bridge.thepasta.org/"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="font-medium text-accent-dim underline underline-offset-2 hover:text-accent"
-                >
-                  Dash bridge
-                </a>{" "}
-                to create one for testing.
-              </p>
-            )}
-            <input
-              type="password"
-              autoComplete="off"
-              required
-              value={secret}
-              onChange={(event) => setSecret(event.target.value)}
-              placeholder="Mnemonic phrase or WIF private key (high/critical)"
-              className="rounded-md border border-line bg-bg px-3 py-2 text-[13px] text-ink outline-none transition focus:border-accent-dim"
-            />
-            {isWifInput && wifPreview.status !== "idle" && (
-              <div
-                data-testid="wif-preview"
-                aria-live="polite"
-                className="mt-1 min-h-[1.5em] text-[11px]"
-              >
-                {wifPreview.status === "checking" && (
-                  <span className="text-ink-4">Checking…</span>
-                )}
-                {wifPreview.status === "resolved" && (
-                  <span className="text-ink-3">
-                    ✓ Identity{" "}
-                    <span className="font-mono text-accent">
-                      {wifPreview.dpnsName
-                        ? `${wifPreview.dpnsName}.dash`
-                        : `${wifPreview.identityId.slice(0, 8)}…${wifPreview.identityId.slice(-4)}`}
-                    </span>
-                  </span>
-                )}
-                {wifPreview.status === "wrong-purpose" && (
-                  <span className="text-[color:var(--color-danger)]">
-                    Found identity{" "}
-                    <span className="font-mono">
-                      {wifPreview.dpnsName
-                        ? `${wifPreview.dpnsName}.dash`
-                        : `${wifPreview.identityId.slice(0, 8)}…${wifPreview.identityId.slice(-4)}`}
-                    </span>
-                    , but this is a{" "}
-                    {wifPreview.purposeName === "AUTHENTICATION"
-                      ? `${wifPreview.securityLevelName} authentication`
-                      : wifPreview.purposeName}{" "}
-                    key — paste a HIGH or CRITICAL authentication key instead.
-                  </span>
-                )}
-                {wifPreview.status === "key-disabled" && (
-                  <span className="text-[color:var(--color-danger)]">
-                    The matching key on identity{" "}
-                    <span className="font-mono">
-                      {wifPreview.dpnsName
-                        ? `${wifPreview.dpnsName}.dash`
-                        : `${wifPreview.identityId.slice(0, 8)}…${wifPreview.identityId.slice(-4)}`}
-                    </span>{" "}
-                    has been disabled.
-                  </span>
-                )}
-              </div>
-            )}
-          </label>
-
-          {session.rememberedIdentityId && (
-            <div
-              data-testid="remembered-identity-actions"
-              className="flex flex-wrap gap-3 text-[11px]"
-            >
-              {!useDifferentIdentity && (
-                <button
-                  type="button"
-                  onClick={() => setUseDifferentIdentity(true)}
-                  className="font-medium text-accent-dim underline-offset-2 hover:text-accent hover:underline"
-                >
-                  Use a different identity
-                </button>
-              )}
               <button
                 type="button"
-                onClick={() => session.forgetIdentity()}
-                className="font-medium text-ink-3 underline-offset-2 hover:text-[color:var(--color-danger)] hover:underline"
+                onClick={applyContractId}
+                disabled={contractInput.trim() === (session.contractId ?? "")}
+                className="self-start rounded-md border border-line-2 bg-transparent px-3 py-1 text-[12px] font-semibold text-ink-2 transition hover:border-accent-dim hover:text-ink disabled:cursor-not-allowed disabled:border-line disabled:text-ink-4"
               >
-                Forget this device
+                Use this ID
               </button>
             </div>
-          )}
+          </div>
+        )}
 
-          <label className="flex items-start gap-2 text-[12px] text-ink-2">
-            <input
-              type="checkbox"
-              checked={rememberMe}
-              onChange={(event) => setRememberMe(event.target.checked)}
-              className="mt-0.5 h-3.5 w-3.5 accent-[color:var(--color-accent)]"
-            />
-            <span>Remember this identity on this device</span>
-          </label>
+        {error && (
+          <OperationResultNotice tone="error" title="Error">
+            {error}
+          </OperationResultNotice>
+        )}
 
+        <p className="text-[11px] text-ink-4">
+          Your secret never leaves this browser. Only the public identity ID is
+          stored when this identity is remembered on this device.
+        </p>
+
+        <div className="flex gap-2 pt-1">
+          <button
+            type="submit"
+            disabled={submitting || !secret.trim() || previewBlocksLogin}
+            className="flex-1 rounded-md bg-accent px-4 py-2 text-[13px] font-semibold text-bg transition hover:bg-accent-dim disabled:cursor-not-allowed disabled:bg-surface-2 disabled:text-ink-4"
+          >
+            {submitting ? "Connecting…" : "Login"}
+          </button>
           <button
             type="button"
-            onClick={() => setShowAdvanced(!showAdvanced)}
-            className="flex items-center gap-1 self-start text-[11px] font-medium text-ink-3 transition hover:text-ink"
+            onClick={onClose}
+            className="rounded-md border border-line bg-transparent px-4 py-2 text-[13px] font-semibold text-ink-3 transition hover:border-line-2 hover:text-ink-2"
           >
-            <span
-              className={`inline-block transition-transform ${showAdvanced ? "rotate-90" : ""}`}
-            >
-              ▶
-            </span>
-            Advanced settings
+            Cancel
           </button>
-
-          {showAdvanced && (
-            <div className="flex flex-col gap-4 rounded-md border border-line bg-bg/40 p-3">
-              {!isWifInput && (
-                <label className="flex flex-col gap-1">
-                  <span className="text-[10px] font-semibold uppercase tracking-[0.12em] text-ink-4">
-                    Identity index
-                  </span>
-                  <input
-                    type="number"
-                    min={0}
-                    value={identityIndex}
-                    onChange={(event) => setIdentityIndex(event.target.value)}
-                    className="w-24 rounded-md border border-line bg-bg px-3 py-2 text-[13px] text-ink outline-none transition focus:border-accent-dim"
-                  />
-                </label>
-              )}
-
-              <div className="flex flex-col gap-2">
-                <span className="text-[10px] font-semibold uppercase tracking-[0.12em] text-ink-4">
-                  Contract ID (optional)
-                </span>
-                <input
-                  type="text"
-                  value={contractInput}
-                  onChange={(event) => setContractInput(event.target.value)}
-                  placeholder="Paste a Dashnote note contract ID to reuse"
-                  className="rounded-md border border-line bg-bg px-3 py-2 font-mono text-[12px] text-ink outline-none transition focus:border-accent-dim"
-                />
-                <button
-                  type="button"
-                  onClick={applyContractId}
-                  disabled={contractInput.trim() === (session.contractId ?? "")}
-                  className="self-start rounded-md border border-line-2 bg-transparent px-3 py-1 text-[12px] font-semibold text-ink-2 transition hover:border-accent-dim hover:text-ink disabled:cursor-not-allowed disabled:border-line disabled:text-ink-4"
-                >
-                  Use this ID
-                </button>
-              </div>
-            </div>
-          )}
-
-          {error && (
-            <OperationResultNotice tone="error" title="Error">
-              {error}
-            </OperationResultNotice>
-          )}
-
-          <p className="text-[11px] text-ink-4">
-            Your secret never leaves this browser. Only the public identity ID
-            is stored when this identity is remembered on this device.
-          </p>
-
-          <div className="flex gap-2 pt-1">
-            <button
-              type="submit"
-              disabled={submitting || !secret.trim() || previewBlocksLogin}
-              className="flex-1 rounded-md bg-accent px-4 py-2 text-[13px] font-semibold text-bg transition hover:bg-accent-dim disabled:cursor-not-allowed disabled:bg-surface-2 disabled:text-ink-4"
-            >
-              {submitting ? "Connecting…" : "Login"}
-            </button>
-            <button
-              type="button"
-              onClick={onClose}
-              className="rounded-md border border-line bg-transparent px-4 py-2 text-[13px] font-semibold text-ink-3 transition hover:border-line-2 hover:text-ink-2"
-            >
-              Cancel
-            </button>
-          </div>
-        </form>
-      )}
+        </div>
+      </form>
     </Modal>
   );
 }

--- a/example-apps/dashnote/src/components/NoteEditor.tsx
+++ b/example-apps/dashnote/src/components/NoteEditor.tsx
@@ -23,6 +23,7 @@ interface NoteEditorProps {
   messageOversize: boolean;
   contractReady: boolean;
   error: string | null;
+  onOpenLogin: () => void;
   onOpenSettings: () => void;
   isReadOnly?: boolean;
   isDesktop: boolean;
@@ -48,6 +49,7 @@ export function NoteEditor({
   messageOversize,
   contractReady,
   error,
+  onOpenLogin,
   onOpenSettings,
   isReadOnly = false,
   isDesktop,
@@ -115,7 +117,7 @@ export function NoteEditor({
           {isReadOnly ? (
             <button
               type="button"
-              onClick={onOpenSettings}
+              onClick={onOpenLogin}
               className="rounded-full bg-accent px-3 py-1.5 text-[12px] font-semibold text-bg transition hover:bg-accent-dim"
             >
               Sign in to edit

--- a/example-apps/dashnote/src/components/NotesWorkspace.tsx
+++ b/example-apps/dashnote/src/components/NotesWorkspace.tsx
@@ -32,8 +32,10 @@ const STALE_EDIT_WARNING =
 type SelectedNoteId = string | "new" | null;
 
 export function NotesWorkspace({
+  onOpenLogin,
   onOpenSettings,
 }: {
+  onOpenLogin: () => void;
   onOpenSettings: () => void;
 }) {
   const session = useSession();
@@ -594,7 +596,7 @@ export function NotesWorkspace({
           title="Sign in to see your notes"
           description="Dashnote stores notes against your testnet identity. Log in with a Dash Platform identity to create, edit, and review your notes."
           actionLabel="Log in"
-          onAction={onOpenSettings}
+          onAction={onOpenLogin}
           secondaryHref="https://bridge.thepasta.org/"
           secondaryLabel="Need an identity? Create one on Dash Bridge"
           footnote="Notes are not private. They are stored publicly on Dash Platform."
@@ -665,6 +667,7 @@ export function NotesWorkspace({
               messageOversize={messageOversize}
               contractReady={contractReady}
               error={error ?? conflictWarning}
+              onOpenLogin={onOpenLogin}
               onOpenSettings={onOpenSettings}
             />
           </div>

--- a/example-apps/dashnote/src/components/SettingsPanel.tsx
+++ b/example-apps/dashnote/src/components/SettingsPanel.tsx
@@ -1,0 +1,239 @@
+import { useCallback, useEffect, useState } from "react";
+
+import { useContractRegistration } from "../hooks/useContractRegistration";
+import { useTheme } from "../hooks/useTheme";
+import { clearCachedNotes } from "../lib/notesCache";
+import { useSession } from "../session/useSession";
+import { OperationResultNotice } from "./OperationResultNotice";
+
+const NETWORK = "testnet" as const;
+
+interface CopyButtonProps {
+  value: string | null;
+  label: string;
+}
+
+function CopyButton({ value, label }: CopyButtonProps) {
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    if (!copied) return;
+    const id = window.setTimeout(() => setCopied(false), 2000);
+    return () => window.clearTimeout(id);
+  }, [copied]);
+
+  const onClick = useCallback(async () => {
+    if (!value) return;
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopied(true);
+    } catch {
+      // Clipboard API can fail in insecure contexts; surface no error here.
+    }
+  }, [value]);
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={!value}
+      aria-label={label}
+      className="rounded-md border border-line-2 bg-transparent px-2.5 py-1 text-[11px] font-semibold text-ink-2 transition hover:border-accent-dim hover:text-ink disabled:cursor-not-allowed disabled:border-line disabled:text-ink-4"
+    >
+      {copied ? "Copied!" : "Copy"}
+    </button>
+  );
+}
+
+function ThemeToggleControl() {
+  const { theme, toggle } = useTheme();
+  const isDark = theme === "dark";
+  return (
+    <button
+      type="button"
+      onClick={toggle}
+      className="rounded-md border border-line-2 bg-transparent px-3 py-1.5 text-[12px] font-semibold text-ink-2 transition hover:border-accent-dim hover:text-ink"
+    >
+      {isDark ? "Switch to light theme" : "Switch to dark theme"}
+    </button>
+  );
+}
+
+function Section({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="flex flex-col gap-3 rounded-md border border-line bg-bg/40 p-4">
+      <h3 className="text-[10px] font-semibold uppercase tracking-[0.12em] text-ink-4">
+        {title}
+      </h3>
+      {children}
+    </section>
+  );
+}
+
+export function SettingsPanel() {
+  const session = useSession();
+  const {
+    register,
+    registering,
+    error: registerError,
+  } = useContractRegistration();
+  const [contractInput, setContractInput] = useState(session.contractId ?? "");
+  const [lastSyncedContractId, setLastSyncedContractId] = useState(
+    session.contractId,
+  );
+  const [cacheCleared, setCacheCleared] = useState(false);
+
+  // Re-sync the local input whenever the upstream contract ID changes (e.g.
+  // a fresh registration completes). Adjusting state during render is the
+  // recommended pattern over a useEffect for prop-derived state.
+  if (session.contractId !== lastSyncedContractId) {
+    setLastSyncedContractId(session.contractId);
+    setContractInput(session.contractId ?? "");
+  }
+
+  useEffect(() => {
+    if (!cacheCleared) return;
+    const id = window.setTimeout(() => setCacheCleared(false), 2000);
+    return () => window.clearTimeout(id);
+  }, [cacheCleared]);
+
+  const isConnected =
+    session.status === "authenticated" || session.status === "browsing";
+
+  if (!isConnected) {
+    return (
+      <div className="rounded-md border border-line bg-bg/40 p-6 text-center text-[13px] text-ink-3">
+        Sign in to view and manage your identity, contract, and device data.
+      </div>
+    );
+  }
+
+  const trimmedContract = contractInput.trim();
+  const canApplyContract =
+    trimmedContract.length > 0 &&
+    trimmedContract !== (session.contractId ?? "");
+  const canRegister = Boolean(
+    session.status === "authenticated" && session.sdk && session.keyManager,
+  );
+
+  return (
+    <div className="flex flex-col gap-4">
+      <Section title="Identity">
+        <div data-testid="settings-identity-block">
+          <div className="flex items-start gap-2">
+            <div className="flex-1 break-all rounded-md border border-line bg-bg px-3 py-2 font-mono text-[12px] text-accent">
+              {session.identityId ?? "—"}
+            </div>
+            <CopyButton value={session.identityId} label="Copy identity ID" />
+          </div>
+          {session.dpnsName && (
+            <div className="mt-1 text-[11px] text-ink-4">
+              ✓ {session.dpnsName}.dash
+            </div>
+          )}
+        </div>
+        <div className="flex items-center justify-between text-[11px] text-ink-3">
+          <span>Network</span>
+          <span className="font-mono text-accent-dim">{NETWORK}</span>
+        </div>
+      </Section>
+
+      <Section title="Contract">
+        <div className="flex flex-col gap-2">
+          <div className="flex items-start gap-2">
+            <input
+              type="text"
+              value={contractInput}
+              onChange={(event) => setContractInput(event.target.value)}
+              placeholder="Paste a note contract ID"
+              className="flex-1 rounded-md border border-line bg-bg px-3 py-2 font-mono text-[12px] text-ink outline-none transition focus:border-accent-dim"
+            />
+            <CopyButton value={session.contractId} label="Copy contract ID" />
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <button
+              type="button"
+              onClick={() =>
+                session.setContractId(contractInput.trim() || null)
+              }
+              disabled={!canApplyContract}
+              className="rounded-md border border-line-2 bg-transparent px-3 py-1.5 text-[12px] font-semibold text-ink-2 transition hover:border-accent-dim hover:text-ink disabled:cursor-not-allowed disabled:border-line disabled:text-ink-4"
+            >
+              Use this ID
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                void register();
+              }}
+              disabled={registering || !canRegister}
+              className="rounded-md bg-accent px-3 py-1.5 text-[12px] font-semibold text-bg transition hover:bg-accent-dim disabled:cursor-not-allowed disabled:bg-surface-2 disabled:text-ink-4"
+            >
+              {registering ? "Registering…" : "Register a fresh contract"}
+            </button>
+          </div>
+          <p className="text-[11px] text-ink-4">
+            Registering deploys a fresh note contract to testnet and switches
+            Dashnote to it immediately.
+          </p>
+          {registerError && (
+            <OperationResultNotice tone="error" title="Error">
+              {registerError}
+            </OperationResultNotice>
+          )}
+        </div>
+      </Section>
+
+      <Section title="Data">
+        <div className="flex flex-col gap-2">
+          <button
+            type="button"
+            onClick={() => {
+              if (!session.identityId) return;
+              clearCachedNotes(session.identityId);
+              setCacheCleared(true);
+            }}
+            disabled={!session.identityId}
+            className="self-start rounded-md border border-line-2 bg-transparent px-3 py-1.5 text-[12px] font-semibold text-ink-2 transition hover:border-accent-dim hover:text-ink disabled:cursor-not-allowed disabled:border-line disabled:text-ink-4"
+          >
+            {cacheCleared
+              ? "Cache cleared"
+              : "Clear local cache for this device"}
+          </button>
+          <p className="text-[11px] text-ink-4">
+            Removes cached note bodies stored in this browser. Notes on Platform
+            are not affected; the cache rebuilds on the next refresh.
+          </p>
+        </div>
+      </Section>
+
+      <Section title="Appearance">
+        <ThemeToggleControl />
+      </Section>
+
+      {session.rememberedIdentityId && (
+        <Section title="Danger zone">
+          <div className="flex flex-col gap-2">
+            <button
+              type="button"
+              onClick={() => session.forgetIdentity()}
+              className="self-start rounded-md border border-[color:var(--color-danger)] bg-transparent px-3 py-1.5 text-[12px] font-semibold text-[color:var(--color-danger)] transition hover:bg-[color:var(--color-danger)] hover:text-bg"
+            >
+              Forget this device
+            </button>
+            <p className="text-[11px] text-ink-4">
+              Removes the remembered identity and clears its cached notes from
+              this browser.
+            </p>
+          </div>
+        </Section>
+      )}
+    </div>
+  );
+}

--- a/example-apps/dashnote/src/components/Tabs.tsx
+++ b/example-apps/dashnote/src/components/Tabs.tsx
@@ -1,1 +1,1 @@
-export type TopTab = "notes" | "how-it-works";
+export type TopTab = "notes" | "how-it-works" | "settings";

--- a/example-apps/dashnote/src/hooks/useContractRegistration.ts
+++ b/example-apps/dashnote/src/hooks/useContractRegistration.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 
 import { registerContract } from "../dash/contract";
 import { errorMessage } from "../lib/logger";
@@ -15,9 +15,15 @@ export function useContractRegistration(): UseContractRegistrationResult {
   const session = useSession();
   const [registering, setRegistering] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // Synchronous re-entrancy guard: contract publish is an irreversible
+  // testnet side effect, so reject a second call before React has a chance
+  // to commit `setRegistering(true)` and disable the button.
+  const inFlightRef = useRef(false);
 
   const register = useCallback(async () => {
+    if (inFlightRef.current) return null;
     if (!session.sdk || !session.keyManager) return null;
+    inFlightRef.current = true;
     setError(null);
     setRegistering(true);
     try {
@@ -32,6 +38,7 @@ export function useContractRegistration(): UseContractRegistrationResult {
       setError(errorMessage(err));
       return null;
     } finally {
+      inFlightRef.current = false;
       setRegistering(false);
     }
   }, [session]);

--- a/example-apps/dashnote/src/hooks/useContractRegistration.ts
+++ b/example-apps/dashnote/src/hooks/useContractRegistration.ts
@@ -1,0 +1,42 @@
+import { useCallback, useState } from "react";
+
+import { registerContract } from "../dash/contract";
+import { errorMessage } from "../lib/logger";
+import { useSession } from "../session/useSession";
+
+export interface UseContractRegistrationResult {
+  register: () => Promise<string | null>;
+  registering: boolean;
+  error: string | null;
+  clearError: () => void;
+}
+
+export function useContractRegistration(): UseContractRegistrationResult {
+  const session = useSession();
+  const [registering, setRegistering] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const register = useCallback(async () => {
+    if (!session.sdk || !session.keyManager) return null;
+    setError(null);
+    setRegistering(true);
+    try {
+      const contractId = await registerContract({
+        sdk: session.sdk,
+        keyManager: session.keyManager,
+        log: session.log,
+      });
+      session.setContractId(contractId);
+      return contractId;
+    } catch (err) {
+      setError(errorMessage(err));
+      return null;
+    } finally {
+      setRegistering(false);
+    }
+  }, [session]);
+
+  const clearError = useCallback(() => setError(null), []);
+
+  return { register, registering, error, clearError };
+}

--- a/example-apps/dashnote/test/App.test.tsx
+++ b/example-apps/dashnote/test/App.test.tsx
@@ -40,7 +40,7 @@ vi.mock("../src/components/AppShell", () => ({
   }: {
     children: ReactNode;
     onLoginOpen: () => void;
-    onTabChange: (tab: "notes" | "how-it-works") => void;
+    onTabChange: (tab: "notes" | "how-it-works" | "settings") => void;
   }) => (
     <div>
       <button type="button" onClick={onLoginOpen}>
@@ -48,6 +48,9 @@ vi.mock("../src/components/AppShell", () => ({
       </button>
       <button type="button" onClick={() => onTabChange("how-it-works")}>
         How it works tab
+      </button>
+      <button type="button" onClick={() => onTabChange("settings")}>
+        Settings tab
       </button>
       {children}
     </div>
@@ -136,5 +139,23 @@ describe("App", () => {
 
     fireEvent.click(screen.getByRole("button", { name: /open settings/i }));
     expect(screen.getByText("login:true")).toBeTruthy();
+  });
+
+  it("renders SettingsPanel when the settings tab is selected", () => {
+    mockUseSession.mockReturnValue(
+      makeSession({
+        status: "authenticated",
+        identityId: "id-app-settings",
+        contractId: "contract-app-settings",
+        sdk: { documents: {} },
+      }),
+    );
+
+    render(<App />);
+    expect(screen.queryByTestId("settings-identity-block")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: /settings tab/i }));
+    expect(screen.getByTestId("settings-identity-block")).toBeTruthy();
+    expect(screen.getByText("id-app-settings")).toBeTruthy();
   });
 });

--- a/example-apps/dashnote/test/IdentityCard.test.tsx
+++ b/example-apps/dashnote/test/IdentityCard.test.tsx
@@ -1,14 +1,18 @@
 // @vitest-environment jsdom
 
-import { cleanup, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { IdentityCard } from "../src/components/IdentityCard";
 import type { SessionStatus } from "../src/session/SessionContext";
 
-afterEach(() => {
-  cleanup();
-});
+const { mockUseSession } = vi.hoisted(() => ({
+  mockUseSession: vi.fn(),
+}));
+
+vi.mock("../src/session/useSession", () => ({
+  useSession: mockUseSession,
+}));
 
 const IDENTITY_ID = "GgZekwh38XcWQTyWWWvmw6CEYFnLU7yiZFPWZEjqKHit";
 // IdentityCard calls truncateId(id, 6); head=6 + ellipsis + tail=8.
@@ -21,6 +25,8 @@ function renderCard(props: {
   identityId: string | null;
   dpnsName: string | null;
   contractId?: string | null;
+  onLoginClick?: () => void;
+  onOpenSettings?: () => void;
 }) {
   return render(
     <IdentityCard
@@ -28,10 +34,20 @@ function renderCard(props: {
       identityId={props.identityId}
       dpnsName={props.dpnsName}
       contractId={props.contractId ?? null}
-      onLoginClick={vi.fn()}
+      onLoginClick={props.onLoginClick ?? vi.fn()}
+      onOpenSettings={props.onOpenSettings ?? vi.fn()}
     />,
   );
 }
+
+beforeEach(() => {
+  mockUseSession.mockReset();
+  mockUseSession.mockReturnValue({ logout: vi.fn() });
+});
+
+afterEach(() => {
+  cleanup();
+});
 
 describe("IdentityCard", () => {
   it("shows @-prefixed DPNS name as the primary line when authenticated", () => {
@@ -86,5 +102,83 @@ describe("IdentityCard", () => {
     // disconnected state, even when an id and name are passed in.
     expect(screen.queryByText("@alice")).toBeNull();
     expect(screen.queryByText(TRUNCATED_ID)).toBeNull();
+  });
+
+  // Regression: when the card was unified into a single menu trigger, readonly
+  // (connected-but-not-signed-in) silently lost its one-click path to the
+  // login modal — the menu offered Settings and Switch identity but no direct
+  // Login. The card must call onLoginClick on click and render no menu.
+  it("calls onLoginClick on click when readonly, without opening a menu", () => {
+    const onLoginClick = vi.fn();
+    renderCard({
+      status: "readonly",
+      identityId: null,
+      dpnsName: null,
+      onLoginClick,
+    });
+    const trigger = screen.getByRole("button");
+    fireEvent.click(trigger);
+    expect(onLoginClick).toHaveBeenCalled();
+    expect(screen.queryByRole("menu")).toBeNull();
+  });
+
+  it("opens a menu when the connected card is clicked", () => {
+    renderCard({
+      status: "authenticated",
+      identityId: IDENTITY_ID,
+      dpnsName: null,
+    });
+    expect(screen.queryByRole("menu")).toBeNull();
+    fireEvent.click(screen.getByRole("button", { expanded: false }));
+    expect(screen.getByRole("menu")).toBeTruthy();
+  });
+
+  it("calls onOpenSettings when Settings is chosen from the menu", () => {
+    const onOpenSettings = vi.fn();
+    renderCard({
+      status: "authenticated",
+      identityId: IDENTITY_ID,
+      dpnsName: null,
+      onOpenSettings,
+    });
+    fireEvent.click(screen.getByRole("button", { expanded: false }));
+    fireEvent.click(screen.getByRole("menuitem", { name: /settings/i }));
+    expect(onOpenSettings).toHaveBeenCalled();
+  });
+
+  it("calls onLoginClick when Switch identity is chosen from the menu", () => {
+    const onLoginClick = vi.fn();
+    renderCard({
+      status: "authenticated",
+      identityId: IDENTITY_ID,
+      dpnsName: null,
+      onLoginClick,
+    });
+    fireEvent.click(screen.getByRole("button", { expanded: false }));
+    fireEvent.click(screen.getByRole("menuitem", { name: /switch identity/i }));
+    expect(onLoginClick).toHaveBeenCalled();
+  });
+
+  it("calls session.logout when Log out is chosen from the menu", () => {
+    const logout = vi.fn();
+    mockUseSession.mockReturnValue({ logout });
+    renderCard({
+      status: "authenticated",
+      identityId: IDENTITY_ID,
+      dpnsName: null,
+    });
+    fireEvent.click(screen.getByRole("button", { expanded: false }));
+    fireEvent.click(screen.getByRole("menuitem", { name: /log out/i }));
+    expect(logout).toHaveBeenCalled();
+  });
+
+  it("hides Log out when browsing read-only", () => {
+    renderCard({
+      status: "browsing",
+      identityId: IDENTITY_ID,
+      dpnsName: null,
+    });
+    fireEvent.click(screen.getByRole("button", { expanded: false }));
+    expect(screen.queryByRole("menuitem", { name: /log out/i })).toBeNull();
   });
 });

--- a/example-apps/dashnote/test/LoginModal.test.tsx
+++ b/example-apps/dashnote/test/LoginModal.test.tsx
@@ -12,20 +12,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { LoginModal } from "../src/components/LoginModal";
 
-const { mockUseSession, mockRegisterContract, mockUseWifPreview } = vi.hoisted(
-  () => ({
-    mockUseSession: vi.fn(),
-    mockRegisterContract: vi.fn(),
-    mockUseWifPreview: vi.fn(),
-  }),
-);
+const { mockUseSession, mockUseWifPreview } = vi.hoisted(() => ({
+  mockUseSession: vi.fn(),
+  mockUseWifPreview: vi.fn(),
+}));
 
 vi.mock("../src/session/useSession", () => ({
   useSession: mockUseSession,
-}));
-
-vi.mock("../src/dash/contract", () => ({
-  registerContract: mockRegisterContract,
 }));
 
 // Mocked so LoginModal's preview-rendering branches can be exercised
@@ -74,7 +67,6 @@ function makeSession(overrides: SessionOverrides = {}) {
 
 beforeEach(() => {
   mockUseSession.mockReset();
-  mockRegisterContract.mockReset();
   mockUseWifPreview.mockReset();
   mockUseWifPreview.mockReturnValue({ status: "idle" });
 });
@@ -88,6 +80,26 @@ describe("LoginModal", () => {
     mockUseSession.mockReturnValue(makeSession());
     const { container } = render(<LoginModal open={false} onClose={vi.fn()} />);
     expect(container.firstChild).toBeNull();
+  });
+
+  // Regression: an earlier auto-close effect dismissed the modal whenever it
+  // was opened while session.status === "authenticated", which broke the
+  // Switch-identity flow (the modal would flash and vanish).
+  it("stays open when opened in an authenticated session (Switch identity)", () => {
+    const onClose = vi.fn();
+    mockUseSession.mockReturnValue(
+      makeSession({
+        status: "authenticated",
+        identityId: "id-already-signed-in",
+        keyManager: { getAuth: vi.fn() },
+      }),
+    );
+
+    render(<LoginModal open onClose={onClose} />);
+
+    expect(onClose).not.toHaveBeenCalled();
+    expect(screen.getByPlaceholderText(/mnemonic phrase/i)).toBeTruthy();
+    expect(screen.getByRole("button", { name: /^login$/i })).toBeTruthy();
   });
 
   it("submits the mnemonic via session.login and closes on success", async () => {
@@ -159,54 +171,6 @@ describe("LoginModal", () => {
         rememberMe: true,
       });
     });
-  });
-
-  it("shows the settings view with logout when authenticated", () => {
-    const logout = vi.fn();
-    mockUseSession.mockReturnValue(
-      makeSession({
-        status: "authenticated",
-        identityId: "id-123456789012345678",
-        contractId: "contract-abc",
-        keyManager: { getAuth: vi.fn() },
-        logout,
-      }),
-    );
-
-    render(<LoginModal open onClose={vi.fn()} />);
-
-    expect(screen.getByText("id-123456789012345678")).toBeTruthy();
-
-    fireEvent.click(screen.getByRole("button", { name: /^logout$/i }));
-    expect(logout).toHaveBeenCalled();
-  });
-
-  it("applies a pasted contract ID immediately without validation", () => {
-    const setContractId = vi.fn();
-    mockUseSession.mockReturnValue(
-      makeSession({
-        status: "authenticated",
-        identityId: "id-1",
-        contractId: null,
-        keyManager: { getAuth: vi.fn() },
-        setContractId,
-      }),
-    );
-
-    render(<LoginModal open onClose={vi.fn()} />);
-
-    fireEvent.click(screen.getByText(/advanced settings/i));
-    fireEvent.change(
-      screen.getByPlaceholderText(
-        /paste a note contract id or register a new one/i,
-      ),
-      {
-        target: { value: " contract-123 " },
-      },
-    );
-    fireEvent.click(screen.getByRole("button", { name: /use this id/i }));
-
-    expect(setContractId).toHaveBeenCalledWith("contract-123");
   });
 
   it("defaults the Remember-me checkbox on when no identity is remembered", () => {
@@ -505,169 +469,6 @@ describe("LoginModal", () => {
 
     const panel = screen.getByTestId("remembered-identity-panel");
     expect(within(panel).queryByText(/\.dash$/)).toBeNull();
-  });
-
-  it("settings panel shows the DPNS name as a ✓ name.dash caption under the identity", () => {
-    mockUseSession.mockReturnValue(
-      makeSession({
-        status: "authenticated",
-        identityId: "id-1",
-        dpnsName: "alice",
-        keyManager: { getAuth: vi.fn() },
-      }),
-    );
-
-    render(<LoginModal open onClose={vi.fn()} />);
-
-    const block = screen.getByTestId("settings-identity-block");
-    expect(within(block).getByText("✓ alice.dash")).toBeTruthy();
-  });
-
-  it("settings panel omits the DPNS caption when no name is set", () => {
-    mockUseSession.mockReturnValue(
-      makeSession({
-        status: "authenticated",
-        identityId: "id-1",
-        dpnsName: null,
-        keyManager: { getAuth: vi.fn() },
-      }),
-    );
-
-    render(<LoginModal open onClose={vi.fn()} />);
-
-    const block = screen.getByTestId("settings-identity-block");
-    expect(within(block).queryByText(/\.dash$/)).toBeNull();
-  });
-
-  it("settings: Use a different identity link calls session.logout", () => {
-    const logout = vi.fn();
-    mockUseSession.mockReturnValue(
-      makeSession({
-        status: "authenticated",
-        identityId: "id-1",
-        keyManager: { getAuth: vi.fn() },
-        logout,
-      }),
-    );
-
-    render(<LoginModal open onClose={vi.fn()} />);
-
-    const actions = screen.getByTestId("settings-identity-actions");
-    fireEvent.click(
-      within(actions).getByRole("button", {
-        name: /use a different identity/i,
-      }),
-    );
-    expect(logout).toHaveBeenCalled();
-  });
-
-  it("settings: Forget this device link calls session.forgetIdentity when remembered", () => {
-    const forgetIdentity = vi.fn();
-    mockUseSession.mockReturnValue(
-      makeSession({
-        status: "authenticated",
-        identityId: "id-1",
-        rememberedIdentityId: "id-1",
-        keyManager: { getAuth: vi.fn() },
-        forgetIdentity,
-      }),
-    );
-
-    render(<LoginModal open onClose={vi.fn()} />);
-
-    const actions = screen.getByTestId("settings-identity-actions");
-    fireEvent.click(
-      within(actions).getByRole("button", { name: /forget this device/i }),
-    );
-    expect(forgetIdentity).toHaveBeenCalled();
-  });
-
-  it("settings: Forget this device link is hidden when nothing is remembered", () => {
-    mockUseSession.mockReturnValue(
-      makeSession({
-        status: "authenticated",
-        identityId: "id-1",
-        rememberedIdentityId: null,
-        keyManager: { getAuth: vi.fn() },
-      }),
-    );
-
-    render(<LoginModal open onClose={vi.fn()} />);
-
-    const actions = screen.getByTestId("settings-identity-actions");
-    expect(
-      within(actions).queryByRole("button", { name: /forget this device/i }),
-    ).toBeNull();
-  });
-
-  it("settings: Close button calls onClose without logging out", () => {
-    const onClose = vi.fn();
-    const logout = vi.fn();
-    mockUseSession.mockReturnValue(
-      makeSession({
-        status: "authenticated",
-        identityId: "id-1",
-        keyManager: { getAuth: vi.fn() },
-        logout,
-      }),
-    );
-
-    render(<LoginModal open onClose={onClose} />);
-
-    const closeButtons = screen.getAllByRole("button", {
-      name: /^close$/i,
-    });
-    const inlineClose = closeButtons.find(
-      (button) => button.textContent === "Close",
-    );
-    expect(inlineClose).toBeDefined();
-    fireEvent.click(inlineClose!);
-    expect(onClose).toHaveBeenCalled();
-    expect(logout).not.toHaveBeenCalled();
-  });
-
-  it("settings: Logout button also calls onClose", () => {
-    const onClose = vi.fn();
-    const logout = vi.fn();
-    mockUseSession.mockReturnValue(
-      makeSession({
-        status: "authenticated",
-        identityId: "id-1",
-        keyManager: { getAuth: vi.fn() },
-        logout,
-      }),
-    );
-
-    render(<LoginModal open onClose={onClose} />);
-
-    fireEvent.click(screen.getByRole("button", { name: /^logout$/i }));
-    expect(logout).toHaveBeenCalled();
-    expect(onClose).toHaveBeenCalled();
-  });
-
-  it("registers a new contract when the Register new button is clicked", async () => {
-    const setContractId = vi.fn();
-    mockRegisterContract.mockResolvedValue("new-contract-id");
-    mockUseSession.mockReturnValue(
-      makeSession({
-        status: "authenticated",
-        identityId: "id-1",
-        keyManager: { getAuth: vi.fn() },
-        setContractId,
-      }),
-    );
-
-    render(<LoginModal open onClose={vi.fn()} />);
-
-    fireEvent.click(screen.getByText(/advanced settings/i));
-    fireEvent.click(screen.getByRole("button", { name: /register new/i }));
-
-    await waitFor(() => {
-      expect(mockRegisterContract).toHaveBeenCalled();
-    });
-    await waitFor(() => {
-      expect(setContractId).toHaveBeenCalledWith("new-contract-id");
-    });
   });
 
   it("shows the identity-index field for mnemonic input under Advanced settings", () => {

--- a/example-apps/dashnote/test/NotesWorkspace.test.tsx
+++ b/example-apps/dashnote/test/NotesWorkspace.test.tsx
@@ -107,13 +107,15 @@ describe("NotesWorkspace", () => {
       }),
     );
 
-    const onOpenSettings = vi.fn();
-    render(<NotesWorkspace onOpenSettings={onOpenSettings} />);
+    const onOpenLogin = vi.fn();
+    render(
+      <NotesWorkspace onOpenLogin={onOpenLogin} onOpenSettings={vi.fn()} />,
+    );
 
     expect(screen.getByText(/sign in to see your notes/i)).toBeTruthy();
     const loginButton = screen.getByRole("button", { name: /^log in$/i });
     fireEvent.click(loginButton);
-    expect(onOpenSettings).toHaveBeenCalled();
+    expect(onOpenLogin).toHaveBeenCalled();
     expect(screen.queryByRole("button", { name: /new note/i })).toBeNull();
 
     const bridgeLink = screen.getByRole("link", { name: /dash bridge/i });
@@ -146,7 +148,7 @@ describe("NotesWorkspace", () => {
     });
     mockCreateNote.mockResolvedValue("note-1");
 
-    render(<NotesWorkspace onOpenSettings={vi.fn()} />);
+    render(<NotesWorkspace onOpenLogin={vi.fn()} onOpenSettings={vi.fn()} />);
 
     await waitFor(() => {
       expect(mockListMyNotes).toHaveBeenCalledTimes(1);
@@ -176,7 +178,7 @@ describe("NotesWorkspace", () => {
     mockUseSession.mockReturnValue(makeSession());
     mockListMyNotes.mockResolvedValue([]);
 
-    render(<NotesWorkspace onOpenSettings={vi.fn()} />);
+    render(<NotesWorkspace onOpenLogin={vi.fn()} onOpenSettings={vi.fn()} />);
 
     await waitFor(() => {
       expect(mockListMyNotes).toHaveBeenCalledTimes(1);
@@ -202,7 +204,7 @@ describe("NotesWorkspace", () => {
     mockUpdateNote.mockResolvedValue(undefined);
     mockDeleteNote.mockResolvedValue(undefined);
 
-    render(<NotesWorkspace onOpenSettings={vi.fn()} />);
+    render(<NotesWorkspace onOpenLogin={vi.fn()} onOpenSettings={vi.fn()} />);
 
     await waitFor(() => {
       expect(mockGetNote).toHaveBeenCalledWith(
@@ -267,7 +269,7 @@ describe("NotesWorkspace", () => {
     mockListMyNotes.mockResolvedValue([stale]);
     mockGetNote.mockResolvedValue(fresh);
 
-    render(<NotesWorkspace onOpenSettings={vi.fn()} />);
+    render(<NotesWorkspace onOpenLogin={vi.fn()} onOpenSettings={vi.fn()} />);
 
     await waitFor(() => {
       expect(mockGetNote).toHaveBeenCalledWith(
@@ -329,7 +331,7 @@ describe("NotesWorkspace", () => {
         .mockResolvedValue(remote); // post-failure refresh — chain has moved
       mockUpdateNote.mockRejectedValue(new Error("Identity nonce is stale"));
 
-      render(<NotesWorkspace onOpenSettings={vi.fn()} />);
+      render(<NotesWorkspace onOpenLogin={vi.fn()} onOpenSettings={vi.fn()} />);
 
       await waitFor(() => {
         expect(
@@ -364,7 +366,7 @@ describe("NotesWorkspace", () => {
       mockGetNote.mockResolvedValue(initial);
       mockUpdateNote.mockRejectedValue(new Error("Network unreachable"));
 
-      render(<NotesWorkspace onOpenSettings={vi.fn()} />);
+      render(<NotesWorkspace onOpenLogin={vi.fn()} onOpenSettings={vi.fn()} />);
 
       await waitFor(() => {
         expect(
@@ -396,7 +398,7 @@ describe("NotesWorkspace", () => {
         .mockRejectedValueOnce(new Error("Identity nonce is stale"))
         .mockResolvedValue(undefined);
 
-      render(<NotesWorkspace onOpenSettings={vi.fn()} />);
+      render(<NotesWorkspace onOpenLogin={vi.fn()} onOpenSettings={vi.fn()} />);
 
       await waitFor(() => {
         expect(
@@ -447,7 +449,7 @@ describe("NotesWorkspace", () => {
         .mockResolvedValue(saved); // post-save reload
       mockUpdateNote.mockResolvedValue(undefined);
 
-      render(<NotesWorkspace onOpenSettings={vi.fn()} />);
+      render(<NotesWorkspace onOpenLogin={vi.fn()} onOpenSettings={vi.fn()} />);
 
       await waitFor(() => {
         expect(
@@ -481,7 +483,7 @@ describe("NotesWorkspace", () => {
     mockUseSession.mockReturnValue(makeSession());
     mockListMyNotes.mockRejectedValue(new Error("Data contract not found"));
 
-    render(<NotesWorkspace onOpenSettings={vi.fn()} />);
+    render(<NotesWorkspace onOpenLogin={vi.fn()} onOpenSettings={vi.fn()} />);
 
     await waitFor(() => {
       expect(screen.getByText(/editor error/i)).toBeTruthy();
@@ -493,7 +495,9 @@ describe("NotesWorkspace", () => {
     mockUseSession.mockReturnValue(makeSession({ contractId: null }));
     const onOpenSettings = vi.fn();
 
-    render(<NotesWorkspace onOpenSettings={onOpenSettings} />);
+    render(
+      <NotesWorkspace onOpenLogin={vi.fn()} onOpenSettings={onOpenSettings} />,
+    );
 
     expect(screen.getByText(/register or select a contract/i)).toBeTruthy();
     fireEvent.click(screen.getByRole("button", { name: /open settings/i }));
@@ -541,7 +545,7 @@ describe("NotesWorkspace", () => {
     mockListMyNotes.mockResolvedValue(notes);
     mockGetNote.mockResolvedValue(notes[0]);
 
-    render(<NotesWorkspace onOpenSettings={vi.fn()} />);
+    render(<NotesWorkspace onOpenLogin={vi.fn()} onOpenSettings={vi.fn()} />);
 
     await waitFor(() => {
       expect(screen.getByText("Grocery list")).toBeTruthy();
@@ -582,7 +586,7 @@ describe("NotesWorkspace", () => {
       mockListMyNotes.mockResolvedValue([noteFixture]);
       mockGetNote.mockResolvedValue(noteFixture);
 
-      render(<NotesWorkspace onOpenSettings={vi.fn()} />);
+      render(<NotesWorkspace onOpenLogin={vi.fn()} onOpenSettings={vi.fn()} />);
 
       await waitFor(() => {
         expect(mockListMyNotes).toHaveBeenCalledTimes(1);
@@ -598,7 +602,7 @@ describe("NotesWorkspace", () => {
       mockUseSession.mockReturnValue(makeSession());
       mockListMyNotes.mockResolvedValue([]);
 
-      render(<NotesWorkspace onOpenSettings={vi.fn()} />);
+      render(<NotesWorkspace onOpenLogin={vi.fn()} onOpenSettings={vi.fn()} />);
 
       await waitFor(() => {
         expect(mockListMyNotes).toHaveBeenCalledTimes(1);
@@ -619,7 +623,7 @@ describe("NotesWorkspace", () => {
       mockListMyNotes.mockResolvedValue([noteFixture]);
       mockGetNote.mockResolvedValue(noteFixture);
 
-      render(<NotesWorkspace onOpenSettings={vi.fn()} />);
+      render(<NotesWorkspace onOpenLogin={vi.fn()} onOpenSettings={vi.fn()} />);
 
       await waitFor(() => {
         expect(screen.getByText(/phone note/i)).toBeTruthy();
@@ -641,7 +645,7 @@ describe("NotesWorkspace", () => {
       mockListMyNotes.mockResolvedValue([noteFixture]);
       mockGetNote.mockResolvedValue(noteFixture);
 
-      render(<NotesWorkspace onOpenSettings={vi.fn()} />);
+      render(<NotesWorkspace onOpenLogin={vi.fn()} onOpenSettings={vi.fn()} />);
 
       await waitFor(() => {
         expect(screen.getByText(/phone note/i)).toBeTruthy();
@@ -666,7 +670,7 @@ describe("NotesWorkspace", () => {
       mockGetNote.mockResolvedValue(noteFixture);
       mockDeleteNote.mockResolvedValue(undefined);
 
-      render(<NotesWorkspace onOpenSettings={vi.fn()} />);
+      render(<NotesWorkspace onOpenLogin={vi.fn()} onOpenSettings={vi.fn()} />);
 
       await waitFor(() => {
         expect(screen.getByText(/phone note/i)).toBeTruthy();
@@ -725,7 +729,7 @@ describe("NotesWorkspace", () => {
       );
       mockGetNote.mockImplementation(() => new Promise(() => {}));
 
-      render(<NotesWorkspace onOpenSettings={vi.fn()} />);
+      render(<NotesWorkspace onOpenLogin={vi.fn()} onOpenSettings={vi.fn()} />);
 
       // Synchronously visible from cache (no waitFor needed).
       expect(screen.getAllByText(/cached title/i).length).toBeGreaterThan(0);
@@ -759,7 +763,7 @@ describe("NotesWorkspace", () => {
       );
       mockGetNote.mockResolvedValue(cached);
 
-      render(<NotesWorkspace onOpenSettings={vi.fn()} />);
+      render(<NotesWorkspace onOpenLogin={vi.fn()} onOpenSettings={vi.fn()} />);
 
       // Cached note is auto-selected on desktop and the editor is shown, but
       // the save button must be disabled because editsReady=false.
@@ -807,7 +811,7 @@ describe("NotesWorkspace", () => {
         .mockResolvedValueOnce([newerFromChain]);
       mockGetNote.mockResolvedValue(initial);
 
-      render(<NotesWorkspace onOpenSettings={vi.fn()} />);
+      render(<NotesWorkspace onOpenLogin={vi.fn()} onOpenSettings={vi.fn()} />);
 
       // Wait for initial load to settle so the editor reflects the cached/
       // chain content with baselines set.
@@ -874,7 +878,7 @@ describe("NotesWorkspace", () => {
         },
       ]);
 
-      render(<NotesWorkspace onOpenSettings={vi.fn()} />);
+      render(<NotesWorkspace onOpenLogin={vi.fn()} onOpenSettings={vi.fn()} />);
 
       // Cached list paints synchronously, even though sdk is null. Without the
       // reloadNotes-skip-when-sdk-null fix, the list would be wiped to [].
@@ -900,7 +904,7 @@ describe("NotesWorkspace", () => {
       mockListMyNotes.mockImplementation(() => new Promise(() => {}));
       mockGetNote.mockImplementation(() => new Promise(() => {}));
 
-      render(<NotesWorkspace onOpenSettings={vi.fn()} />);
+      render(<NotesWorkspace onOpenLogin={vi.fn()} onOpenSettings={vi.fn()} />);
 
       // Editor pane shows the seeded note's content from the very first paint
       // (no "No note selected" empty state in between).
@@ -927,7 +931,7 @@ describe("NotesWorkspace", () => {
       ]);
       mockListMyNotes.mockImplementation(() => new Promise(() => {}));
 
-      render(<NotesWorkspace onOpenSettings={vi.fn()} />);
+      render(<NotesWorkspace onOpenLogin={vi.fn()} onOpenSettings={vi.fn()} />);
 
       // Cached list paints synchronously on mobile too.
       expect(screen.getByText("Mobile cached")).toBeTruthy();
@@ -968,7 +972,9 @@ describe("NotesWorkspace", () => {
         );
       mockGetNote.mockImplementation(() => new Promise(() => {}));
 
-      const { rerender } = render(<NotesWorkspace onOpenSettings={vi.fn()} />);
+      const { rerender } = render(
+        <NotesWorkspace onOpenLogin={vi.fn()} onOpenSettings={vi.fn()} />,
+      );
 
       // Switch to a new identity+contract while the first listMyNotes is
       // still pending. Re-rendering with a fresh session value triggers the
@@ -977,7 +983,9 @@ describe("NotesWorkspace", () => {
       mockUseSession.mockReturnValue(
         makeSession({ identityId: "identity-2", contractId: "contract-2" }),
       );
-      rerender(<NotesWorkspace onOpenSettings={vi.fn()} />);
+      rerender(
+        <NotesWorkspace onOpenLogin={vi.fn()} onOpenSettings={vi.fn()} />,
+      );
 
       // Wait until the post-rerender hydrate effect has actually issued its
       // own listMyNotes call. This proves the new reload token is in place
@@ -1034,7 +1042,7 @@ describe("NotesWorkspace", () => {
       mockListMyNotes.mockRejectedValue(new Error("Network unreachable"));
       mockGetNote.mockRejectedValue(new Error("Network unreachable"));
 
-      render(<NotesWorkspace onOpenSettings={vi.fn()} />);
+      render(<NotesWorkspace onOpenLogin={vi.fn()} onOpenSettings={vi.fn()} />);
 
       // Error surfaces but cached data stays visible.
       await waitFor(() => {

--- a/example-apps/dashnote/test/SettingsPanel.test.tsx
+++ b/example-apps/dashnote/test/SettingsPanel.test.tsx
@@ -185,6 +185,31 @@ describe("SettingsPanel", () => {
     });
   });
 
+  it("rejects concurrent register clicks before React disables the button", async () => {
+    // Hold the first call open so a second invocation can race past
+    // setRegistering(true). The ref guard inside the hook must short-circuit
+    // the second call so the SDK only sees one publish.
+    let resolveFirst: ((value: string) => void) | undefined;
+    mockRegisterContract.mockImplementation(
+      () =>
+        new Promise<string>((resolve) => {
+          resolveFirst = resolve;
+        }),
+    );
+    mockUseSession.mockReturnValue(makeSession({ setContractId: vi.fn() }));
+    render(<SettingsPanel />);
+    const button = screen.getByRole("button", {
+      name: /register a fresh contract/i,
+    });
+    fireEvent.click(button);
+    fireEvent.click(button);
+    expect(mockRegisterContract).toHaveBeenCalledTimes(1);
+    resolveFirst?.("only-id");
+    await waitFor(() => {
+      expect(mockRegisterContract).toHaveBeenCalledTimes(1);
+    });
+  });
+
   it("surfaces a registration failure without switching contracts", async () => {
     const setContractId = vi.fn();
     mockRegisterContract.mockRejectedValue(new Error("Network down"));

--- a/example-apps/dashnote/test/SettingsPanel.test.tsx
+++ b/example-apps/dashnote/test/SettingsPanel.test.tsx
@@ -1,0 +1,210 @@
+// @vitest-environment jsdom
+
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { SettingsPanel } from "../src/components/SettingsPanel";
+
+const { mockUseSession, mockRegisterContract, mockClearCachedNotes } =
+  vi.hoisted(() => ({
+    mockUseSession: vi.fn(),
+    mockRegisterContract: vi.fn(),
+    mockClearCachedNotes: vi.fn(),
+  }));
+
+vi.mock("../src/session/useSession", () => ({
+  useSession: mockUseSession,
+}));
+
+vi.mock("../src/dash/contract", () => ({
+  registerContract: mockRegisterContract,
+}));
+
+vi.mock("../src/lib/notesCache", () => ({
+  clearCachedNotes: mockClearCachedNotes,
+}));
+
+interface SessionOverrides {
+  status?: string;
+  identityId?: string | null;
+  contractId?: string | null;
+  rememberedIdentityId?: string | null;
+  dpnsName?: string | null;
+  sdk?: unknown;
+  keyManager?: unknown;
+  setContractId?: ReturnType<typeof vi.fn>;
+  forgetIdentity?: ReturnType<typeof vi.fn>;
+  logout?: ReturnType<typeof vi.fn>;
+  log?: ReturnType<typeof vi.fn>;
+}
+
+function makeSession(overrides: SessionOverrides = {}) {
+  return {
+    status: "authenticated",
+    error: null,
+    sdk: { documents: {} },
+    keyManager: { getAuth: vi.fn() },
+    identityId: "id-1234567890",
+    contractId: "contract-abc",
+    rememberedIdentityId: null,
+    dpnsName: null,
+    log: vi.fn(),
+    login: vi.fn(),
+    logout: vi.fn(),
+    setContractId: vi.fn(),
+    enterReadOnly: vi.fn(),
+    viewAsRemembered: vi.fn(),
+    forgetIdentity: vi.fn(),
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  mockUseSession.mockReset();
+  mockRegisterContract.mockReset();
+  mockClearCachedNotes.mockReset();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("SettingsPanel", () => {
+  it("renders the identity ID and DPNS caption when authenticated", () => {
+    mockUseSession.mockReturnValue(
+      makeSession({ identityId: "id-abc", dpnsName: "alice" }),
+    );
+    render(<SettingsPanel />);
+    const block = screen.getByTestId("settings-identity-block");
+    expect(within(block).getByText("id-abc")).toBeTruthy();
+    expect(within(block).getByText("✓ alice.dash")).toBeTruthy();
+  });
+
+  it("omits the DPNS caption when no name is set", () => {
+    mockUseSession.mockReturnValue(
+      makeSession({ identityId: "id-abc", dpnsName: null }),
+    );
+    render(<SettingsPanel />);
+    const block = screen.getByTestId("settings-identity-block");
+    expect(within(block).queryByText(/\.dash$/)).toBeNull();
+  });
+
+  it("renders the network indicator as testnet", () => {
+    mockUseSession.mockReturnValue(makeSession());
+    render(<SettingsPanel />);
+    expect(screen.getByText("testnet")).toBeTruthy();
+  });
+
+  it("shows an empty state when not signed in or browsing", () => {
+    mockUseSession.mockReturnValue(
+      makeSession({ status: "readonly", identityId: null, keyManager: null }),
+    );
+    render(<SettingsPanel />);
+    expect(screen.getByText(/sign in to view/i)).toBeTruthy();
+    expect(screen.queryByTestId("settings-identity-block")).toBeNull();
+  });
+
+  it("hides the danger zone when nothing is remembered", () => {
+    mockUseSession.mockReturnValue(makeSession({ rememberedIdentityId: null }));
+    render(<SettingsPanel />);
+    expect(
+      screen.queryByRole("button", { name: /forget this device/i }),
+    ).toBeNull();
+  });
+
+  it("calls session.forgetIdentity when Forget this device is clicked", () => {
+    const forgetIdentity = vi.fn();
+    mockUseSession.mockReturnValue(
+      makeSession({
+        rememberedIdentityId: "id-1234567890",
+        forgetIdentity,
+      }),
+    );
+    render(<SettingsPanel />);
+    fireEvent.click(
+      screen.getByRole("button", { name: /forget this device/i }),
+    );
+    expect(forgetIdentity).toHaveBeenCalled();
+  });
+
+  it("copies the identity ID to the clipboard", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+    mockUseSession.mockReturnValue(makeSession({ identityId: "id-xyz" }));
+    render(<SettingsPanel />);
+    fireEvent.click(screen.getByRole("button", { name: /copy identity id/i }));
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith("id-xyz");
+    });
+  });
+
+  it("applies a pasted contract ID via session.setContractId", () => {
+    const setContractId = vi.fn();
+    mockUseSession.mockReturnValue(
+      makeSession({ contractId: "old", setContractId }),
+    );
+    render(<SettingsPanel />);
+    const input = screen.getByPlaceholderText(/paste a note contract id/i);
+    fireEvent.change(input, { target: { value: " new-contract " } });
+    fireEvent.click(screen.getByRole("button", { name: /use this id/i }));
+    expect(setContractId).toHaveBeenCalledWith("new-contract");
+  });
+
+  it("registers a fresh contract with the session sdk, keyManager, and log", async () => {
+    const setContractId = vi.fn();
+    const sdk = { documents: {}, marker: "sdk" };
+    const keyManager = { getAuth: vi.fn(), marker: "km" };
+    const log = vi.fn();
+    mockRegisterContract.mockResolvedValue("brand-new-id");
+    mockUseSession.mockReturnValue(
+      makeSession({ setContractId, sdk, keyManager, log }),
+    );
+    render(<SettingsPanel />);
+    fireEvent.click(
+      screen.getByRole("button", { name: /register a fresh contract/i }),
+    );
+    await waitFor(() => {
+      expect(mockRegisterContract).toHaveBeenCalledWith({
+        sdk,
+        keyManager,
+        log,
+      });
+    });
+    await waitFor(() => {
+      expect(setContractId).toHaveBeenCalledWith("brand-new-id");
+    });
+  });
+
+  it("surfaces a registration failure without switching contracts", async () => {
+    const setContractId = vi.fn();
+    mockRegisterContract.mockRejectedValue(new Error("Network down"));
+    mockUseSession.mockReturnValue(makeSession({ setContractId }));
+    render(<SettingsPanel />);
+    fireEvent.click(
+      screen.getByRole("button", { name: /register a fresh contract/i }),
+    );
+    expect(await screen.findByText("Network down")).toBeTruthy();
+    expect(setContractId).not.toHaveBeenCalled();
+  });
+
+  it("invokes clearCachedNotes with the current identity ID", () => {
+    mockUseSession.mockReturnValue(makeSession({ identityId: "id-cache" }));
+    render(<SettingsPanel />);
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: /clear local cache for this device/i,
+      }),
+    );
+    expect(mockClearCachedNotes).toHaveBeenCalledWith("id-cache");
+  });
+});


### PR DESCRIPTION
LoginModal stripped to the unauthenticated flow only. Account management moves to a Settings tab (Identity, Contract, Data, Appearance, Danger zone) and an IdentityCard popover (Settings, Switch identity, Log out when authed; one-click login when readonly).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a Settings tab for managing app preferences and identity settings
  * Added a Settings dropdown menu accessible from the user identity card, with options to switch identity or log out
  * Added theme toggle in Settings to customize app appearance
  * Added ability to clear cached note data from Settings
  * Moved contract registration and management to the Settings section

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dashpay/platform-tutorials/pull/80)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->