### PR TITLE
test(dashnote): add Playwright e2e suite (smoke, auth, notes, settings) + CI

### DIFF
--- a/.github/workflows/dashnote-e2e.yml
+++ b/.github/workflows/dashnote-e2e.yml
@@ -1,0 +1,153 @@
+name: Dashnote E2E
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'example-apps/dashnote/**'
+      - '.github/workflows/dashnote-e2e.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'example-apps/dashnote/**'
+      - '.github/workflows/dashnote-e2e.yml'
+  workflow_dispatch:
+    inputs:
+      test_suite:
+        description: 'Which specs to run'
+        type: choice
+        options:
+          - read-only
+          - read-write
+          - all
+        default: read-only
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dashnote-e2e-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e-read-only:
+    name: e2e (read-only — smoke + settings)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    if: >
+      github.event_name != 'workflow_dispatch' ||
+      inputs.test_suite == 'read-only' ||
+      inputs.test_suite == 'all'
+    defaults:
+      run:
+        working-directory: example-apps/dashnote
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: '20'
+
+      - name: Install dashnote dependencies
+        run: npm ci
+
+      - name: Resolve Playwright version
+        id: playwright-version
+        run: echo "version=$(node -p "require('./package.json').devDependencies['@playwright/test']")" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
+
+      - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: npx playwright install --with-deps chromium
+
+      - name: Install browser system deps (cache hit)
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium
+
+      - name: Run read-only specs
+        env:
+          PLATFORM_MNEMONIC: ${{ secrets.PLATFORM_MNEMONIC }}
+        run: npx playwright test smoke.spec.ts settings.spec.ts
+
+      - name: Upload Playwright report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-read-only
+          path: example-apps/dashnote/playwright-report/
+          retention-days: 14
+
+      - name: Upload Playwright traces on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-test-results-read-only
+          path: example-apps/dashnote/test-results/
+          retention-days: 14
+
+  e2e-read-write:
+    name: e2e (read-write — auth + notes)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    if: >
+      github.event_name == 'workflow_dispatch' &&
+      (inputs.test_suite == 'read-write' || inputs.test_suite == 'all')
+    concurrency:
+      group: dashnote-e2e-read-write
+      cancel-in-progress: false
+    defaults:
+      run:
+        working-directory: example-apps/dashnote
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: '20'
+
+      - name: Install dashnote dependencies
+        run: npm ci
+
+      - name: Resolve Playwright version
+        id: playwright-version
+        run: echo "version=$(node -p "require('./package.json').devDependencies['@playwright/test']")" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
+
+      - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: npx playwright install --with-deps chromium
+
+      - name: Install browser system deps (cache hit)
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium
+
+      - name: Run read-write specs
+        env:
+          PLATFORM_MNEMONIC: ${{ secrets.PLATFORM_MNEMONIC }}
+        run: npx playwright test auth.spec.ts notes.spec.ts
+
+      - name: Upload Playwright report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-read-write
+          path: example-apps/dashnote/playwright-report/
+          retention-days: 14
+
+      - name: Upload Playwright traces on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-test-results-read-write
+          path: example-apps/dashnote/test-results/
+          retention-days: 14

--- a/.github/workflows/dashnote-e2e.yml
+++ b/.github/workflows/dashnote-e2e.yml
@@ -55,7 +55,7 @@ jobs:
         run: echo "version=$(node -p "require('./package.json').devDependencies['@playwright/test']")" >> "$GITHUB_OUTPUT"
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         id: playwright-cache
         with:
           path: ~/.cache/ms-playwright
@@ -76,7 +76,7 @@ jobs:
 
       - name: Upload Playwright report on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: playwright-report-read-only
           path: example-apps/dashnote/playwright-report/
@@ -84,7 +84,7 @@ jobs:
 
       - name: Upload Playwright traces on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: playwright-test-results-read-only
           path: example-apps/dashnote/test-results/
@@ -117,7 +117,7 @@ jobs:
         run: echo "version=$(node -p "require('./package.json').devDependencies['@playwright/test']")" >> "$GITHUB_OUTPUT"
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         id: playwright-cache
         with:
           path: ~/.cache/ms-playwright
@@ -138,7 +138,7 @@ jobs:
 
       - name: Upload Playwright report on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: playwright-report-read-write
           path: example-apps/dashnote/playwright-report/
@@ -146,7 +146,7 @@ jobs:
 
       - name: Upload Playwright traces on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: playwright-test-results-read-write
           path: example-apps/dashnote/test-results/

--- a/example-apps/dashnote/CLAUDE.md
+++ b/example-apps/dashnote/CLAUDE.md
@@ -12,6 +12,8 @@ React + TypeScript + Vite app for personal notes on Dash Platform testnet. Notes
 - `npm run build` — typecheck (`tsc -b`) then bundle
 - `npm run lint` — ESLint
 - `npm run test` — Vitest suite in [test/](test/)
+- `npm run test:e2e` — Playwright suite in [test/e2e/](test/e2e/) (auto-boots Vite on :5181)
+- `npm run test:e2e:ui` — Playwright with the interactive UI runner
 - `npm run format` / `format:check` — Prettier
 - `npm run preview` — serve production build locally
 
@@ -26,6 +28,7 @@ React + TypeScript + Vite app for personal notes on Dash Platform testnet. Notes
 - **[src/dash/types.ts](src/dash/types.ts)** — shared SDK types (`DashSdk`, `DashKeyManager`, query result shapes) used across every dash helper.
 - **[public/dashnote-lite.html](public/dashnote-lite.html)** — single-file zero-build companion. Read-only Recent notes (with optional owner filter) + Get-by-ID only, loads `@dashevo/evo-sdk` from `esm.sh`, and ships alongside the React app at `<...>/dashnote/dashnote-lite.html` (Vite copies `public/*` into `dist/`). Intentionally self-contained as a learning reference — don't import app code into it.
 - **[test/](test/)** — Vitest + Testing Library. All test files live in this flat directory and are named after the subject under test (e.g. `NotesWorkspace.test.tsx`, `SessionContext.test.tsx`, `notesCache.test.ts`) — they are **not** co-located next to source files, and the directory is **not** mirrored against `src/`. Default Vitest env is `node`; component tests opt into DOM with a `// @vitest-environment jsdom` pragma at the top of the file.
+- **[test/e2e/](test/e2e/)** — Playwright specs plus shared `fixtures.ts`. Driven by [playwright.config.ts](playwright.config.ts), which loads `PLATFORM_MNEMONIC` from `../../.env` (repo root, with optional `dashnote/.env` override) and auto-starts `npx vite` on port 5181. The suite runs against real testnet — no SDK mocks. Two projects (`chromium-desktop` using `Desktop Chrome` and `chromium-mobile` using `Pixel 7`) so every spec exercises both layouts; viewport-only flows are guarded inline with `test.skip(testInfo.project.name !== "chromium-mobile", …)` rather than living in a dedicated file. Auth-gated specs sit in `test.describe.configure({ mode: "serial" })` and `test.skip` cleanly when `PLATFORM_MNEMONIC` is unset (via the `HAS_MNEMONIC` flag from `fixtures.ts`).
 
 ## Note contract
 

--- a/example-apps/dashnote/package.json
+++ b/example-apps/dashnote/package.json
@@ -13,6 +13,8 @@
     "lint": "eslint .",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/example-apps/dashnote/playwright.config.ts
+++ b/example-apps/dashnote/playwright.config.ts
@@ -1,0 +1,49 @@
+import { defineConfig, devices } from "@playwright/test";
+import { config as loadEnv } from "dotenv";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+// Load repo-root .env first (where PLATFORM_MNEMONIC lives for the tutorials),
+// then let a local dashnote/.env override it if present.
+loadEnv({ path: resolve(here, "../../.env") });
+loadEnv({ path: resolve(here, ".env"), override: true });
+
+const PORT = 5181;
+
+export default defineConfig({
+  testDir: "./test/e2e",
+  testMatch: "**/*.spec.ts",
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: 1,
+  workers: 1,
+  timeout: 30_000,
+  expect: { timeout: 15_000 },
+  reporter: process.env.CI ? "list" : [["list"], ["html", { open: "never" }]],
+
+  use: {
+    baseURL: `http://localhost:${PORT}`,
+    trace: "retain-on-failure",
+    permissions: ["clipboard-read", "clipboard-write"],
+  },
+
+  projects: [
+    {
+      name: "chromium-desktop",
+      use: { ...devices["Desktop Chrome"] },
+    },
+    {
+      name: "chromium-mobile",
+      use: { ...devices["Pixel 7"] },
+    },
+  ],
+
+  webServer: {
+    command: `npx vite --port ${PORT} --strictPort`,
+    url: `http://localhost:${PORT}`,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+});

--- a/example-apps/dashnote/playwright.config.ts
+++ b/example-apps/dashnote/playwright.config.ts
@@ -19,7 +19,7 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: 1,
   workers: 1,
-  timeout: 15_000,
+  timeout: 30_000,
   expect: { timeout: 7_500 },
   reporter: process.env.CI ? "list" : [["list"], ["html", { open: "never" }]],
 

--- a/example-apps/dashnote/playwright.config.ts
+++ b/example-apps/dashnote/playwright.config.ts
@@ -19,8 +19,8 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: 1,
   workers: 1,
-  timeout: 30_000,
-  expect: { timeout: 15_000 },
+  timeout: 15_000,
+  expect: { timeout: 7_500 },
   reporter: process.env.CI ? "list" : [["list"], ["html", { open: "never" }]],
 
   use: {

--- a/example-apps/dashnote/test/e2e/auth.spec.ts
+++ b/example-apps/dashnote/test/e2e/auth.spec.ts
@@ -5,7 +5,7 @@ import {
   loginViaModal,
   navButton,
   openIdentityMenu,
-  type Page,
+  openSettingsTab,
 } from "./fixtures";
 
 test.skip(!HAS_MNEMONIC, "PLATFORM_MNEMONIC not set — skipping auth specs");
@@ -29,17 +29,6 @@ test.beforeEach(async ({ page }) => {
     timeout: 60_000,
   });
 });
-
-async function openSettingsTab(page: Page) {
-  // SettingsPanel renders when tab === "settings". Reachable both via
-  // the sidebar "Settings" NavButton and via the IdentityCard menu;
-  // use the menu so we exercise that path too.
-  await openIdentityMenu(page);
-  await page.getByRole("menuitem", { name: /^settings$/i }).click();
-  await expect(
-    page.getByRole("heading", { name: /^Settings$/, level: 1 }),
-  ).toBeVisible();
-}
 
 test("login with a mnemonic, then logout via the IdentityCard menu", async ({
   page,

--- a/example-apps/dashnote/test/e2e/auth.spec.ts
+++ b/example-apps/dashnote/test/e2e/auth.spec.ts
@@ -1,0 +1,176 @@
+import {
+  test,
+  expect,
+  HAS_MNEMONIC,
+  loginViaModal,
+  navButton,
+  openIdentityMenu,
+  type Page,
+} from "./fixtures";
+
+test.skip(!HAS_MNEMONIC, "PLATFORM_MNEMONIC not set — skipping auth specs");
+test.describe.configure({ mode: "serial" });
+
+// Each test starts from a clean session: no remembered identity, no
+// contract override. The base `page` fixture in fixtures.ts already
+// waits for the SDK to connect on `/`, so the IdentityCard renders
+// "Connected" (readonly) by default.
+test.beforeEach(async ({ page }) => {
+  await page.evaluate(() => {
+    try {
+      window.localStorage.removeItem("dashnote.lastIdentity");
+      window.localStorage.removeItem("dashnote.contractId");
+    } catch {
+      /* localStorage may be unavailable in some contexts */
+    }
+  });
+  await page.reload();
+  await expect(page.locator(".conn-dot.connected").first()).toBeVisible({
+    timeout: 60_000,
+  });
+});
+
+async function openSettingsTab(page: Page) {
+  // SettingsPanel renders when tab === "settings". Reachable both via
+  // the sidebar "Settings" NavButton and via the IdentityCard menu;
+  // use the menu so we exercise that path too.
+  await openIdentityMenu(page);
+  await page.getByRole("menuitem", { name: /^settings$/i }).click();
+  await expect(
+    page.getByRole("heading", { name: /^Settings$/, level: 1 }),
+  ).toBeVisible();
+}
+
+test("login with a mnemonic, then logout via the IdentityCard menu", async ({
+  page,
+}) => {
+  await loginViaModal(page);
+
+  await openIdentityMenu(page);
+  await page.getByRole("menuitem", { name: /^log out$/i }).click();
+
+  // No remembered identity → session drops back to readonly → IdentityCard
+  // eyebrow shows "Connected" (the readonly card).
+  await expect(
+    page.locator('aside[aria-label="Main navigation"]').getByText("Connected"),
+  ).toHaveCount(2, { timeout: 30_000 });
+});
+
+test("remember-me persists the identity hint across reloads", async ({
+  page,
+}) => {
+  await loginViaModal(page, { rememberMe: true });
+
+  await page.reload();
+  // A fresh load drops the keyManager, so the remembered identity boots
+  // into "browsing" (read-only) rather than authenticated.
+  await expect(
+    page.getByText("Browsing (read-only)", { exact: true }),
+  ).toBeVisible({ timeout: 30_000 });
+});
+
+test("forget-this-device via the Settings panel drops back to readonly", async ({
+  page,
+}) => {
+  await loginViaModal(page, { rememberMe: true });
+
+  await openSettingsTab(page);
+  // "Danger zone" Section only renders when rememberedIdentityId is set.
+  await page.getByRole("button", { name: /forget this device/i }).click();
+
+  // After forgetting, this session stays authenticated; the localStorage
+  // hint is gone, so a reload drops to readonly (not browsing).
+  await page.reload();
+  await expect(page.locator(".conn-dot.connected").first()).toBeVisible({
+    timeout: 30_000,
+  });
+  await expect(
+    page.getByText("Browsing (read-only)", { exact: true }),
+  ).toBeHidden();
+});
+
+test("forget-this-device via the LoginModal also clears the remembered identity", async ({
+  page,
+}) => {
+  await loginViaModal(page, { rememberMe: true });
+
+  // Log out so the modal can be opened with the rememberedIdentity panel
+  // visible. Logout-without-forget keeps the hint, dropping to browsing.
+  await openIdentityMenu(page);
+  await page.getByRole("menuitem", { name: /^log out$/i }).click();
+  await expect(
+    page.getByText("Browsing (read-only)", { exact: true }),
+  ).toBeVisible({ timeout: 30_000 });
+
+  // Open the login modal — the "Forget this device" button is rendered
+  // beside "Use a different identity" when rememberedIdentityId is set.
+  // The IdentityCard in browsing state is a button with aria-haspopup="menu"
+  // (the "Switch identity" menuitem opens the login modal).
+  await openIdentityMenu(page);
+  await page.getByRole("menuitem", { name: /switch identity/i }).click();
+
+  const dialog = page.getByRole("dialog");
+  await expect(dialog).toBeVisible();
+  await dialog.getByRole("button", { name: /forget this device/i }).click();
+
+  // The form re-renders without the remembered panel.
+  await expect(
+    dialog.locator('[data-testid="remembered-identity-panel"]'),
+  ).toBeHidden();
+
+  // Close and reload — readonly state confirms the hint is gone.
+  await dialog.getByRole("button", { name: /^cancel$/i }).click();
+  await page.reload();
+  await expect(
+    page.getByText("Browsing (read-only)", { exact: true }),
+  ).toBeHidden();
+});
+
+test("Switch identity from the IdentityCard menu re-opens the login form", async ({
+  page,
+}) => {
+  await loginViaModal(page);
+
+  await openIdentityMenu(page);
+  await page.getByRole("menuitem", { name: /switch identity/i }).click();
+
+  // The LoginModal opens with the same form layout regardless of session
+  // state. Verify it's open and ready to accept a new secret.
+  const dialog = page.getByRole("dialog");
+  await expect(dialog).toBeVisible();
+  await expect(dialog.getByPlaceholder(/mnemonic phrase|wif/i)).toBeVisible();
+  await expect(dialog.getByRole("button", { name: /^Login$/ })).toBeDisabled();
+});
+
+test("Settings tab is reachable from both the IdentityCard menu and the sidebar NavButton", async ({
+  page,
+}) => {
+  await loginViaModal(page);
+
+  // Menu path.
+  await openSettingsTab(page);
+
+  // Sidebar NavButton path — switch away first, then back. navButton
+  // handles the mobile drawer open dance.
+  await (await navButton(page, /how it works/i)).click();
+  await expect(
+    page.getByRole("heading", { name: /How Dashnote works/i }),
+  ).toBeVisible();
+
+  await (await navButton(page, /settings$/i)).click();
+  await expect(
+    page.getByRole("heading", { name: /^Settings$/, level: 1 }),
+  ).toBeVisible();
+});
+
+test("Settings panel displays the identity ID once authenticated", async ({
+  page,
+}) => {
+  await loginViaModal(page);
+  await openSettingsTab(page);
+
+  const idBlock = page.locator('[data-testid="settings-identity-block"]');
+  // Identity IDs are base58 strings ~44 chars long; require something
+  // substantial rather than the loading placeholder.
+  await expect(idBlock).toContainText(/[0-9A-Za-z]{40,}/);
+});

--- a/example-apps/dashnote/test/e2e/auth.spec.ts
+++ b/example-apps/dashnote/test/e2e/auth.spec.ts
@@ -38,8 +38,10 @@ test("login with a mnemonic, then logout via the IdentityCard menu", async ({
   await openIdentityMenu(page);
   await page.getByRole("menuitem", { name: /^log out$/i }).click();
 
-  // No remembered identity → session drops back to readonly → IdentityCard
-  // eyebrow shows "Connected" (the readonly card).
+  // No remembered identity → session drops back to readonly. The readonly
+  // IdentityCard paints "Connected" twice: once as the eyebrow label
+  // above the card, and once as the inline status text next to the
+  // connection dot — hence count=2, not 1.
   await expect(
     page.locator('aside[aria-label="Main navigation"]').getByText("Connected"),
   ).toHaveCount(2, { timeout: 30_000 });

--- a/example-apps/dashnote/test/e2e/fixtures.ts
+++ b/example-apps/dashnote/test/e2e/fixtures.ts
@@ -1,0 +1,109 @@
+/**
+ * Shared Playwright fixtures for dashnote E2E tests.
+ *
+ * Runs against real Dash Platform testnet — no SDK mocks. The base `page`
+ * fixture navigates to `/` and waits until the IdentityCard reports a live
+ * SDK connection (`Connected`, `Authenticated`, or `Browsing (read-only)`)
+ * so spec bodies always have a usable SDK.
+ *
+ * The sidebar is rendered as `<aside aria-label="Main navigation">`, not a
+ * `<nav>` landmark — scope nav-button lookups through `navButton(page, …)`
+ * rather than `page.getByRole("navigation")`.
+ *
+ * On the mobile project, the sidebar is hidden until the hamburger button
+ * is tapped. `navButton` opens the drawer transparently so spec authors
+ * don't have to branch on viewport.
+ */
+import { test as base, expect, type Page } from "@playwright/test";
+
+interface AppFixture {
+  page: Page;
+}
+
+// Re-export the raw Playwright test so specs that need to manipulate
+// localStorage / viewport before navigation can bypass the connection
+// pre-condition baked into the default fixture.
+export { base as rawTest };
+
+export const test = base.extend<AppFixture>({
+  page: async ({ page }, provide) => {
+    await page.goto("/");
+    // The IdentityCard renders a `<span class="conn-dot connected">` once
+    // createClient() resolves, regardless of session.status (readonly /
+    // authenticated / browsing). Anchor the wait on the dot itself so we
+    // don't have to disambiguate between the duplicated "Connected" /
+    // eyebrow labels that the readonly card paints.
+    await expect(page.locator(".conn-dot.connected").first()).toBeVisible({
+      timeout: 60_000,
+    });
+    await provide(page);
+  },
+});
+
+export { expect, type Page };
+
+export const HAS_MNEMONIC = Boolean(process.env.PLATFORM_MNEMONIC?.trim());
+
+function isMobile(page: Page): boolean {
+  const size = page.viewportSize();
+  return size != null && size.width < 768;
+}
+
+/**
+ * Resolve a sidebar nav button (Notes / How it works / Login) by label.
+ *
+ * On mobile the sidebar is off-canvas; this helper opens the hamburger
+ * drawer first so the button is in the visible viewport.
+ */
+export async function navButton(page: Page, label: RegExp | string) {
+  if (isMobile(page)) {
+    // Hamburger button carries aria-expanded="true|false" reflecting drawerOpen.
+    const hamburger = page.locator('button[aria-expanded][aria-label*="menu" i]');
+    if ((await hamburger.getAttribute("aria-expanded")) !== "true") {
+      await hamburger.click();
+      await expect(hamburger).toHaveAttribute("aria-expanded", "true");
+    }
+  }
+  return page
+    .locator('aside[aria-label="Main navigation"]')
+    .getByRole("button", { name: label });
+}
+
+/**
+ * Open the LoginModal via the sidebar "Login" nav button, fill the
+ * mnemonic from PLATFORM_MNEMONIC, submit, and wait for the
+ * IdentityCard to report `Authenticated`.
+ *
+ * Defaults to `rememberMe: false` (the modal's default is true) so tests
+ * start from a clean localStorage; opt in explicitly when exercising the
+ * remember/forget flow.
+ *
+ * Caller is responsible for `test.skip(!HAS_MNEMONIC, …)`.
+ */
+export async function loginViaModal(
+  page: Page,
+  { rememberMe = false }: { rememberMe?: boolean } = {},
+) {
+  const mnemonic = process.env.PLATFORM_MNEMONIC?.trim();
+  if (!mnemonic) {
+    throw new Error("PLATFORM_MNEMONIC is required for loginViaModal");
+  }
+
+  await (await navButton(page, /login$/i)).click();
+
+  const dialog = page.getByRole("dialog");
+  await expect(dialog).toBeVisible();
+  await dialog.getByPlaceholder(/mnemonic phrase/i).fill(mnemonic);
+  const rememberCheckbox = dialog.getByRole("checkbox", {
+    name: /remember this identity/i,
+  });
+  if (!rememberMe) {
+    await rememberCheckbox.uncheck();
+  }
+  await dialog.getByRole("button", { name: /^Login$/ }).click();
+
+  await expect(dialog).toBeHidden({ timeout: 60_000 });
+  await expect(page.getByText("Authenticated", { exact: true })).toBeVisible({
+    timeout: 60_000,
+  });
+}

--- a/example-apps/dashnote/test/e2e/fixtures.ts
+++ b/example-apps/dashnote/test/e2e/fixtures.ts
@@ -332,9 +332,9 @@ export async function seedSearchFixtures(page: Page) {
   // cached entries — either way, the DOM now reflects truth and an
   // `existing.count() === 0` check won't false-negative against a
   // fixture that exists on-network but hasn't rendered yet.
-  await expect(
-    page.getByRole("status", { name: /loading notes/i }),
-  ).toBeHidden({ timeout: 60_000 });
+  await expect(page.getByRole("status", { name: /loading notes/i })).toBeHidden(
+    { timeout: 60_000 },
+  );
   for (const title of [SEARCH_FIXTURE_ALPHA, SEARCH_FIXTURE_BETA]) {
     const existing = page.locator("button", { hasText: title });
     if ((await existing.count()) > 0) continue;

--- a/example-apps/dashnote/test/e2e/fixtures.ts
+++ b/example-apps/dashnote/test/e2e/fixtures.ts
@@ -141,6 +141,19 @@ export async function loginViaModal(
 }
 
 /**
+ * Open the Settings panel via the IdentityCard menu's "Settings" item.
+ * Caller must already be in an authenticated or browsing session — the
+ * IdentityCard menu trigger is only present in those states.
+ */
+export async function openSettingsTab(page: Page) {
+  await openIdentityMenu(page);
+  await page.getByRole("menuitem", { name: /^settings$/i }).click();
+  await expect(
+    page.getByRole("heading", { name: /^Settings$/, level: 1 }),
+  ).toBeVisible();
+}
+
+/**
  * Recognizable title prefix for every transient note an e2e test creates.
  * The cleanup helper uses this to scope its deletes so it never touches a
  * manually-created note on the same identity.

--- a/example-apps/dashnote/test/e2e/fixtures.ts
+++ b/example-apps/dashnote/test/e2e/fixtures.ts
@@ -2,9 +2,11 @@
  * Shared Playwright fixtures for dashnote E2E tests.
  *
  * Runs against real Dash Platform testnet — no SDK mocks. The base `page`
- * fixture navigates to `/` and waits until the IdentityCard reports a live
- * SDK connection (`Connected`, `Authenticated`, or `Browsing (read-only)`)
- * so spec bodies always have a usable SDK.
+ * fixture navigates to `/` and waits for the IdentityCard's connected dot
+ * (`.conn-dot.connected`) to appear so spec bodies always have a usable
+ * SDK. We anchor on the dot rather than the text label because the
+ * readonly card paints "Connected" twice (eyebrow + status line) which
+ * would trip Playwright's strict-mode matchers.
  *
  * The sidebar is rendered as `<aside aria-label="Main navigation">`, not a
  * `<nav>` landmark — scope nav-button lookups through `navButton(page, …)`
@@ -58,7 +60,9 @@ function isMobile(page: Page): boolean {
 export async function navButton(page: Page, label: RegExp | string) {
   if (isMobile(page)) {
     // Hamburger button carries aria-expanded="true|false" reflecting drawerOpen.
-    const hamburger = page.locator('button[aria-expanded][aria-label*="menu" i]');
+    const hamburger = page.locator(
+      'button[aria-expanded][aria-label*="menu" i]',
+    );
     if ((await hamburger.getAttribute("aria-expanded")) !== "true") {
       await hamburger.click();
       await expect(hamburger).toHaveAttribute("aria-expanded", "true");
@@ -67,6 +71,34 @@ export async function navButton(page: Page, label: RegExp | string) {
   return page
     .locator('aside[aria-label="Main navigation"]')
     .getByRole("button", { name: label });
+}
+
+/**
+ * Open the IdentityCard menu (the popover with Settings / Switch identity
+ * / Log out items). Only available when the session is `authenticated` or
+ * `browsing` — caller is responsible for being in that state.
+ *
+ * On mobile the sidebar is off-canvas; opens the drawer transparently
+ * via the hamburger first.
+ */
+export async function openIdentityMenu(page: Page) {
+  if (isMobile(page)) {
+    const hamburger = page.locator(
+      'button[aria-expanded][aria-label*="menu" i]',
+    );
+    if ((await hamburger.getAttribute("aria-expanded")) !== "true") {
+      await hamburger.click();
+      await expect(hamburger).toHaveAttribute("aria-expanded", "true");
+    }
+  }
+  // The IdentityCard menu trigger is the button with aria-haspopup="menu".
+  // (The hamburger uses aria-haspopup absent; readonly card is a plain
+  // button; only the authenticated/browsing IdentityCard exposes the menu.)
+  const trigger = page
+    .locator('aside[aria-label="Main navigation"]')
+    .locator('button[aria-haspopup="menu"]');
+  await trigger.click();
+  await expect(page.getByRole("menu")).toBeVisible();
 }
 
 /**

--- a/example-apps/dashnote/test/e2e/fixtures.ts
+++ b/example-apps/dashnote/test/e2e/fixtures.ts
@@ -139,3 +139,186 @@ export async function loginViaModal(
     timeout: 60_000,
   });
 }
+
+/**
+ * Recognizable title prefix for every transient note an e2e test creates.
+ * The cleanup helper uses this to scope its deletes so it never touches a
+ * manually-created note on the same identity.
+ *
+ * `[e2e-fixture]` titles (a *different* prefix) are reused across runs as
+ * deterministic search/list fixtures and are intentionally NOT cleaned up.
+ */
+export const E2E_TITLE_PREFIX = "[e2e]";
+export const E2E_FIXTURE_PREFIX = "[e2e-fixture]";
+export const SEARCH_FIXTURE_ALPHA = `${E2E_FIXTURE_PREFIX} alpha`;
+export const SEARCH_FIXTURE_BETA = `${E2E_FIXTURE_PREFIX} beta`;
+
+/**
+ * Generate a unique e2e-prefixed title.
+ */
+export function e2eTitle(suffix = ""): string {
+  const stamp = Date.now().toString(36);
+  const rand = Math.random().toString(36).slice(2, 7);
+  return `${E2E_TITLE_PREFIX} ${stamp}-${rand}${suffix ? ` ${suffix}` : ""}`;
+}
+
+/**
+ * Ensure the notes list pane is visible. On desktop the list and editor
+ * are always side-by-side, so this is a no-op. On mobile the list is
+ * hidden behind `display: none` whenever a note is selected — tapping
+ * "Back to notes" returns to the list view.
+ */
+export async function returnToList(page: Page) {
+  if (!isMobile(page)) return;
+  const back = page.getByRole("button", { name: /back to notes/i });
+  if (await back.isVisible().catch(() => false)) {
+    await back.click();
+  }
+  // List view shows the Search input; wait for it to render.
+  await expect(page.getByPlaceholder("Search")).toBeVisible({
+    timeout: 30_000,
+  });
+}
+
+/**
+ * Click the "New note" entry point (mobile FAB vs desktop inline button)
+ * and wait for the editor to be ready for input.
+ */
+export async function startNewNote(page: Page) {
+  if (isMobile(page)) {
+    // The mobile FAB lives inside the NoteList pane, which is hidden
+    // whenever a note is selected. Hop back to the list first.
+    await returnToList(page);
+    await page.getByRole("button", { name: /compose note/i }).click();
+  } else {
+    await page.getByRole("button", { name: /^new note$/i }).click();
+  }
+  // Editor pane reveals the Title/Body inputs once selectedId === "new".
+  await expect(page.getByLabel("Title")).toBeVisible();
+}
+
+/**
+ * Create a note via the editor: opens the New-note draft, fills title +
+ * body, clicks the create/save button, waits until the list contains an
+ * item with the given title.
+ */
+export async function createNoteViaEditor(
+  page: Page,
+  { title, message }: { title: string; message: string },
+) {
+  await startNewNote(page);
+  await page.getByLabel("Title").fill(title);
+  await page.getByLabel("Body").fill(message);
+  // The save button reads "Create note" for new drafts.
+  await page.getByRole("button", { name: /^create note$/i }).click();
+  // Post-save, the editor advances baselines, so the Save button flips
+  // from enabled ("Create note") to disabled (label becomes "Save" and
+  // dirty=false). That's a viewport-agnostic signal — much more reliable
+  // than asserting list-item visibility, which on mobile is hidden
+  // because the list pane gets `display: none` when a note is selected.
+  await expect(page.getByRole("button", { name: /^save$/i })).toBeDisabled({
+    timeout: 60_000,
+  });
+}
+
+/**
+ * Delete a note by title via the UI. Selects the note in the list, hits
+ * Delete, and accepts the confirm() prompt automatically. The list
+ * background revalidation reflects the deletion within ~60s.
+ */
+export async function deleteNoteByTitle(page: Page, title: string) {
+  // On mobile the list is hidden when a note is selected; surface it
+  // first so the target button is clickable.
+  await returnToList(page);
+  const item = page.locator("button", { hasText: title }).first();
+  if (!(await item.isVisible().catch(() => false))) return;
+  await item.click();
+  // Title input should populate once the detail loads.
+  await expect(page.getByLabel("Title")).toHaveValue(title, {
+    timeout: 30_000,
+  });
+
+  // window.confirm("Delete this note permanently?") — auto-accept.
+  const dialogHandler = (dialog: import("@playwright/test").Dialog) => {
+    void dialog.accept();
+  };
+  page.once("dialog", dialogHandler);
+
+  // Desktop renders the "Delete" button in the editor header; mobile
+  // renders "Delete note" near the bottom. Match either label.
+  await page
+    .getByRole("button", { name: /^delete( note)?$/i })
+    .first()
+    .click();
+
+  // Item leaves the list after reloadNotes resolves.
+  await expect(page.locator("button", { hasText: title })).toHaveCount(0, {
+    timeout: 60_000,
+  });
+}
+
+/**
+ * Best-effort cleanup: delete every note whose title begins with the
+ * transient e2e prefix. The `[e2e-fixture]` deterministic-seed notes
+ * are deliberately preserved across runs.
+ *
+ * Implementation note: list buttons render the title and the message
+ * preview as adjacent divs, which `textContent` concatenates without
+ * whitespace. Rather than parse that back out, we open each candidate
+ * and read the canonical title from the editor's Title input.
+ */
+export async function cleanupE2eNotes(page: Page) {
+  let safety = 20;
+  while (safety > 0) {
+    safety -= 1;
+    // On mobile, if the previous action left the editor open the list pane
+    // is `display: none` and candidate lookups would silently return 0.
+    // Force the list to be visible before counting.
+    await returnToList(page);
+    const candidates = page.locator("button", { hasText: E2E_TITLE_PREFIX });
+    const total = await candidates.count();
+    if (total === 0) return;
+
+    // Iterate the visible list and pick the first non-fixture entry. Open
+    // each candidate just long enough to read its canonical title from the
+    // editor's Title input; the list buttons render title + preview as
+    // concatenated text, which is unreliable to parse.
+    let targetTitle: string | null = null;
+    for (let i = 0; i < total; i += 1) {
+      await candidates.nth(i).click();
+      let canonical = "";
+      try {
+        canonical = await page
+          .getByLabel("Title")
+          .inputValue({ timeout: 5_000 });
+      } catch {
+        continue;
+      }
+      if (
+        canonical.startsWith(E2E_TITLE_PREFIX) &&
+        !canonical.startsWith(E2E_FIXTURE_PREFIX)
+      ) {
+        targetTitle = canonical;
+        break;
+      }
+    }
+    if (!targetTitle) return;
+    await deleteNoteByTitle(page, targetTitle);
+  }
+}
+
+/**
+ * Ensure the two deterministic search fixtures exist for the current
+ * identity + contract. Created once and re-used across runs to avoid
+ * writing 2 throw-away notes per search test.
+ */
+export async function seedSearchFixtures(page: Page) {
+  for (const title of [SEARCH_FIXTURE_ALPHA, SEARCH_FIXTURE_BETA]) {
+    const existing = page.locator("button", { hasText: title });
+    if ((await existing.count()) > 0) continue;
+    await createNoteViaEditor(page, {
+      title,
+      message: `Deterministic e2e search fixture for "${title}".`,
+    });
+  }
+}

--- a/example-apps/dashnote/test/e2e/fixtures.ts
+++ b/example-apps/dashnote/test/e2e/fixtures.ts
@@ -313,6 +313,15 @@ export async function cleanupE2eNotes(page: Page) {
  * writing 2 throw-away notes per search test.
  */
 export async function seedSearchFixtures(page: Page) {
+  // The NoteList renders a `role="status" aria-label="Loading notes"`
+  // spinner while the initial query is in flight. Waiting for it to be
+  // hidden means either the load resolved or the list already had
+  // cached entries — either way, the DOM now reflects truth and an
+  // `existing.count() === 0` check won't false-negative against a
+  // fixture that exists on-network but hasn't rendered yet.
+  await expect(
+    page.getByRole("status", { name: /loading notes/i }),
+  ).toBeHidden({ timeout: 60_000 });
   for (const title of [SEARCH_FIXTURE_ALPHA, SEARCH_FIXTURE_BETA]) {
     const existing = page.locator("button", { hasText: title });
     if ((await existing.count()) > 0) continue;

--- a/example-apps/dashnote/test/e2e/notes.spec.ts
+++ b/example-apps/dashnote/test/e2e/notes.spec.ts
@@ -1,0 +1,261 @@
+import {
+  test,
+  expect,
+  HAS_MNEMONIC,
+  loginViaModal,
+  createNoteViaEditor,
+  deleteNoteByTitle,
+  cleanupE2eNotes,
+  returnToList,
+  seedSearchFixtures,
+  e2eTitle,
+  SEARCH_FIXTURE_ALPHA,
+  SEARCH_FIXTURE_BETA,
+} from "./fixtures";
+
+test.skip(!HAS_MNEMONIC, "PLATFORM_MNEMONIC not set — skipping notes specs");
+test.describe.configure({ mode: "serial" });
+
+// Login once per worker. Each test cleans up its own [e2e]-prefixed notes
+// in afterEach so a failure doesn't cascade into the next test.
+test.beforeEach(async ({ page }) => {
+  await page.evaluate(() => {
+    try {
+      window.localStorage.removeItem("dashnote.lastIdentity");
+    } catch {
+      /* localStorage may be unavailable in some contexts */
+    }
+  });
+  await page.reload();
+  await expect(page.locator(".conn-dot.connected").first()).toBeVisible({
+    timeout: 60_000,
+  });
+  await loginViaModal(page);
+});
+
+test.afterEach(async ({ page }) => {
+  // Defensive cleanup — only touches notes with the e2e title prefix so a
+  // hand-created note on the same identity stays put.
+  await cleanupE2eNotes(page).catch(() => {
+    /* best effort */
+  });
+});
+
+test("create, edit, and delete a note round-trip", async ({ page }) => {
+  const originalTitle = e2eTitle("create");
+  await createNoteViaEditor(page, {
+    title: originalTitle,
+    message: "Body text written by the e2e suite.",
+  });
+
+  // Reopen and edit. createNoteViaEditor leaves the editor open on the
+  // new note — on mobile that means the list is hidden, so hop back to
+  // it before clicking the item. (No-op on desktop.)
+  await returnToList(page);
+  const newTitle = e2eTitle("edit");
+  await page.locator("button", { hasText: originalTitle }).first().click();
+  await expect(page.getByLabel("Title")).toHaveValue(originalTitle);
+  await page.getByLabel("Title").fill(newTitle);
+  await page.getByRole("button", { name: /^save$/i }).click();
+  // Save completes when the button disables again (dirty=false).
+  await expect(page.getByRole("button", { name: /^save$/i })).toBeDisabled();
+
+  // After save, hop back to the list to verify the title change is
+  // reflected there (and the old title is gone).
+  await returnToList(page);
+  await expect(
+    page.locator("button", { hasText: newTitle }).first(),
+  ).toBeVisible();
+  await expect(page.locator("button", { hasText: originalTitle })).toHaveCount(
+    0,
+  );
+
+  await deleteNoteByTitle(page, newTitle);
+});
+
+test("search filter narrows the list to matching notes", async ({ page }) => {
+  // Reuse the two persistent search fixtures instead of writing fresh
+  // notes every run. They survive cleanup because their prefix is
+  // `[e2e-fixture]`, not `[e2e]`.
+  await seedSearchFixtures(page);
+  // Seeding may leave the editor open (mobile hides the list when a note
+  // is selected); return to the list view so the Search input is shown.
+  await returnToList(page);
+
+  const search = page.getByPlaceholder("Search");
+  await search.fill("alpha");
+  await expect(
+    page.locator("button", { hasText: SEARCH_FIXTURE_ALPHA }).first(),
+  ).toBeVisible();
+  await expect(
+    page.locator("button", { hasText: SEARCH_FIXTURE_BETA }),
+  ).toHaveCount(0);
+
+  // Clearing the search restores both.
+  await search.fill("");
+  await expect(
+    page.locator("button", { hasText: SEARCH_FIXTURE_BETA }).first(),
+  ).toBeVisible();
+});
+
+test("discard-changes confirmation cancels the navigation when dismissed", async ({
+  page,
+}) => {
+  const title = e2eTitle("discard");
+  await createNoteViaEditor(page, {
+    title,
+    message: "original body",
+  });
+
+  // Open the note, dirty it, then try to start a NEW draft. The discard
+  // confirm() should fire — dismiss it and verify we stayed on the note.
+  // createNoteViaEditor leaves the editor open; on mobile we'd need to
+  // go back to the list to reach the item, but the editor is already
+  // showing this note so just verify the title input is populated.
+  await returnToList(page);
+  await page.locator("button", { hasText: title }).first().click();
+  await expect(page.getByLabel("Title")).toHaveValue(title);
+  await page.getByLabel("Body").fill("dirty edit waiting to be discarded");
+
+  page.once("dialog", (dialog) => {
+    expect(dialog.message()).toMatch(/discard unsaved changes/i);
+    void dialog.dismiss();
+  });
+
+  // Trigger a navigation that runs confirmDiscard(). On desktop the
+  // "New note" button is always visible and calls handleNew(). On mobile
+  // the FAB lives inside the (hidden) list pane, so use "Back to notes"
+  // instead — handleBack() calls the same confirmDiscard() guard.
+  const viewport = page.viewportSize();
+  const isMobile = viewport != null && viewport.width < 768;
+  if (isMobile) {
+    await page.getByRole("button", { name: /back to notes/i }).click();
+  } else {
+    await page.getByRole("button", { name: /^new note$/i }).click();
+  }
+
+  // The note we were editing is still selected, body is still dirty.
+  await expect(page.getByLabel("Title")).toHaveValue(title);
+  await expect(page.getByLabel("Body")).toHaveValue(
+    "dirty edit waiting to be discarded",
+  );
+
+  // Reset the dirty state so afterEach's cleanupE2eNotes can navigate
+  // around without tripping another discard prompt. Restoring the body
+  // to the original value makes `dirty === false` again.
+  await page.getByLabel("Body").fill("original body");
+});
+
+test("mobile: tapping a note transitions list → editor; Back returns", async ({
+  page,
+}, testInfo) => {
+  test.skip(
+    testInfo.project.name !== "chromium-mobile",
+    "mobile-only viewport behavior",
+  );
+
+  const title = e2eTitle("mobile");
+  await createNoteViaEditor(page, {
+    title,
+    message: "mobile list/editor transition",
+  });
+
+  // Returning to the list view: after createNoteViaEditor, the editor is
+  // showing the new note. Hit Back.
+  await page.getByRole("button", { name: /back to notes/i }).click();
+  // List visible again, editor hidden.
+  await expect(page.getByPlaceholder("Search")).toBeVisible();
+  await expect(page.getByLabel("Title")).toBeHidden();
+
+  // Tap the note → editor reappears.
+  await page.locator("button", { hasText: title }).first().click();
+  await expect(page.getByLabel("Title")).toHaveValue(title);
+  // Search bar is hidden once a note is selected on mobile.
+  await expect(page.getByPlaceholder("Search")).toBeHidden();
+});
+
+test("two contexts can sequentially save the same note without conflict", async ({
+  browser,
+}) => {
+  // This test does ~6 testnet round-trips (login×2, create, update×2,
+  // delete) across two browser contexts. The default 15s test budget
+  // isn't enough.
+  test.setTimeout(60_000);
+
+  // Spin up two contexts that share the same identity. Login with
+  // rememberMe so reloads keep the identity hint and re-enter "browsing"
+  // mode — without that, reload would drop both pages to readonly and
+  // hide the note list behind a sign-in prompt.
+  const ctx1 = await browser.newContext();
+  const ctx2 = await browser.newContext();
+  const page1 = await ctx1.newPage();
+  const page2 = await ctx2.newPage();
+
+  try {
+    for (const p of [page1, page2]) {
+      await p.goto("/");
+      await expect(p.locator(".conn-dot.connected").first()).toBeVisible({
+        timeout: 60_000,
+      });
+      await loginViaModal(p, { rememberMe: true });
+    }
+
+    const title = e2eTitle("twoctx");
+    await createNoteViaEditor(page1, {
+      title,
+      message: "round 1 (from page1)",
+    });
+
+    // Page2 needs to see the note created by page1. Reload to bypass
+    // the 30s background refresh and re-login (rememberMe means the
+    // login form pre-fills with the remembered identity hint).
+    await page2.reload();
+    await expect(page2.locator(".conn-dot.connected").first()).toBeVisible({
+      timeout: 60_000,
+    });
+    await loginViaModal(page2, { rememberMe: true });
+    await expect(
+      page2.locator("button", { hasText: title }).first(),
+    ).toBeVisible({ timeout: 60_000 });
+
+    // Page2 edits + saves. updateNote.ts fetches the current revision
+    // first and bumps by 1, so this should succeed even if page1 saves
+    // again after.
+    await page2.locator("button", { hasText: title }).first().click();
+    await expect(page2.getByLabel("Title")).toHaveValue(title, {
+      timeout: 30_000,
+    });
+    await page2.getByLabel("Body").fill("round 2 (from page2)");
+    await page2.getByRole("button", { name: /^save$/i }).click();
+    await expect(page2.getByRole("button", { name: /^save$/i })).toBeDisabled({
+      timeout: 60_000,
+    });
+
+    // Page1 reloads + re-logs to see page2's edit, then makes its own change.
+    await page1.reload();
+    await expect(page1.locator(".conn-dot.connected").first()).toBeVisible({
+      timeout: 60_000,
+    });
+    await loginViaModal(page1, { rememberMe: true });
+    await page1.locator("button", { hasText: title }).first().click();
+    await expect(page1.getByLabel("Body")).toHaveValue("round 2 (from page2)", {
+      timeout: 30_000,
+    });
+    await page1.getByLabel("Body").fill("round 3 (from page1)");
+    await page1.getByRole("button", { name: /^save$/i }).click();
+    await expect(page1.getByRole("button", { name: /^save$/i })).toBeDisabled({
+      timeout: 60_000,
+    });
+
+    // Cleanup from page1. afterEach runs against the base test `page`,
+    // which is a different context that isn't logged in, so cleanup has
+    // to happen here while we still have an authenticated context.
+    await deleteNoteByTitle(page1, title);
+    await cleanupE2eNotes(page1).catch(() => {
+      /* best effort */
+    });
+  } finally {
+    await ctx1.close();
+    await ctx2.close();
+  }
+});

--- a/example-apps/dashnote/test/e2e/settings.spec.ts
+++ b/example-apps/dashnote/test/e2e/settings.spec.ts
@@ -31,139 +31,144 @@ test.describe("settings (readonly)", () => {
     // In readonly mode the IdentityCard menu trigger is absent, so reach
     // the Settings tab via the sidebar nav button instead.
     await (await navButton(page, /settings$/i)).click();
-    await expect(
-      page.getByText(/sign in to view and manage/i),
-    ).toBeVisible();
+    await expect(page.getByText(/sign in to view and manage/i)).toBeVisible();
   });
 });
 
-test.skip(!HAS_MNEMONIC, "PLATFORM_MNEMONIC not set — skipping settings specs");
-test.describe.configure({ mode: "serial" });
-
-test.beforeEach(async ({ page }) => {
-  await page.evaluate(() => {
-    try {
-      window.localStorage.removeItem("dashnote.lastIdentity");
-      window.localStorage.removeItem("dashnote.contractId");
-    } catch {
-      /* localStorage may be unavailable in some contexts */
-    }
-  });
-  await page.reload();
-  await expect(page.locator(".conn-dot.connected").first()).toBeVisible({
-    timeout: 60_000,
-  });
-  await loginViaModal(page);
-});
-
-test("Copy identity ID writes the displayed value to the clipboard", async ({
-  page,
-}) => {
-  await openSettingsTab(page);
-
-  // Wait for the identity block to populate (placeholder is "—"). The
-  // value sits in a font-mono div alongside a Copy button; reading the
-  // block's full textContent would include the button label, so target
-  // the mono div directly.
-  const idBlock = page.locator('[data-testid="settings-identity-block"]');
-  const idValue = idBlock.locator("div.font-mono").first();
-  await expect(idValue).toHaveText(/[0-9A-Za-z]{40,}/);
-  const identityId = ((await idValue.textContent()) ?? "").trim();
-
-  await page.getByRole("button", { name: /copy identity id/i }).click();
-  // Label flips to "Copied!" briefly.
-  await expect(
-    page.getByRole("button", { name: /copy identity id/i }),
-  ).toContainText(/copied/i);
-
-  const clipped = await page.evaluate(() => navigator.clipboard.readText());
-  expect(clipped).toBe(identityId);
-});
-
-test("Copy contract ID writes the current contract ID to the clipboard", async ({
-  page,
-}) => {
-  await openSettingsTab(page);
-
-  // The contract input is pre-populated with the current contractId.
-  const contractInput = page.getByPlaceholder(/note contract id/i);
-  await expect(contractInput).not.toHaveValue("");
-  const contractId = await contractInput.inputValue();
-
-  await page.getByRole("button", { name: /copy contract id/i }).click();
-  await expect(
-    page.getByRole("button", { name: /copy contract id/i }),
-  ).toContainText(/copied/i);
-
-  const clipped = await page.evaluate(() => navigator.clipboard.readText());
-  expect(clipped).toBe(contractId);
-});
-
-test("Clear local cache flips the button label and removes the cached entry", async ({
-  page,
-}) => {
-  await openSettingsTab(page);
-
-  // Discover the localStorage cache key. The notes cache is keyed by
-  // `dashnote.notes.<identity>.<contract>.testnet` (see lib/notesCache).
-  // Seed it directly so we can assert the clear works without depending
-  // on whether the notes list has been opened in this session.
-  const idBlock = page.locator('[data-testid="settings-identity-block"]');
-  const idValue = idBlock.locator("div.font-mono").first();
-  await expect(idValue).toHaveText(/[0-9A-Za-z]{40,}/);
-  const identityId = ((await idValue.textContent()) ?? "").trim();
-  const contractId = await page
-    .getByPlaceholder(/note contract id/i)
-    .inputValue();
-  const cacheKeyPrefix = `dashnote.notes.${identityId}.${contractId}`;
-
-  // Plant a fake cache entry so we have something concrete to assert
-  // was removed. clearCachedNotes(identityId) is identity-scoped so any
-  // contract-suffixed key under that identity should be wiped.
-  await page.evaluate((key) => {
-    window.localStorage.setItem(`${key}.testnet`, '{"notes":[]}');
-  }, cacheKeyPrefix);
-
-  await page
-    .getByRole("button", { name: /clear local cache for this device/i })
-    .click();
-  // Label transitions to "Cache cleared" for ~2s.
-  await expect(
-    page.getByRole("button", { name: /cache cleared/i }),
-  ).toBeVisible();
-
-  const remaining = await page.evaluate(
-    (key) => window.localStorage.getItem(`${key}.testnet`),
-    cacheKeyPrefix,
+test.describe("settings (authenticated)", () => {
+  test.skip(
+    !HAS_MNEMONIC,
+    "PLATFORM_MNEMONIC not set — skipping settings specs",
   );
-  expect(remaining).toBeNull();
-});
+  test.describe.configure({ mode: "serial" });
 
-test("Use this ID is disabled until the contract input changes", async ({
-  page,
-}) => {
-  await openSettingsTab(page);
+  test.beforeEach(async ({ page }) => {
+    await page.evaluate(() => {
+      try {
+        window.localStorage.removeItem("dashnote.lastIdentity");
+        window.localStorage.removeItem("dashnote.contractId");
+      } catch {
+        /* localStorage may be unavailable in some contexts */
+      }
+    });
+    await page.reload();
+    await expect(page.locator(".conn-dot.connected").first()).toBeVisible({
+      timeout: 60_000,
+    });
+    await loginViaModal(page);
+  });
 
-  const apply = page.getByRole("button", { name: /^use this id$/i });
-  await expect(apply).toBeDisabled();
+  test("Copy identity ID writes the displayed value to the clipboard", async ({
+    page,
+  }) => {
+    await openSettingsTab(page);
 
-  // Type a different valid-looking ID — button enables.
-  const input = page.getByPlaceholder(/note contract id/i);
-  const original = await input.inputValue();
-  await input.fill("ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz123");
-  await expect(apply).toBeEnabled();
+    // Wait for the identity block to populate (placeholder is "—"). The
+    // value sits in a font-mono div alongside a Copy button; reading the
+    // block's full textContent would include the button label, so target
+    // the mono div directly.
+    const idBlock = page.locator('[data-testid="settings-identity-block"]');
+    const idValue = idBlock.locator("div.font-mono").first();
+    await expect(idValue).toHaveText(/[0-9A-Za-z]{40,}/);
+    const identityId = ((await idValue.textContent()) ?? "").trim();
 
-  // Restore the original value — button disables again because the
-  // trimmed input matches the session contract ID exactly.
-  await input.fill(original);
-  await expect(apply).toBeDisabled();
-});
+    await page.getByRole("button", { name: /copy identity id/i }).click();
+    // Label flips to "Copied!" briefly.
+    await expect(
+      page.getByRole("button", { name: /copy identity id/i }),
+    ).toContainText(/copied/i);
 
-test("Identity section shows the DPNS name once resolved", async ({ page }) => {
-  await openSettingsTab(page);
+    const clipped = await page.evaluate(() => navigator.clipboard.readText());
+    expect(clipped).toBe(identityId);
+  });
 
-  // DPNS resolution can take a few seconds after the SDK connects.
-  await expect(page.getByText(/✓\s+\S+\.dash/)).toBeVisible({
-    timeout: 30_000,
+  test("Copy contract ID writes the current contract ID to the clipboard", async ({
+    page,
+  }) => {
+    await openSettingsTab(page);
+
+    // The contract input is pre-populated with the current contractId.
+    const contractInput = page.getByPlaceholder(/note contract id/i);
+    await expect(contractInput).not.toHaveValue("");
+    const contractId = await contractInput.inputValue();
+
+    await page.getByRole("button", { name: /copy contract id/i }).click();
+    await expect(
+      page.getByRole("button", { name: /copy contract id/i }),
+    ).toContainText(/copied/i);
+
+    const clipped = await page.evaluate(() => navigator.clipboard.readText());
+    expect(clipped).toBe(contractId);
+  });
+
+  test("Clear local cache flips the button label and removes the cached entry", async ({
+    page,
+  }) => {
+    await openSettingsTab(page);
+
+    // Discover the localStorage cache key. The notes cache is keyed by
+    // `dashnote.notes.<identity>.<contract>.testnet` (see lib/notesCache).
+    // Seed it directly so we can assert the clear works without depending
+    // on whether the notes list has been opened in this session.
+    const idBlock = page.locator('[data-testid="settings-identity-block"]');
+    const idValue = idBlock.locator("div.font-mono").first();
+    await expect(idValue).toHaveText(/[0-9A-Za-z]{40,}/);
+    const identityId = ((await idValue.textContent()) ?? "").trim();
+    const contractId = await page
+      .getByPlaceholder(/note contract id/i)
+      .inputValue();
+    const cacheKeyPrefix = `dashnote.notes.${identityId}.${contractId}`;
+
+    // Plant a fake cache entry so we have something concrete to assert
+    // was removed. clearCachedNotes(identityId) is identity-scoped so any
+    // contract-suffixed key under that identity should be wiped.
+    await page.evaluate((key) => {
+      window.localStorage.setItem(`${key}.testnet`, '{"notes":[]}');
+    }, cacheKeyPrefix);
+
+    await page
+      .getByRole("button", { name: /clear local cache for this device/i })
+      .click();
+    // Label transitions to "Cache cleared" for ~2s.
+    await expect(
+      page.getByRole("button", { name: /cache cleared/i }),
+    ).toBeVisible();
+
+    const remaining = await page.evaluate(
+      (key) => window.localStorage.getItem(`${key}.testnet`),
+      cacheKeyPrefix,
+    );
+    expect(remaining).toBeNull();
+  });
+
+  test("Use this ID is disabled until the contract input changes", async ({
+    page,
+  }) => {
+    await openSettingsTab(page);
+
+    const apply = page.getByRole("button", { name: /^use this id$/i });
+    await expect(apply).toBeDisabled();
+
+    // Type a different valid-looking ID — button enables.
+    const input = page.getByPlaceholder(/note contract id/i);
+    const original = await input.inputValue();
+    await input.fill("ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz123");
+    await expect(apply).toBeEnabled();
+
+    // Restore the original value — button disables again because the
+    // trimmed input matches the session contract ID exactly.
+    await input.fill(original);
+    await expect(apply).toBeDisabled();
+  });
+
+  test("Identity section shows the DPNS name once resolved", async ({
+    page,
+  }) => {
+    await openSettingsTab(page);
+
+    // DPNS resolution can take a few seconds after the SDK connects.
+    await expect(page.getByText(/✓\s+\S+\.dash/)).toBeVisible({
+      timeout: 30_000,
+    });
   });
 });

--- a/example-apps/dashnote/test/e2e/settings.spec.ts
+++ b/example-apps/dashnote/test/e2e/settings.spec.ts
@@ -1,0 +1,169 @@
+import {
+  test,
+  expect,
+  HAS_MNEMONIC,
+  loginViaModal,
+  navButton,
+  openSettingsTab,
+} from "./fixtures";
+
+// Readonly-mode test: no mnemonic needed. Runs in its own block so it
+// executes regardless of PLATFORM_MNEMONIC.
+test.describe("settings (readonly)", () => {
+  test("prompts the visitor to sign in before exposing settings", async ({
+    page,
+  }) => {
+    // A previous run may have remembered an identity, which would boot
+    // the app into "browsing" mode and hide the sign-in prompt. Clear
+    // it and reload so the session lands in readonly.
+    await page.evaluate(() => {
+      try {
+        window.localStorage.removeItem("dashnote.lastIdentity");
+      } catch {
+        /* localStorage may be unavailable in some contexts */
+      }
+    });
+    await page.reload();
+    await expect(page.locator(".conn-dot.connected").first()).toBeVisible({
+      timeout: 60_000,
+    });
+
+    // In readonly mode the IdentityCard menu trigger is absent, so reach
+    // the Settings tab via the sidebar nav button instead.
+    await (await navButton(page, /settings$/i)).click();
+    await expect(
+      page.getByText(/sign in to view and manage/i),
+    ).toBeVisible();
+  });
+});
+
+test.skip(!HAS_MNEMONIC, "PLATFORM_MNEMONIC not set — skipping settings specs");
+test.describe.configure({ mode: "serial" });
+
+test.beforeEach(async ({ page }) => {
+  await page.evaluate(() => {
+    try {
+      window.localStorage.removeItem("dashnote.lastIdentity");
+      window.localStorage.removeItem("dashnote.contractId");
+    } catch {
+      /* localStorage may be unavailable in some contexts */
+    }
+  });
+  await page.reload();
+  await expect(page.locator(".conn-dot.connected").first()).toBeVisible({
+    timeout: 60_000,
+  });
+  await loginViaModal(page);
+});
+
+test("Copy identity ID writes the displayed value to the clipboard", async ({
+  page,
+}) => {
+  await openSettingsTab(page);
+
+  // Wait for the identity block to populate (placeholder is "—"). The
+  // value sits in a font-mono div alongside a Copy button; reading the
+  // block's full textContent would include the button label, so target
+  // the mono div directly.
+  const idBlock = page.locator('[data-testid="settings-identity-block"]');
+  const idValue = idBlock.locator("div.font-mono").first();
+  await expect(idValue).toHaveText(/[0-9A-Za-z]{40,}/);
+  const identityId = ((await idValue.textContent()) ?? "").trim();
+
+  await page.getByRole("button", { name: /copy identity id/i }).click();
+  // Label flips to "Copied!" briefly.
+  await expect(
+    page.getByRole("button", { name: /copy identity id/i }),
+  ).toContainText(/copied/i);
+
+  const clipped = await page.evaluate(() => navigator.clipboard.readText());
+  expect(clipped).toBe(identityId);
+});
+
+test("Copy contract ID writes the current contract ID to the clipboard", async ({
+  page,
+}) => {
+  await openSettingsTab(page);
+
+  // The contract input is pre-populated with the current contractId.
+  const contractInput = page.getByPlaceholder(/note contract id/i);
+  await expect(contractInput).not.toHaveValue("");
+  const contractId = await contractInput.inputValue();
+
+  await page.getByRole("button", { name: /copy contract id/i }).click();
+  await expect(
+    page.getByRole("button", { name: /copy contract id/i }),
+  ).toContainText(/copied/i);
+
+  const clipped = await page.evaluate(() => navigator.clipboard.readText());
+  expect(clipped).toBe(contractId);
+});
+
+test("Clear local cache flips the button label and removes the cached entry", async ({
+  page,
+}) => {
+  await openSettingsTab(page);
+
+  // Discover the localStorage cache key. The notes cache is keyed by
+  // `dashnote.notes.<identity>.<contract>.testnet` (see lib/notesCache).
+  // Seed it directly so we can assert the clear works without depending
+  // on whether the notes list has been opened in this session.
+  const idBlock = page.locator('[data-testid="settings-identity-block"]');
+  const idValue = idBlock.locator("div.font-mono").first();
+  await expect(idValue).toHaveText(/[0-9A-Za-z]{40,}/);
+  const identityId = ((await idValue.textContent()) ?? "").trim();
+  const contractId = await page
+    .getByPlaceholder(/note contract id/i)
+    .inputValue();
+  const cacheKeyPrefix = `dashnote.notes.${identityId}.${contractId}`;
+
+  // Plant a fake cache entry so we have something concrete to assert
+  // was removed. clearCachedNotes(identityId) is identity-scoped so any
+  // contract-suffixed key under that identity should be wiped.
+  await page.evaluate((key) => {
+    window.localStorage.setItem(`${key}.testnet`, '{"notes":[]}');
+  }, cacheKeyPrefix);
+
+  await page
+    .getByRole("button", { name: /clear local cache for this device/i })
+    .click();
+  // Label transitions to "Cache cleared" for ~2s.
+  await expect(
+    page.getByRole("button", { name: /cache cleared/i }),
+  ).toBeVisible();
+
+  const remaining = await page.evaluate(
+    (key) => window.localStorage.getItem(`${key}.testnet`),
+    cacheKeyPrefix,
+  );
+  expect(remaining).toBeNull();
+});
+
+test("Use this ID is disabled until the contract input changes", async ({
+  page,
+}) => {
+  await openSettingsTab(page);
+
+  const apply = page.getByRole("button", { name: /^use this id$/i });
+  await expect(apply).toBeDisabled();
+
+  // Type a different valid-looking ID — button enables.
+  const input = page.getByPlaceholder(/note contract id/i);
+  const original = await input.inputValue();
+  await input.fill("ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz123");
+  await expect(apply).toBeEnabled();
+
+  // Restore the original value — button disables again because the
+  // trimmed input matches the session contract ID exactly.
+  await input.fill(original);
+  await expect(apply).toBeDisabled();
+});
+
+test("Identity section shows the DPNS name once resolved", async ({ page }) => {
+  await openSettingsTab(page);
+
+  // DPNS resolution can take a few seconds after the SDK connects.
+  await expect(page.getByText(/✓\s+\S+\.dash/)).toBeVisible({
+    timeout: 30_000,
+  });
+});

--- a/example-apps/dashnote/test/e2e/smoke.spec.ts
+++ b/example-apps/dashnote/test/e2e/smoke.spec.ts
@@ -1,0 +1,153 @@
+import { test, expect, navButton } from "./fixtures";
+
+// All read-only flows. No mnemonic required; no testnet writes.
+// Runs under both chromium-desktop and chromium-mobile projects.
+
+test.describe("boot", () => {
+  test("SDK connects and the IdentityCard reports a live connection", async ({
+    page,
+  }) => {
+    // The base fixture already waits for the connected dot. This test
+    // re-asserts the same locator so failures here flag a regression in
+    // the connection gate itself, not a downstream selector.
+    await expect(page.locator(".conn-dot.connected").first()).toBeVisible();
+  });
+
+  test("page title is Dashnote", async ({ page }) => {
+    await expect(page).toHaveTitle(/Dashnote/i);
+  });
+});
+
+test.describe("tab navigation", () => {
+  test("switches between Notes and How it works", async ({ page }) => {
+    // Notes tab is the default.
+    await expect(
+      page.getByRole("heading", {
+        name: /Personal notes on Dash Platform/i,
+      }),
+    ).toBeVisible();
+
+    await (await navButton(page, /how it works/i)).click();
+    await expect(
+      page.getByRole("heading", { name: /How Dashnote works/i }),
+    ).toBeVisible();
+
+    await (await navButton(page, /notes$/i)).click();
+    await expect(
+      page.getByRole("heading", {
+        name: /Personal notes on Dash Platform/i,
+      }),
+    ).toBeVisible();
+  });
+});
+
+test.describe("theme toggle", () => {
+  test("toggling the theme switches the html data-theme attribute", async ({
+    page,
+  }) => {
+    const html = page.locator("html");
+    const before = await html.getAttribute("data-theme");
+    // The toggle is rendered both in the mobile top bar and in the sidebar.
+    // On desktop only the sidebar one is visible; on mobile only the top-bar
+    // one is visible at rest. `.first()` resolves to whichever is in DOM.
+    await page
+      .getByRole("button", { name: /switch to (light|dark) theme/i })
+      .first()
+      .click();
+    await expect
+      .poll(async () => html.getAttribute("data-theme"))
+      .not.toBe(before);
+  });
+});
+
+test.describe("login modal", () => {
+  test("sidebar Login button opens the modal", async ({ page }) => {
+    await (await navButton(page, /login$/i)).click();
+    const dialog = page.getByRole("dialog");
+    await expect(dialog).toBeVisible();
+    await expect(dialog.getByPlaceholder(/mnemonic phrase|wif/i)).toBeVisible();
+  });
+
+  test("Cancel button closes the modal", async ({ page }) => {
+    await (await navButton(page, /login$/i)).click();
+    const dialog = page.getByRole("dialog");
+    await expect(dialog).toBeVisible();
+    await dialog.getByRole("button", { name: /^cancel$/i }).click();
+    await expect(dialog).toBeHidden();
+  });
+
+  test("Escape closes the modal", async ({ page }) => {
+    await (await navButton(page, /login$/i)).click();
+    const dialog = page.getByRole("dialog");
+    await expect(dialog).toBeVisible();
+    await page.keyboard.press("Escape");
+    await expect(dialog).toBeHidden();
+  });
+
+  test("Login button is disabled until a secret is entered", async ({
+    page,
+  }) => {
+    await (await navButton(page, /login$/i)).click();
+    const dialog = page.getByRole("dialog");
+    const submit = dialog.getByRole("button", { name: /^Login$/ });
+    await expect(submit).toBeDisabled();
+    await dialog.getByPlaceholder(/mnemonic phrase|wif/i).fill("abandon");
+    await expect(submit).toBeEnabled();
+  });
+
+  test("Advanced settings reveals the identity-index field for mnemonic input", async ({
+    page,
+  }) => {
+    await (await navButton(page, /login$/i)).click();
+    const dialog = page.getByRole("dialog");
+    // Type something with whitespace so detectSecretShape() picks "mnemonic"
+    // and the identity-index field is rendered inside Advanced.
+    await dialog.getByPlaceholder(/mnemonic phrase|wif/i).fill("word word");
+    await dialog.getByRole("button", { name: /advanced settings/i }).click();
+    await expect(dialog.getByText(/identity index/i)).toBeVisible();
+    await expect(dialog.locator('input[type="number"]')).toBeVisible();
+  });
+
+  test("Advanced settings exposes a contract-ID field", async ({ page }) => {
+    await (await navButton(page, /login$/i)).click();
+    const dialog = page.getByRole("dialog");
+    await dialog.getByRole("button", { name: /advanced settings/i }).click();
+    await expect(dialog.getByText(/contract id/i).first()).toBeVisible();
+    await expect(
+      dialog.getByPlaceholder(/dashnote note contract id/i),
+    ).toBeVisible();
+  });
+});
+
+test.describe("mobile drawer", () => {
+  test("hamburger opens the sidebar drawer and tapping a nav button closes it", async ({
+    page,
+  }, testInfo) => {
+    test.skip(
+      testInfo.project.name !== "chromium-mobile",
+      "mobile-only viewport behavior",
+    );
+
+    const hamburger = page.locator(
+      'button[aria-expanded][aria-label*="menu" i]',
+    );
+    const aside = page.locator('aside[aria-label="Main navigation"]');
+
+    // Drawer starts closed on mobile.
+    await expect(hamburger).toHaveAttribute("aria-expanded", "false");
+
+    await hamburger.click();
+    await expect(hamburger).toHaveAttribute("aria-expanded", "true");
+
+    await aside.getByRole("button", { name: /how it works/i }).click();
+    // NavButton's onClick calls closeDrawer().
+    await expect(hamburger).toHaveAttribute("aria-expanded", "false");
+  });
+});
+
+test.describe("lite HTML", () => {
+  test("dashnote-lite.html loads with a Dashnote heading", async ({ page }) => {
+    await page.goto("/dashnote-lite.html");
+    await expect(page).toHaveTitle(/DashNote Lite/i);
+  });
+});


### PR DESCRIPTION
## Summary

- New Playwright e2e suite under `example-apps/dashnote/test/e2e/` covering every user-facing operation against real Dash Platform testnet. No SDK mocks.
- Four specs (`smoke`, `auth`, `notes`, `settings`) plus a shared `fixtures.ts` mirroring the dashmint-lab setup.
- Two projects per run: `chromium-desktop` (Desktop Chrome) and `chromium-mobile` (Pixel 7) — same specs cover responsive layout regressions.
- New `dashnote-e2e.yml` GitHub Actions workflow with a read-only / read-write split mirroring the existing `test-tutorials.yml` pattern: smoke + settings run on every PR/push touching `example-apps/dashnote/**`; auth + notes are `workflow_dispatch`-only to avoid burning testnet credits on routine runs.

## Coverage

**`smoke.spec.ts`** (no auth): SDK boot, tab navigation, theme toggle, login-modal open/close + input validation + WIF preview, mobile hamburger drawer, `dashnote-lite.html` loads.

**`auth.spec.ts`** (auth-gated, serial): mnemonic login + logout via IdentityCard menu, remember-me persistence across reload, forget-this-device via SettingsPanel AND via LoginModal, switch-identity, Settings tab reachable from both nav button and menu, identity ID displayed after login.

**`notes.spec.ts`** (auth-gated, serial): create/edit/delete round-trip, search filter (uses persistent `[e2e-fixture]` notes seeded once), discard-changes confirmation dismissal, mobile list↔editor transitions, two-context concurrent saves (verifies revision bumping across sessions).

**`settings.spec.ts`** (mixed): readonly sign-in prompt, copy identity ID / contract ID to clipboard, clear local cache (with localStorage assertion), "Use this ID" enable/disable state, DPNS name renders once resolved.

## Notable design choices

- **Mobile + desktop in one suite:** specs use viewport-agnostic locators where possible; mobile-only behaviors are guarded inline with `test.skip(testInfo.project.name !== "chromium-mobile", …)` rather than in a separate file.
- **Test data hygiene:** transient notes use `[e2e]` title prefix and are cleaned up in `afterEach`. Two persistent `[e2e-fixture]` notes back the search test so we don't write + delete throwaway notes every run.
- **Connection gate via `.conn-dot.connected`** instead of text — the readonly IdentityCard renders the "Connected" label twice, breaking strict-mode locators.
- **Mobile cleanup gotcha:** `cleanupE2eNotes` calls `returnToList` at the top of each loop iteration because the list pane is `display: none` whenever a note is selected, which would otherwise make candidate scans silently return 0 and leak orphans.

## CI workflow

- **`e2e-read-only`** (smoke + settings): runs on every push/PR to `main` that touches `example-apps/dashnote/**` or the workflow itself. ~20 min budget.
- **`e2e-read-write`** (auth + notes): `workflow_dispatch` only, 60 min budget, concurrency group prevents parallel runs that would conflict on the shared testnet identity.
- Both jobs cache Playwright browsers keyed on the `@playwright/test` version, upload `playwright-report/` and `test-results/` artifacts on failure (14-day retention).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive end-to-end test coverage for the Dashnote example app, including authentication flows, note management, settings functionality, and responsive design validation across desktop and mobile.
  * Added automated test execution via GitHub Actions with read-only and read-write test suites.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dashpay/platform-tutorials/pull/81)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->