### PR TITLE
refactor(dashnote): redesign workspace with toolbar, activity log, and sign-in hero

### DIFF
--- a/example-apps/dashnote/src/App.tsx
+++ b/example-apps/dashnote/src/App.tsx
@@ -77,9 +77,6 @@ function App() {
           />
         ) : (
           <header className="rounded-[28px] border border-line bg-surface px-5 py-5 shadow-[0_20px_60px_-36px_rgba(0,0,0,0.45)] max-md:rounded-none max-md:border-0 max-md:bg-transparent max-md:px-4 max-md:py-4 max-md:shadow-none">
-            <div className="text-[10px] font-semibold uppercase tracking-[0.14em] text-ink-4">
-              Dash Platform Notes Tutorial
-            </div>
             <h1 className="mt-2 text-[28px] font-semibold leading-[1.05] tracking-tight text-ink">
               {header.title}
             </h1>

--- a/example-apps/dashnote/src/App.tsx
+++ b/example-apps/dashnote/src/App.tsx
@@ -1,9 +1,11 @@
 import { useEffect, useMemo, useState } from "react";
 import { Toaster } from "sonner";
 
+import { ActivityPanel } from "./components/ActivityPanel";
 import { AppShell } from "./components/AppShell";
 import { HowItWorks } from "./components/HowItWorks";
 import { LoginModal } from "./components/LoginModal";
+import { NotesToolbar } from "./components/NotesToolbar";
 import { NotesWorkspace } from "./components/NotesWorkspace";
 import { OperationResultNotice } from "./components/OperationResultNotice";
 import { SettingsPanel } from "./components/SettingsPanel";
@@ -33,6 +35,7 @@ function App() {
   const { status, sdk, enterReadOnly, viewAsRemembered } = session;
   const [tab, setTab] = useState<TopTab>("notes");
   const [loginOpen, setLoginOpen] = useState(false);
+  const [activityOpen, setActivityOpen] = useState(false);
 
   const mobileFullBleed = tab === "notes";
 
@@ -40,6 +43,17 @@ function App() {
     if (status === "idle") void enterReadOnly();
     else if (status === "browsing" && !sdk) void viewAsRemembered();
   }, [enterReadOnly, viewAsRemembered, status, sdk]);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "l") {
+        e.preventDefault();
+        setActivityOpen((v) => !v);
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, []);
 
   const header = useMemo(() => screenCopy[tab], [tab]);
 
@@ -56,31 +70,28 @@ function App() {
         onLoginOpen={() => setLoginOpen(true)}
         mobileFullBleed={mobileFullBleed}
       >
-        <header
-          className={`rounded-[28px] border border-line bg-surface px-5 py-5 shadow-[0_20px_60px_-36px_rgba(0,0,0,0.45)] max-md:rounded-none max-md:border-0 max-md:bg-transparent max-md:px-4 max-md:py-4 max-md:shadow-none ${
-            tab === "notes" &&
-            (status === "authenticated" || status === "browsing")
-              ? "max-md:hidden"
-              : ""
-          }`}
-        >
-          <div className="text-[10px] font-semibold uppercase tracking-[0.14em] text-ink-4">
-            Dash Platform Notes Tutorial
-          </div>
-          <h1 className="mt-2 text-[28px] font-semibold leading-[1.05] tracking-tight text-ink">
-            {header.title}
-          </h1>
-          <p className="mt-2 max-w-[760px] text-[13px] leading-6 text-ink-3">
-            {header.subtitle}
-          </p>
-        </header>
+        {tab === "notes" ? (
+          <NotesToolbar
+            title="Notes"
+            onOpenActivity={() => setActivityOpen(true)}
+          />
+        ) : (
+          <header className="rounded-[28px] border border-line bg-surface px-5 py-5 shadow-[0_20px_60px_-36px_rgba(0,0,0,0.45)] max-md:rounded-none max-md:border-0 max-md:bg-transparent max-md:px-4 max-md:py-4 max-md:shadow-none">
+            <div className="text-[10px] font-semibold uppercase tracking-[0.14em] text-ink-4">
+              Dash Platform Notes Tutorial
+            </div>
+            <h1 className="mt-2 text-[28px] font-semibold leading-[1.05] tracking-tight text-ink">
+              {header.title}
+            </h1>
+            <p className="mt-2 max-w-[760px] text-[13px] leading-6 text-ink-3">
+              {header.subtitle}
+            </p>
+          </header>
+        )}
 
         <div
           className={`${
-            tab === "notes" &&
-            (status === "authenticated" || status === "browsing")
-              ? "mt-6 max-md:mt-0"
-              : "mt-6"
+            tab === "notes" ? "mt-4 max-md:mt-0" : "mt-6"
           } ${mobileFullBleed ? "max-md:flex max-md:min-h-0 max-md:flex-1 max-md:flex-col" : ""}`}
         >
           {session.error && (
@@ -105,6 +116,10 @@ function App() {
       </AppShell>
 
       <LoginModal open={loginOpen} onClose={() => setLoginOpen(false)} />
+      <ActivityPanel
+        open={activityOpen}
+        onClose={() => setActivityOpen(false)}
+      />
     </>
   );
 }

--- a/example-apps/dashnote/src/App.tsx
+++ b/example-apps/dashnote/src/App.tsx
@@ -75,7 +75,7 @@ function App() {
             title="Notes"
             onOpenActivity={() => setActivityOpen(true)}
           />
-        ) : (
+        ) : tab === "how-it-works" ? null : (
           <header className="rounded-[28px] border border-line bg-surface px-5 py-5 shadow-[0_20px_60px_-36px_rgba(0,0,0,0.45)] max-md:rounded-none max-md:border-0 max-md:bg-transparent max-md:px-4 max-md:py-4 max-md:shadow-none">
             <h1 className="mt-2 text-[28px] font-semibold leading-[1.05] tracking-tight text-ink">
               {header.title}
@@ -88,7 +88,7 @@ function App() {
 
         <div
           className={`${
-            tab === "notes" ? "mt-4 max-md:mt-0" : "mt-6"
+            tab === "notes" || tab === "how-it-works" ? "mt-4 max-md:mt-0" : "mt-6"
           } ${mobileFullBleed ? "max-md:flex max-md:min-h-0 max-md:flex-1 max-md:flex-col" : ""}`}
         >
           {session.error && (

--- a/example-apps/dashnote/src/App.tsx
+++ b/example-apps/dashnote/src/App.tsx
@@ -88,7 +88,9 @@ function App() {
 
         <div
           className={`${
-            tab === "notes" || tab === "how-it-works" ? "mt-4 max-md:mt-0" : "mt-6"
+            tab === "notes" || tab === "how-it-works"
+              ? "mt-4 max-md:mt-0"
+              : "mt-6"
           } ${mobileFullBleed ? "max-md:flex max-md:min-h-0 max-md:flex-1 max-md:flex-col" : ""}`}
         >
           {session.error && (

--- a/example-apps/dashnote/src/components/ActivityPanel.tsx
+++ b/example-apps/dashnote/src/components/ActivityPanel.tsx
@@ -25,6 +25,7 @@ export function ActivityPanel({ open, onClose }: ActivityPanelProps) {
   return (
     <div
       role="dialog"
+      aria-modal="true"
       aria-label="Activity log"
       className="fixed inset-0 z-40 flex justify-end bg-black/40"
       onClick={onClose}

--- a/example-apps/dashnote/src/components/ActivityPanel.tsx
+++ b/example-apps/dashnote/src/components/ActivityPanel.tsx
@@ -1,0 +1,115 @@
+import { useEffect } from "react";
+
+import { formatRelativeTime } from "../lib/format";
+import { useSession } from "../session/useSession";
+
+interface ActivityPanelProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export function ActivityPanel({ open, onClose }: ActivityPanelProps) {
+  const { activityLog, clearActivityLog } = useSession();
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      role="dialog"
+      aria-label="Activity log"
+      className="fixed inset-0 z-40 flex justify-end bg-black/40"
+      onClick={onClose}
+    >
+      <aside
+        onClick={(e) => e.stopPropagation()}
+        className="flex h-full w-full max-w-[440px] flex-col border-l border-line bg-surface shadow-[0_30px_70px_-22px_rgba(0,0,0,0.7)]"
+      >
+        <div className="flex items-center justify-between border-b border-line px-5 py-3">
+          <div className="flex items-center gap-2">
+            <svg
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.8"
+              className="text-accent"
+              aria-hidden
+            >
+              <path d="M22 12h-4l-3 9L9 3l-3 9H2" />
+            </svg>
+            <div className="text-[13px] font-semibold text-ink">Activity</div>
+            <span className="rounded-full bg-surface-2 px-2 py-0.5 font-mono text-[10px] text-ink-4">
+              live
+            </span>
+          </div>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={clearActivityLog}
+              className="rounded-md border border-line px-2 py-1 text-[11px] text-ink-3 hover:border-line-2 hover:text-ink"
+            >
+              Clear
+            </button>
+            <button
+              type="button"
+              onClick={onClose}
+              aria-label="Close"
+              className="text-ink-4 hover:text-ink"
+            >
+              ×
+            </button>
+          </div>
+        </div>
+
+        <div className="flex-1 overflow-y-auto">
+          {activityLog.length === 0 ? (
+            <div className="px-5 py-8 text-center text-[12.5px] text-ink-4">
+              No activity yet. Save a note to see SDK calls land here.
+            </div>
+          ) : (
+            activityLog.map((entry) => (
+              <div
+                key={entry.id}
+                className="grid grid-cols-[10px_1fr_auto] items-center gap-3 px-5 py-2.5 hover:bg-bg/30"
+              >
+                <span
+                  className={`h-1.5 w-1.5 rounded-full ${
+                    entry.level === "success"
+                      ? "bg-[oklch(70%_0.16_150)]"
+                      : entry.level === "error"
+                        ? "bg-[color:var(--color-danger)]"
+                        : "bg-ink-4"
+                  }`}
+                  aria-hidden
+                />
+                <div className="min-w-0">
+                  <div className="truncate text-[12.5px] text-ink">
+                    {entry.message}
+                  </div>
+                  {entry.detail && (
+                    <div className="truncate font-mono text-[11px] text-ink-4">
+                      {entry.detail}
+                    </div>
+                  )}
+                </div>
+                <div className="font-mono text-[10.5px] text-ink-4">
+                  {formatRelativeTime(entry.timestamp)}
+                </div>
+              </div>
+            ))
+          )}
+        </div>
+      </aside>
+    </div>
+  );
+}

--- a/example-apps/dashnote/src/components/AppShell.tsx
+++ b/example-apps/dashnote/src/components/AppShell.tsx
@@ -21,12 +21,28 @@ interface AppShellProps {
 function LogoAvatar() {
   return (
     <div
-      className="h-[28px] w-[28px] shrink-0 rounded-[9px] border border-black/10 shadow-[inset_0_1px_0_rgba(255,255,255,0.45)]"
+      className="flex h-[28px] w-[28px] shrink-0 items-center justify-center rounded-[9px] border border-black/10 shadow-[inset_0_1px_0_rgba(255,255,255,0.45)]"
       style={{
         background:
           "linear-gradient(135deg, oklch(94% 0.04 95), oklch(88% 0.05 85))",
       }}
-    />
+    >
+      <svg
+        width="16"
+        height="16"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="oklch(35% 0.05 65)"
+        strokeWidth="2.2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+      >
+        <path d="M14 3v4a1 1 0 0 0 1 1h4" />
+        <path d="M17 21H7a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h7l5 5v11a2 2 0 0 1-2 2z" />
+        <path d="M9 9h1M9 13h6M9 17h6" />
+      </svg>
+    </div>
   );
 }
 

--- a/example-apps/dashnote/src/components/HowItWorks.tsx
+++ b/example-apps/dashnote/src/components/HowItWorks.tsx
@@ -85,7 +85,7 @@ const OPS = [
     op: "Update a note",
     file: "updateNote.ts",
     sdk: "documents.get → replace",
-    },
+  },
   { op: "Delete a note", file: "deleteNote.ts", sdk: "documents.delete" },
   { op: "List my notes", file: "queries.ts", sdk: "documents.query" },
   { op: "Register a contract", file: "contract.ts", sdk: "contracts.publish" },
@@ -194,8 +194,8 @@ export function HowItWorks() {
             <div className={SECTION_LABEL}>Platform operations</div>
             <p className={SECTION_INTRO}>
               Each row links to a one-file helper in <code>src/dash/</code>.
-              Read these as the canonical example of each SDK call. Every
-              update is a full document replacement with an incremented{" "}
+              Read these as the canonical example of each SDK call. Every update
+              is a full document replacement with an incremented{" "}
               <code>$revision</code>, so the UI can show that alongside the
               Platform-provided <code>$createdAt</code> and{" "}
               <code>$updatedAt</code> timestamps.

--- a/example-apps/dashnote/src/components/HowItWorks.tsx
+++ b/example-apps/dashnote/src/components/HowItWorks.tsx
@@ -3,41 +3,81 @@ const REPO =
 const APP_REPO =
   "https://github.com/dashpay/platform-tutorials/blob/main/example-apps/dashnote/";
 
+type PipelineGlyph = "ui" | "helper" | "sdk" | "platform";
+
 const PIPELINE: Array<{
   label: string;
   sub: string;
+  glyph: PipelineGlyph;
   href?: string;
 }> = [
   {
     label: "UI",
     sub: "NoteEditor.tsx",
+    glyph: "ui",
     href: "https://github.com/dashpay/platform-tutorials/blob/main/example-apps/dashnote/src/components/NoteEditor.tsx",
   },
   {
     label: "Helper",
     sub: "src/dash/*.ts",
+    glyph: "helper",
     href: "https://github.com/dashpay/platform-tutorials/tree/main/example-apps/dashnote/src/dash",
   },
   {
     label: "Evo SDK",
     sub: "@dashevo/evo-sdk",
+    glyph: "sdk",
     href: "https://www.npmjs.com/package/@dashevo/evo-sdk",
   },
   {
     label: "Platform",
     sub: "testnet",
+    glyph: "platform",
     href: "https://testnet.platform-explorer.com/",
   },
 ];
 
-// Progressively darker cards reinforce the left-to-right flow direction so
-// the four boxes don't read as equally-weighted siblings.
-const PIPELINE_BG = [
-  "bg-bg",
-  "bg-[color:color-mix(in_oklab,var(--color-bg)_75%,var(--color-accent)_8%)]",
-  "bg-[color:color-mix(in_oklab,var(--color-bg)_50%,var(--color-accent)_16%)]",
-  "bg-[color:color-mix(in_oklab,var(--color-bg)_25%,var(--color-accent)_24%)]",
-];
+function PipelineGlyphIcon({ kind }: { kind: PipelineGlyph }) {
+  const common = {
+    width: 14,
+    height: 14,
+    viewBox: "0 0 24 24",
+    fill: "none" as const,
+    stroke: "currentColor",
+    strokeWidth: 2,
+    strokeLinecap: "round" as const,
+    strokeLinejoin: "round" as const,
+    "aria-hidden": true,
+  };
+  switch (kind) {
+    case "ui":
+      return (
+        <svg {...common}>
+          <rect x="3" y="3" width="18" height="18" rx="2" />
+          <path d="M3 9h18M9 21V9" />
+        </svg>
+      );
+    case "helper":
+      return (
+        <svg {...common}>
+          <path d="m16 18 6-6-6-6M8 6l-6 6 6 6" />
+        </svg>
+      );
+    case "sdk":
+      return (
+        <svg {...common}>
+          <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+          <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+        </svg>
+      );
+    case "platform":
+      return (
+        <svg {...common}>
+          <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
+        </svg>
+      );
+  }
+}
 
 const OPS = [
   { op: "Create a note", file: "createNote.ts", sdk: "documents.create" },
@@ -45,7 +85,7 @@ const OPS = [
     op: "Update a note",
     file: "updateNote.ts",
     sdk: "documents.get → replace",
-  },
+    },
   { op: "Delete a note", file: "deleteNote.ts", sdk: "documents.delete" },
   { op: "List my notes", file: "queries.ts", sdk: "documents.query" },
   { op: "Register a contract", file: "contract.ts", sdk: "contracts.publish" },
@@ -82,39 +122,36 @@ const SECTION_INTRO = "mt-2 text-[12.5px] leading-5 text-ink-2";
 export function HowItWorks() {
   return (
     <div className="flex flex-col gap-3">
-      {/* 1. How data flows */}
-      <section className="rounded-2xl border border-line bg-surface px-7 py-4 max-md:px-5 max-md:py-4">
-        <div className={SECTION_LABEL}>Data flow</div>
-        <div className="mt-2 space-y-2 text-[13px] leading-6 text-ink-2">
-          <p>
-            Dashnote stores each entry as a single <code>note</code> document
-            with an optional <code>title</code> and a required{" "}
-            <code>message</code>. Every operation in the app follows the same
-            four-step path below: a React component calls a one-file helper in{" "}
-            <code>src/dash/</code>, the helper calls the Evo SDK, and the SDK
-            writes to a Platform node on testnet.{" "}
-            <strong className="font-semibold text-ink">
-              If you&apos;re reading dashnote to learn the SDK, the files in{" "}
-              <code>src/dash/</code> are the lesson — everything else is
-              plumbing.
-            </strong>
-          </p>
-          <p>
-            Every update is a full document replacement with an incremented
-            revision, so the UI can show <code>$revision</code> alongside the
-            Platform-provided <code>$createdAt</code> and{" "}
-            <code>$updatedAt</code> timestamps. Earlier note bodies aren&apos;t
-            shown — &quot;history&quot; in dashnote means the current state plus
-            its metadata.
-          </p>
+      {/* 0. Page header */}
+      <header className="px-1 pb-1 pt-2">
+        <div className="text-[10px] font-semibold uppercase tracking-[0.14em] text-accent">
+          How Dashnote works
         </div>
+        <h1 className="mt-1.5 text-[28px] font-semibold leading-[1.1] tracking-tight text-ink max-md:text-[22px]">
+          A walkthrough of every SDK call this app makes
+        </h1>
+        <p className="mt-2 max-w-[640px] text-[13px] leading-6 text-ink-2">
+          Dashnote stores each entry as a single <code>note</code> document with
+          an optional <code>title</code> and a required <code>message</code>.
+          Every operation follows the same four-step path: a React component
+          calls a one-file helper in <code>src/dash/</code>, the helper calls
+          the Evo SDK, and the SDK writes to a Platform node on testnet. The
+          files in <code>src/dash/</code> are the lesson — everything else is
+          plumbing.
+        </p>
+      </header>
 
+      {/* 1. Data flow */}
+      <section className="rounded-2xl border border-line bg-surface px-7 py-5 max-md:px-5 max-md:py-4">
+        <div className={SECTION_LABEL}>Data flow</div>
         <div className="mt-4 grid grid-cols-1 gap-3 md:grid-cols-4">
           {PIPELINE.map((step, i, arr) => {
-            const cardClass = `block rounded-xl border border-line p-4 ${PIPELINE_BG[i]}`;
+            const cardClass =
+              "block rounded-xl border border-line bg-bg p-4 text-accent";
             const cardBody = (
               <>
-                <div className="text-[14px] font-bold text-ink">
+                <PipelineGlyphIcon kind={step.glyph} />
+                <div className="mt-3 text-[14px] font-bold text-ink">
                   {step.label}
                 </div>
                 <div className="mt-0.5 font-mono text-[11px] text-ink-3">
@@ -157,7 +194,11 @@ export function HowItWorks() {
             <div className={SECTION_LABEL}>Platform operations</div>
             <p className={SECTION_INTRO}>
               Each row links to a one-file helper in <code>src/dash/</code>.
-              Read these as the canonical example of each SDK call.
+              Read these as the canonical example of each SDK call. Every
+              update is a full document replacement with an incremented{" "}
+              <code>$revision</code>, so the UI can show that alongside the
+              Platform-provided <code>$createdAt</code> and{" "}
+              <code>$updatedAt</code> timestamps.
             </p>
           </div>
           {OPS.map((o) => (

--- a/example-apps/dashnote/src/components/HowItWorks.tsx
+++ b/example-apps/dashnote/src/components/HowItWorks.tsx
@@ -1,53 +1,273 @@
+const REPO =
+  "https://github.com/dashpay/platform-tutorials/blob/main/example-apps/dashnote/src/dash/";
+const APP_REPO =
+  "https://github.com/dashpay/platform-tutorials/blob/main/example-apps/dashnote/";
+
+const PIPELINE: Array<{
+  label: string;
+  sub: string;
+  href?: string;
+}> = [
+  {
+    label: "UI",
+    sub: "NoteEditor.tsx",
+    href: "https://github.com/dashpay/platform-tutorials/blob/main/example-apps/dashnote/src/components/NoteEditor.tsx",
+  },
+  {
+    label: "Helper",
+    sub: "src/dash/*.ts",
+    href: "https://github.com/dashpay/platform-tutorials/tree/main/example-apps/dashnote/src/dash",
+  },
+  {
+    label: "Evo SDK",
+    sub: "@dashevo/evo-sdk",
+    href: "https://www.npmjs.com/package/@dashevo/evo-sdk",
+  },
+  {
+    label: "Platform",
+    sub: "testnet",
+    href: "https://testnet.platform-explorer.com/",
+  },
+];
+
+// Progressively darker cards reinforce the left-to-right flow direction so
+// the four boxes don't read as equally-weighted siblings.
+const PIPELINE_BG = [
+  "bg-bg",
+  "bg-[color:color-mix(in_oklab,var(--color-bg)_75%,var(--color-accent)_8%)]",
+  "bg-[color:color-mix(in_oklab,var(--color-bg)_50%,var(--color-accent)_16%)]",
+  "bg-[color:color-mix(in_oklab,var(--color-bg)_25%,var(--color-accent)_24%)]",
+];
+
+const OPS = [
+  { op: "Create a note", file: "createNote.ts", sdk: "documents.create" },
+  {
+    op: "Update a note",
+    file: "updateNote.ts",
+    sdk: "documents.get → replace",
+  },
+  { op: "Delete a note", file: "deleteNote.ts", sdk: "documents.delete" },
+  { op: "List my notes", file: "queries.ts", sdk: "documents.query" },
+  { op: "Register a contract", file: "contract.ts", sdk: "contracts.publish" },
+];
+
+const READING_ORDER = [
+  { file: "src/dash/contract.ts", caption: "Schema + indices." },
+  { file: "src/dash/createNote.ts", caption: "Simplest mutation." },
+  {
+    file: "src/dash/updateNote.ts",
+    caption: "Fetch → bump revision → replace.",
+  },
+  {
+    file: "src/components/NotesWorkspace.tsx",
+    caption: "Cache + revalidation.",
+  },
+];
+
+const SAMPLE_CODE = `const document = new Document({
+  properties: { title, message },
+  documentTypeName: "note",
+  dataContractId,
+  ownerId,
+});
+
+await sdk.documents.create({
+  document, identityKey, signer,
+});`;
+
+const SECTION_LABEL =
+  "text-[10px] font-semibold uppercase tracking-[0.14em] text-ink-3";
+const SECTION_INTRO = "mt-2 text-[12.5px] leading-5 text-ink-2";
+
 export function HowItWorks() {
   return (
-    <section className="grid gap-4 lg:grid-cols-[minmax(0,1.1fr)_minmax(0,0.9fr)]">
-      <article className="rounded-[24px] border border-line bg-surface px-5 py-5 shadow-[0_20px_60px_-36px_rgba(0,0,0,0.45)]">
-        <div className="text-[10px] font-semibold uppercase tracking-[0.12em] text-ink-4">
-          Product model
+    <div className="flex flex-col gap-3">
+      {/* 1. How data flows */}
+      <section className="rounded-2xl border border-line bg-surface px-7 py-4 max-md:px-5 max-md:py-4">
+        <div className={SECTION_LABEL}>Data flow</div>
+        <div className="mt-2 space-y-2 text-[13px] leading-6 text-ink-2">
+          <p>
+            Dashnote stores each entry as a single <code>note</code> document
+            with an optional <code>title</code> and a required{" "}
+            <code>message</code>. Every operation in the app follows the same
+            four-step path below: a React component calls a one-file helper in{" "}
+            <code>src/dash/</code>, the helper calls the Evo SDK, and the SDK
+            writes to a Platform node on testnet.{" "}
+            <strong className="font-semibold text-ink">
+              If you&apos;re reading dashnote to learn the SDK, the files in{" "}
+              <code>src/dash/</code> are the lesson — everything else is
+              plumbing.
+            </strong>
+          </p>
+          <p>
+            Every update is a full document replacement with an incremented
+            revision, so the UI can show <code>$revision</code> alongside the
+            Platform-provided <code>$createdAt</code> and{" "}
+            <code>$updatedAt</code> timestamps. Earlier note bodies aren&apos;t
+            shown — &quot;history&quot; in dashnote means the current state plus
+            its metadata.
+          </p>
         </div>
-        <h2 className="mt-2 text-[22px] font-semibold tracking-tight text-ink">
-          Editable notes on a tutorial contract
-        </h2>
-        <div className="mt-4 space-y-3 text-[13px] leading-6 text-ink-2">
-          <p>
-            Dashnote keeps the tutorial document type name as <code>note</code>,
-            then adds an optional <code>title</code> plus a required{" "}
-            <code>message</code>.
-          </p>
-          <p>
-            Each save uses document replacement, so the UI can show the current
-            revision number and the Platform-provided <code>$createdAt</code>{" "}
-            and <code>$updatedAt</code> timestamps.
-          </p>
-          <p>
-            v1 does not reconstruct earlier note bodies. History here means the
-            current document state plus metadata about when it was created and
-            last updated.
-          </p>
-        </div>
-      </article>
 
-      <article className="rounded-[24px] border border-line bg-surface px-5 py-5 shadow-[0_20px_60px_-36px_rgba(0,0,0,0.45)]">
-        <div className="text-[10px] font-semibold uppercase tracking-[0.12em] text-ink-4">
-          Code map
+        <div className="mt-4 grid grid-cols-1 gap-3 md:grid-cols-4">
+          {PIPELINE.map((step, i, arr) => {
+            const cardClass = `block rounded-xl border border-line p-4 ${PIPELINE_BG[i]}`;
+            const cardBody = (
+              <>
+                <div className="text-[14px] font-bold text-ink">
+                  {step.label}
+                </div>
+                <div className="mt-0.5 font-mono text-[11px] text-ink-3">
+                  {step.sub}
+                </div>
+              </>
+            );
+            return (
+              <div key={step.label} className="relative">
+                {step.href ? (
+                  <a
+                    href={step.href}
+                    target="_blank"
+                    rel="noreferrer"
+                    className={`${cardClass} transition hover:border-accent-dim`}
+                  >
+                    {cardBody}
+                  </a>
+                ) : (
+                  <div className={cardClass}>{cardBody}</div>
+                )}
+                {i < arr.length - 1 && (
+                  <span
+                    aria-hidden="true"
+                    className="pointer-events-none absolute left-full top-1/2 z-10 hidden -translate-y-1/2 text-[14px] leading-none text-accent md:block"
+                  >
+                    →
+                  </span>
+                )}
+              </div>
+            );
+          })}
         </div>
-        <div className="mt-4 space-y-3 text-[13px] leading-6 text-ink-2">
-          <p>
-            <code>src/dash/contract.ts</code> defines the note schema and
-            registration flow.
-          </p>
-          <p>
-            <code>src/dash/createNote.ts</code>,{" "}
-            <code>src/dash/updateNote.ts</code>, and{" "}
-            <code>src/dash/deleteNote.ts</code> each wrap one Platform mutation.
-          </p>
-          <p>
-            <code>src/dash/queries.ts</code> handles the note list and note
-            detail reads, while <code>src/components/NotesWorkspace.tsx</code>{" "}
-            owns the notebook UI state.
-          </p>
-        </div>
-      </article>
-    </section>
+      </section>
+
+      {/* 2. Operations table + inline code peek */}
+      <div className="grid grid-cols-1 gap-3 lg:grid-cols-[1.05fr_0.95fr]">
+        <section className="overflow-hidden rounded-2xl border border-line bg-surface">
+          <div className="px-5 pt-4 pb-3">
+            <div className={SECTION_LABEL}>Platform operations</div>
+            <p className={SECTION_INTRO}>
+              Each row links to a one-file helper in <code>src/dash/</code>.
+              Read these as the canonical example of each SDK call.
+            </p>
+          </div>
+          {OPS.map((o) => (
+            <a
+              key={o.file}
+              href={`${REPO}${o.file}`}
+              target="_blank"
+              rel="noreferrer"
+              className="grid grid-cols-[1.05fr_0.95fr] items-center gap-3 border-t border-line px-5 py-3 text-[13px] hover:bg-surface-2"
+            >
+              <span className="font-medium text-ink">{o.op}</span>
+              <span className="font-mono text-[12px] text-ink-3">{o.sdk}</span>
+            </a>
+          ))}
+        </section>
+
+        <section className="overflow-hidden rounded-2xl border border-line bg-bg">
+          <div className="border-b border-line px-5 py-3">
+            <div className="flex items-center justify-between">
+              <code className="text-[12px] text-ink-2">
+                src/dash/createNote.ts
+              </code>
+              <a
+                href={`${REPO}createNote.ts`}
+                target="_blank"
+                rel="noreferrer"
+                className="font-mono text-[10px] text-accent hover:underline"
+              >
+                View full file →
+              </a>
+            </div>
+            <p className={SECTION_INTRO}>
+              The shortest mutation in the app — building a{" "}
+              <code>Document</code> and handing it to{" "}
+              <code>sdk.documents.create</code>.
+            </p>
+          </div>
+          <pre className="overflow-x-auto px-5 py-4 font-mono text-[11.5px] leading-[1.65] text-ink-2">
+            {SAMPLE_CODE}
+          </pre>
+        </section>
+      </div>
+
+      {/* 3. Suggested reading order */}
+      <section className="rounded-2xl border border-line bg-surface px-7 py-5 max-md:px-5">
+        <div className={SECTION_LABEL}>Recommended source files</div>
+        <p className={SECTION_INTRO}>
+          Read these in order to build up the mental model: schema first, then
+          the simplest write, then the read-bump-replace pattern, and finally
+          the UI layer that owns caching and revalidation.
+        </p>
+        <ol className="mt-4 space-y-1">
+          {READING_ORDER.map((item, i) => (
+            <li key={item.file}>
+              <a
+                href={`${APP_REPO}${item.file}`}
+                target="_blank"
+                rel="noreferrer"
+                className="-mx-2 flex items-baseline gap-3 rounded-md px-2 py-1.5 transition hover:bg-surface-2"
+              >
+                <span
+                  aria-hidden="true"
+                  className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-[color:color-mix(in_oklab,var(--color-accent)_14%,transparent)] font-mono text-[11px] font-semibold text-accent"
+                >
+                  {i + 1}
+                </span>
+                <span className="text-[13px] leading-5 text-ink-2">
+                  <code className="text-ink">{item.file}</code> — {item.caption}
+                </span>
+              </a>
+            </li>
+          ))}
+        </ol>
+      </section>
+
+      {/* 4. Continue to tutorial */}
+      <a
+        href="https://docs.dash.org/projects/platform/en/stable/docs/tutorials/example-apps/dashnote.html"
+        target="_blank"
+        rel="noreferrer"
+        className="group flex items-center justify-between gap-3 rounded-2xl border border-line bg-surface px-5 py-3.5 text-[13px] text-ink-2 transition hover:border-accent-dim hover:bg-surface-2 hover:text-ink"
+      >
+        <span className="flex items-center gap-3">
+          <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-[color:color-mix(in_oklab,var(--color-accent)_18%,transparent)] text-accent transition group-hover:bg-accent group-hover:text-bg">
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden="true"
+            >
+              <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20" />
+              <path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z" />
+            </svg>
+          </span>
+          <span>
+            <span className="font-semibold text-ink">
+              Continue to the Dashnote tutorial
+            </span>
+            <span className="ml-1.5 text-ink-3">on docs.dash.org</span>
+          </span>
+        </span>
+        <span aria-hidden="true" className="text-ink-3 group-hover:text-accent">
+          →
+        </span>
+      </a>
+    </div>
   );
 }

--- a/example-apps/dashnote/src/components/IdentityCard.tsx
+++ b/example-apps/dashnote/src/components/IdentityCard.tsx
@@ -71,16 +71,7 @@ export function IdentityCard({
         >
           Sign in
         </button>
-        <div className="mt-2.5 flex items-center gap-1.5">
-          <span
-            className={`conn-dot ${
-              status === "connecting"
-                ? "connecting"
-                : status === "error"
-                  ? "error"
-                  : ""
-            }`}
-          />
+        <div className="mt-2.5">
           <span className="font-mono text-[10.5px] text-ink-3">
             {status === "connecting"
               ? "Connecting..."
@@ -105,14 +96,13 @@ export function IdentityCard({
       >
         <div className="flex items-center justify-between">
           <span className="text-[10px] font-semibold uppercase tracking-[0.12em] text-ink-4">
-            Connected
+            Guest
           </span>
           <span className="text-[10px] text-ink-4 opacity-0 transition-opacity group-hover:opacity-100">
             Sign in
           </span>
         </div>
-        <div className="mt-2.5 flex items-center gap-1.5">
-          <span className="conn-dot connected" />
+        <div className="mt-2.5">
           <span className="font-mono text-[10.5px] text-ink-3">Connected</span>
         </div>
       </button>
@@ -132,19 +122,19 @@ export function IdentityCard({
           <>
             <div className="mb-0.5 flex items-center justify-between">
               <span className="text-[10px] font-semibold uppercase tracking-[0.12em] text-ink-4">
-                {isAuthed ? "Signed in" : "Read-only"}
+                {isAuthed ? "Signed in" : "Remembered"}
               </span>
               <span className="text-[10px] text-ink-4 opacity-0 transition-opacity group-hover:opacity-100">
                 Menu
               </span>
             </div>
-            <div className="flex items-center gap-2">
+            <div className="flex items-center gap-2.5">
               <div
-                className="h-5 w-5 shrink-0 rounded-full"
+                className="h-7 w-7 shrink-0 rounded-full"
                 style={{ background: avatarGradient(identityId) }}
               />
               <div className="min-w-0">
-                <div className="truncate text-[12px] font-medium text-ink transition-colors group-hover:text-accent">
+                <div className="truncate text-[12px] font-semibold text-ink transition-colors group-hover:text-accent">
                   {dpnsName
                     ? `@${dpnsName}`
                     : identityId
@@ -163,10 +153,9 @@ export function IdentityCard({
           </>
         )}
 
-        <div className="mt-2.5 flex items-center gap-1.5">
-          <span className="conn-dot connected" />
+        <div className="mt-2.5">
           <span className="font-mono text-[10.5px] text-ink-3">
-            {isAuthed ? "Authenticated" : "Browsing (read-only)"}
+            {isAuthed ? "Full access" : "Read-only access"}
           </span>
         </div>
       </button>

--- a/example-apps/dashnote/src/components/IdentityCard.tsx
+++ b/example-apps/dashnote/src/components/IdentityCard.tsx
@@ -37,7 +37,6 @@ export function IdentityCard({
   const isBrowsing = status === "browsing";
   const isReadonly = status === "readonly";
   const isConnected = isReadonly || isAuthed || isBrowsing;
-  const hasIdentity = isAuthed || isBrowsing;
   const [menuOpen, setMenuOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -84,26 +83,53 @@ export function IdentityCard({
     );
   }
 
-  // Read-only mode has nothing to put in a menu (no identity → no Settings
-  // target, no Login/Switch entry, no Log out), so the card goes straight
-  // to the login modal on click — matching the pre-menu behavior.
-  if (isReadonly) {
+  // Logged out — either without (readonly) or with (browsing) a remembered
+  // identity hint. Both variants click straight to the login modal; the
+  // browsing variant additionally decorates the card with the cached
+  // DPNS name + avatar so returning users see who they were.
+  if (isReadonly || isBrowsing) {
     return (
       <button
         type="button"
         onClick={onLoginClick}
         className="group w-full border-t border-line pt-3.5 text-left"
       >
-        <div className="flex items-center justify-between">
+        <div className="mb-0.5 flex items-center justify-between">
           <span className="text-[10px] font-semibold uppercase tracking-[0.12em] text-ink-4">
-            Guest
+            {isBrowsing ? "Signed out" : "Guest"}
           </span>
           <span className="text-[10px] text-ink-4 opacity-0 transition-opacity group-hover:opacity-100">
             Sign in
           </span>
         </div>
+        {isBrowsing && (
+          <div className="flex items-center gap-2.5">
+            <div
+              className="h-7 w-7 shrink-0 rounded-full"
+              style={{ background: avatarGradient(identityId) }}
+            />
+            <div className="min-w-0">
+              <div className="truncate text-[12px] font-semibold text-ink transition-colors group-hover:text-accent">
+                {dpnsName
+                  ? `@${dpnsName}`
+                  : identityId
+                    ? truncateId(identityId, 6)
+                    : "Identity"}
+              </div>
+              <div className="truncate font-mono text-[10px] text-ink-4">
+                {dpnsName && identityId
+                  ? truncateId(identityId, 6)
+                  : contractId
+                    ? `contract ${truncateId(contractId, 6)}`
+                    : "No contract"}
+              </div>
+            </div>
+          </div>
+        )}
         <div className="mt-2.5">
-          <span className="font-mono text-[10.5px] text-ink-3">Connected</span>
+          <span className="font-mono text-[10.5px] text-ink-3">
+            {isBrowsing ? "Read-only access" : "Connected"}
+          </span>
         </div>
       </button>
     );
@@ -118,44 +144,40 @@ export function IdentityCard({
         aria-expanded={menuOpen}
         className="group w-full border-t border-line pt-3.5 text-left"
       >
-        {hasIdentity && (
-          <>
-            <div className="mb-0.5 flex items-center justify-between">
-              <span className="text-[10px] font-semibold uppercase tracking-[0.12em] text-ink-4">
-                {isAuthed ? "Signed in" : "Remembered"}
-              </span>
-              <span className="text-[10px] text-ink-4 opacity-0 transition-opacity group-hover:opacity-100">
-                Menu
-              </span>
+        <div className="mb-0.5 flex items-center justify-between">
+          <span className="text-[10px] font-semibold uppercase tracking-[0.12em] text-ink-4">
+            Signed in
+          </span>
+          <span className="text-[10px] text-ink-4 opacity-0 transition-opacity group-hover:opacity-100">
+            Menu
+          </span>
+        </div>
+        <div className="flex items-center gap-2.5">
+          <div
+            className="h-7 w-7 shrink-0 rounded-full"
+            style={{ background: avatarGradient(identityId) }}
+          />
+          <div className="min-w-0">
+            <div className="truncate text-[12px] font-semibold text-ink transition-colors group-hover:text-accent">
+              {dpnsName
+                ? `@${dpnsName}`
+                : identityId
+                  ? truncateId(identityId, 6)
+                  : "Identity"}
             </div>
-            <div className="flex items-center gap-2.5">
-              <div
-                className="h-7 w-7 shrink-0 rounded-full"
-                style={{ background: avatarGradient(identityId) }}
-              />
-              <div className="min-w-0">
-                <div className="truncate text-[12px] font-semibold text-ink transition-colors group-hover:text-accent">
-                  {dpnsName
-                    ? `@${dpnsName}`
-                    : identityId
-                      ? truncateId(identityId, 6)
-                      : "Identity"}
-                </div>
-                <div className="truncate font-mono text-[10px] text-ink-4">
-                  {dpnsName && identityId
-                    ? truncateId(identityId, 6)
-                    : contractId
-                      ? `contract ${truncateId(contractId, 6)}`
-                      : "No contract"}
-                </div>
-              </div>
+            <div className="truncate font-mono text-[10px] text-ink-4">
+              {dpnsName && identityId
+                ? truncateId(identityId, 6)
+                : contractId
+                  ? `contract ${truncateId(contractId, 6)}`
+                  : "No contract"}
             </div>
-          </>
-        )}
+          </div>
+        </div>
 
         <div className="mt-2.5">
           <span className="font-mono text-[10.5px] text-ink-3">
-            {isAuthed ? "Full access" : "Read-only access"}
+            Full access
           </span>
         </div>
       </button>
@@ -185,21 +207,19 @@ export function IdentityCard({
             }}
             className="rounded-md px-2 py-1.5 text-left text-[12px] font-medium text-ink-2 transition hover:bg-surface-2 hover:text-ink"
           >
-            {isAuthed ? "Switch identity" : "Sign in"}
+            Switch identity
           </button>
-          {isAuthed && (
-            <button
-              type="button"
-              role="menuitem"
-              onClick={() => {
-                setMenuOpen(false);
-                session.logout();
-              }}
-              className="rounded-md px-2 py-1.5 text-left text-[12px] font-medium text-ink-2 transition hover:bg-surface-2 hover:text-ink"
-            >
-              Log out
-            </button>
-          )}
+          <button
+            type="button"
+            role="menuitem"
+            onClick={() => {
+              setMenuOpen(false);
+              session.logout();
+            }}
+            className="rounded-md px-2 py-1.5 text-left text-[12px] font-medium text-ink-2 transition hover:bg-surface-2 hover:text-ink"
+          >
+            Log out
+          </button>
         </div>
       )}
     </div>

--- a/example-apps/dashnote/src/components/LoginModal.tsx
+++ b/example-apps/dashnote/src/components/LoginModal.tsx
@@ -65,7 +65,38 @@ export function LoginModal({ open, onClose }: LoginModalProps) {
   }
 
   return (
-    <Modal open={open} onClose={onClose} title="Sign in">
+    <Modal
+      open={open}
+      onClose={onClose}
+      title={
+        <div className="flex items-center gap-2.5">
+          <span className="flex h-7 w-7 items-center justify-center rounded-lg bg-accent text-bg">
+            <svg
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2.2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden="true"
+            >
+              <circle cx="7.5" cy="15.5" r="3.5" />
+              <path d="M21 2 9.6 13.4M14.5 8.5l4 4M19 5l3 3" />
+            </svg>
+          </span>
+          <div>
+            <div className="text-[15px] font-bold tracking-[-0.01em] text-ink">
+              Sign in to Dashnote
+            </div>
+            <div className="text-[11px] text-ink-4">
+              Connects to <span className="font-mono text-accent">testnet</span>
+            </div>
+          </div>
+        </div>
+      }
+    >
       <form onSubmit={handleLogin} className="flex flex-col gap-4 py-2">
         {showRememberedPanel && session.rememberedIdentityId && (
           <label
@@ -106,20 +137,6 @@ export function LoginModal({ open, onClose }: LoginModalProps) {
               ? "Mnemonic or Private Key"
               : "Identity Mnemonic or Private Key"}
           </span>
-          {!showRememberedPanel && (
-            <p className="text-[11px] text-ink-3">
-              Need an identity? Use the{" "}
-              <a
-                href="https://bridge.thepasta.org/"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="font-medium text-accent-dim underline underline-offset-2 hover:text-accent"
-              >
-                Dash bridge
-              </a>{" "}
-              to create one for testing.
-            </p>
-          )}
           <input
             type="password"
             autoComplete="off"
@@ -177,6 +194,21 @@ export function LoginModal({ open, onClose }: LoginModalProps) {
             </div>
           )}
         </label>
+
+        <div className="flex items-center gap-1.5 text-[11px] text-ink-4">
+          <svg
+            width="11"
+            height="11"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            aria-hidden="true"
+          >
+            <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
+          </svg>
+          Stored in memory only — never sent over the network.
+        </div>
 
         {session.rememberedIdentityId && !useDifferentIdentity && (
           <div
@@ -243,11 +275,6 @@ export function LoginModal({ open, onClose }: LoginModalProps) {
           </OperationResultNotice>
         )}
 
-        <p className="text-[11px] text-ink-4">
-          Your secret never leaves this browser. Only the public identity ID is
-          stored when this identity is remembered on this device.
-        </p>
-
         <div className="flex gap-2 pt-1">
           <button
             type="submit"
@@ -264,6 +291,38 @@ export function LoginModal({ open, onClose }: LoginModalProps) {
             Cancel
           </button>
         </div>
+
+        {!showRememberedPanel && (
+          <div className="flex items-start gap-2.5 rounded-xl border border-dashed border-line-2 px-3.5 py-3 text-[12px] text-ink-3">
+            <svg
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.6"
+              className="mt-px text-accent"
+              aria-hidden="true"
+            >
+              <path d="M12 3v3M12 18v3M3 12h3M18 12h3M5.6 5.6l2 2M16.4 16.4l2 2M5.6 18.4l2-2M16.4 7.6l2-2" />
+            </svg>
+            <div>
+              Don&apos;t have a testnet identity?{" "}
+              <a
+                href="https://bridge.thepasta.org/"
+                target="_blank"
+                rel="noreferrer"
+                className="font-semibold text-accent underline-offset-2 hover:underline"
+              >
+                Create one on Dash Bridge →
+              </a>
+              <br />
+              <span className="text-ink-4">
+                Funded automatically. ~30 seconds.
+              </span>
+            </div>
+          </div>
+        )}
       </form>
     </Modal>
   );

--- a/example-apps/dashnote/src/components/Modal.tsx
+++ b/example-apps/dashnote/src/components/Modal.tsx
@@ -7,7 +7,7 @@ import { useEffect, useId, useRef, type ReactNode } from "react";
 
 export interface ModalProps {
   open: boolean;
-  title: string;
+  title: ReactNode;
   onClose: () => void;
   children: ReactNode;
   footer?: ReactNode;
@@ -55,12 +55,16 @@ export function Modal({
         onClick={(e) => e.stopPropagation()}
       >
         <div className="flex items-center justify-between px-5 py-3">
-          <h2
-            id={titleId}
-            className="text-[10px] font-semibold uppercase tracking-[0.12em] text-ink-4"
-          >
-            {title}
-          </h2>
+          {typeof title === "string" ? (
+            <h2
+              id={titleId}
+              className="text-[10px] font-semibold uppercase tracking-[0.12em] text-ink-4"
+            >
+              {title}
+            </h2>
+          ) : (
+            <div id={titleId}>{title}</div>
+          )}
           <button
             type="button"
             onClick={onClose}

--- a/example-apps/dashnote/src/components/NoteEditor.tsx
+++ b/example-apps/dashnote/src/components/NoteEditor.tsx
@@ -208,36 +208,24 @@ export function NoteEditor({
               </svg>
             </button>
           )}
-          {isReadOnly ? (
+          {!isReadOnly && hasSelection && (
             <button
               type="button"
-              onClick={onOpenLogin}
-              className="rounded-full bg-accent px-3 py-1.5 text-[12px] font-semibold text-bg transition hover:bg-accent-dim"
+              onClick={onSave}
+              disabled={!canEdit || saving || !dirty || oversize}
+              aria-label={saving ? "Saving…" : isNew ? "Create note" : "Save"}
+              className="inline-flex items-center gap-2 rounded-md bg-accent px-3 py-1.5 text-[13px] font-semibold text-bg transition hover:bg-accent-dim disabled:cursor-not-allowed disabled:bg-surface-2 disabled:text-ink-4"
             >
-              Sign in to edit
-            </button>
-          ) : (
-            hasSelection && (
-              <button
-                type="button"
-                onClick={onSave}
-                disabled={!canEdit || saving || !dirty || oversize}
-                aria-label={saving ? "Saving…" : isNew ? "Create note" : "Save"}
-                className="inline-flex items-center gap-2 rounded-md bg-accent px-3 py-1.5 text-[13px] font-semibold text-bg transition hover:bg-accent-dim disabled:cursor-not-allowed disabled:bg-surface-2 disabled:text-ink-4"
-              >
-                <span>
-                  {saving ? "Saving…" : isNew ? "Create note" : "Save"}
+              <span>{saving ? "Saving…" : isNew ? "Create note" : "Save"}</span>
+              {isDesktop && (
+                <span
+                  aria-hidden
+                  className="rounded bg-black/20 px-1.5 py-px font-mono text-[10px] opacity-70"
+                >
+                  ⌘S
                 </span>
-                {isDesktop && (
-                  <span
-                    aria-hidden
-                    className="rounded bg-black/20 px-1.5 py-px font-mono text-[10px] opacity-70"
-                  >
-                    ⌘S
-                  </span>
-                )}
-              </button>
-            )
+              )}
+            </button>
           )}
         </div>
       </div>
@@ -318,7 +306,7 @@ export function NoteEditor({
           </div>
         ) : (
           <>
-            <label className="flex min-h-0 flex-1 flex-col">
+            <label className="relative flex min-h-0 flex-1 flex-col">
               <input
                 type="text"
                 aria-label="Title"
@@ -341,6 +329,14 @@ export function NoteEditor({
                 <div className="mt-2 md:hidden">
                   <FillBar bytes={messageBytes} limit={FIELD_BYTE_LIMIT} />
                 </div>
+              )}
+              {isReadOnly && (
+                <button
+                  type="button"
+                  onClick={onOpenLogin}
+                  aria-label="Sign in to edit this note"
+                  className="absolute inset-0 z-10 cursor-pointer bg-transparent outline-none focus-visible:ring-2 focus-visible:ring-accent"
+                />
               )}
             </label>
 

--- a/example-apps/dashnote/src/components/NoteEditor.tsx
+++ b/example-apps/dashnote/src/components/NoteEditor.tsx
@@ -71,8 +71,8 @@ export function NoteEditor({
     if (!isDesktop || isReadOnly || !hasSelection) return;
     const onKey = (e: KeyboardEvent) => {
       if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "s") {
-        if (!canEdit || saving || !dirty || oversize) return;
         e.preventDefault();
+        if (!canEdit || saving || !dirty || oversize) return;
         onSave();
       }
     };

--- a/example-apps/dashnote/src/components/NoteEditor.tsx
+++ b/example-apps/dashnote/src/components/NoteEditor.tsx
@@ -1,6 +1,9 @@
+import { useEffect, useState } from "react";
+
 import type { NoteRecord } from "../dash/queries";
 import { FIELD_BYTE_LIMIT } from "../lib/fieldLimits";
-import { formatTimestamp } from "../lib/format";
+import { formatRelativeTime, formatTimestamp } from "../lib/format";
+import { NoteJsonDrawer } from "./NoteJsonDrawer";
 import { OperationResultNotice } from "./OperationResultNotice";
 
 interface NoteEditorProps {
@@ -22,7 +25,9 @@ interface NoteEditorProps {
   messageBytes: number;
   messageOversize: boolean;
   contractReady: boolean;
+  contractId: string | null;
   error: string | null;
+  conflictWarning?: string | null;
   onOpenLogin: () => void;
   onOpenSettings: () => void;
   isReadOnly?: boolean;
@@ -48,7 +53,9 @@ export function NoteEditor({
   messageBytes,
   messageOversize,
   contractReady,
+  contractId,
   error,
+  conflictWarning,
   onOpenLogin,
   onOpenSettings,
   isReadOnly = false,
@@ -57,10 +64,34 @@ export function NoteEditor({
   const hasSelection = selectedId !== null;
   const isNew = selectedId === "new";
   const oversize = messageOversize;
+  const [jsonOpen, setJsonOpen] = useState(false);
+
+  // Cmd/Ctrl-S triggers Save (matches the keyboard hint chip).
+  useEffect(() => {
+    if (!isDesktop || isReadOnly || !hasSelection) return;
+    const onKey = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "s") {
+        if (!canEdit || saving || !dirty || oversize) return;
+        e.preventDefault();
+        onSave();
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [
+    isDesktop,
+    isReadOnly,
+    hasSelection,
+    canEdit,
+    saving,
+    dirty,
+    oversize,
+    onSave,
+  ]);
 
   return (
     <section className="flex min-h-0 flex-1 flex-col rounded-[24px] border border-line bg-surface shadow-[0_20px_60px_-36px_rgba(0,0,0,0.45)] max-md:rounded-none max-md:border-0 max-md:shadow-none md:h-full md:rounded-none md:border-0 md:bg-transparent md:shadow-none">
-      <div className="flex h-[61px] items-center justify-between gap-3 border-b border-line px-4 py-3 max-md:h-auto max-md:px-3 max-md:py-2.5">
+      <div className="flex h-[61px] min-w-0 items-center justify-between gap-3 overflow-hidden border-b border-line px-4 py-3 max-md:h-auto max-md:px-3 max-md:py-2.5">
         {hasSelection && (
           <button
             type="button"
@@ -85,7 +116,7 @@ export function NoteEditor({
           </button>
         )}
         {isDesktop && (
-          <div className="min-w-0 flex-1">
+          <div className="flex min-w-0 flex-1 items-center gap-3">
             {!hasSelection ? (
               <div className="text-[14px] text-ink-4">
                 Select a note from the list
@@ -98,20 +129,83 @@ export function NoteEditor({
                 />
                 Loading…
               </div>
+            ) : note ? (
+              <>
+                <span className="inline-flex shrink-0 items-center gap-1.5 whitespace-nowrap rounded-full bg-[color:color-mix(in_oklab,var(--color-accent)_14%,transparent)] px-2.5 py-1 font-mono text-[11px] font-semibold text-accent max-lg:hidden">
+                  <svg
+                    width="11"
+                    height="11"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    aria-hidden
+                  >
+                    <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+                    <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+                  </svg>
+                  Revision {note.revision}
+                </span>
+                {note.updatedAt && (
+                  <span
+                    title={formatTimestamp(note.updatedAt)}
+                    className="min-w-0 truncate text-[12px] text-ink-4 max-lg:hidden"
+                  >
+                    Updated {formatRelativeTime(note.updatedAt)}
+                  </span>
+                )}
+              </>
             ) : null}
           </div>
         )}
         <div className="flex-1 md:hidden" />
 
-        <div className="flex gap-2">
-          {canDelete && (
+        <div className="flex shrink-0 items-center gap-2">
+          {isDesktop && note && (
+            <button
+              type="button"
+              onClick={() => setJsonOpen(true)}
+              className="inline-flex items-center gap-1.5 rounded-md border border-line px-2.5 py-1.5 text-[11.5px] font-medium text-ink-3 hover:border-line-2 hover:text-ink max-lg:hidden"
+            >
+              <svg
+                width="12"
+                height="12"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden
+              >
+                <path d="m16 18 6-6-6-6M8 6l-6 6 6 6" />
+              </svg>
+              View JSON
+            </button>
+          )}
+          {canDelete && isDesktop && (
             <button
               type="button"
               onClick={onDelete}
+              aria-label="Delete"
               disabled={deleting}
-              className="rounded-full border border-line-2 px-3 py-1.5 text-[12px] font-semibold text-ink-2 transition hover:border-[color:var(--color-danger)] hover:text-[color:var(--color-danger)] disabled:cursor-not-allowed disabled:border-line disabled:text-ink-4 max-md:hidden"
+              className="inline-flex h-7 w-7 items-center justify-center rounded-md border border-line text-ink-3 transition hover:border-[color:var(--color-danger)] hover:text-[color:var(--color-danger)] disabled:cursor-not-allowed disabled:opacity-50"
             >
-              {deleting ? "Deleting…" : "Delete"}
+              <svg
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.8"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden
+              >
+                <path d="M3 6h18M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6" />
+              </svg>
             </button>
           )}
           {isReadOnly ? (
@@ -128,9 +222,20 @@ export function NoteEditor({
                 type="button"
                 onClick={onSave}
                 disabled={!canEdit || saving || !dirty || oversize}
-                className="rounded-full bg-accent px-3 py-1.5 text-[12px] font-semibold text-bg transition hover:bg-accent-dim disabled:cursor-not-allowed disabled:bg-surface-2 disabled:text-ink-4"
+                aria-label={saving ? "Saving…" : isNew ? "Create note" : "Save"}
+                className="inline-flex items-center gap-2 rounded-md bg-accent px-3 py-1.5 text-[13px] font-semibold text-bg transition hover:bg-accent-dim disabled:cursor-not-allowed disabled:bg-surface-2 disabled:text-ink-4"
               >
-                {saving ? "Saving…" : isNew ? "Create note" : "Save"}
+                <span>
+                  {saving ? "Saving…" : isNew ? "Create note" : "Save"}
+                </span>
+                {isDesktop && (
+                  <span
+                    aria-hidden
+                    className="rounded bg-black/20 px-1.5 py-px font-mono text-[10px] opacity-70"
+                  >
+                    ⌘S
+                  </span>
+                )}
               </button>
             )
           )}
@@ -138,6 +243,25 @@ export function NoteEditor({
       </div>
 
       <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto px-5 py-5 max-md:px-4 max-md:py-3">
+        {conflictWarning && (
+          <div className="flex items-start gap-2.5 rounded-xl border border-[color:color-mix(in_oklab,var(--color-warning)_45%,transparent)] bg-[color:color-mix(in_oklab,var(--color-warning)_7%,var(--color-surface))] px-3.5 py-2.5 text-[12.5px] leading-[1.55] text-ink-2">
+            <svg
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              className="mt-px shrink-0 text-[color:var(--color-warning)]"
+              aria-hidden
+            >
+              <path d="M21 12a9 9 0 1 1-3-6.7" />
+              <path d="M21 3v6h-6" />
+            </svg>
+            <span>{conflictWarning}</span>
+          </div>
+        )}
+
         {error && (
           <OperationResultNotice tone="error" title="Editor error">
             {error}
@@ -241,32 +365,6 @@ export function NoteEditor({
               </span>
             </div>
 
-            <div className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1 border-t border-line pt-3 text-[11px] text-ink-3 max-md:hidden">
-              {note && (
-                <>
-                  <div>
-                    <span className="text-ink-4">Revision </span>
-                    <span className="font-mono text-ink-2">
-                      {note.revision}
-                    </span>
-                  </div>
-                  <div>
-                    <span className="text-ink-4">Created </span>
-                    {formatTimestamp(note.createdAt)}
-                  </div>
-                  <div>
-                    <span className="text-ink-4">Updated </span>
-                    {formatTimestamp(note.updatedAt)}
-                  </div>
-                </>
-              )}
-              {(messageBytes / FIELD_BYTE_LIMIT >= 0.75 || messageOversize) && (
-                <div className="w-[140px]">
-                  <FillBar bytes={messageBytes} limit={FIELD_BYTE_LIMIT} />
-                </div>
-              )}
-            </div>
-
             {canDelete && (
               <div className="mt-2 flex justify-center md:hidden">
                 <button
@@ -297,6 +395,41 @@ export function NoteEditor({
           </>
         )}
       </div>
+      {isDesktop && hasSelection && contractReady && (
+        <div className="flex items-center justify-between gap-4 border-t border-line bg-[color:color-mix(in_oklab,var(--color-bg)_30%,var(--color-surface))] px-5 py-3">
+          {note ? (
+            <div className="flex flex-wrap items-center gap-x-5 gap-y-1 text-[11.5px] text-ink-3">
+              <span className="flex items-center gap-1.5">
+                <span className="font-mono text-ink-4">$createdAt</span>
+                <span>{formatTimestamp(note.createdAt)}</span>
+              </span>
+              <span className="flex items-center gap-1.5">
+                <span className="font-mono text-ink-4">$updatedAt</span>
+                <span>{formatTimestamp(note.updatedAt)}</span>
+              </span>
+            </div>
+          ) : (
+            <div className="text-[11.5px] text-ink-4">
+              Platform metadata appears after the first save.
+            </div>
+          )}
+          <div className="flex items-center gap-2 text-[11px] text-ink-4">
+            <span>
+              {messageBytes.toLocaleString()} /{" "}
+              {FIELD_BYTE_LIMIT.toLocaleString()} B
+            </span>
+            <div className="w-20">
+              <FillBar bytes={messageBytes} limit={FIELD_BYTE_LIMIT} />
+            </div>
+          </div>
+        </div>
+      )}
+      <NoteJsonDrawer
+        open={jsonOpen}
+        note={note}
+        contractId={contractId}
+        onClose={() => setJsonOpen(false)}
+      />
     </section>
   );
 }

--- a/example-apps/dashnote/src/components/NoteJsonDrawer.tsx
+++ b/example-apps/dashnote/src/components/NoteJsonDrawer.tsx
@@ -1,0 +1,76 @@
+import { useEffect } from "react";
+
+import type { NoteRecord } from "../dash/queries";
+
+interface NoteJsonDrawerProps {
+  open: boolean;
+  note: NoteRecord | null;
+  contractId: string | null;
+  onClose: () => void;
+}
+
+export function NoteJsonDrawer({
+  open,
+  note,
+  contractId,
+  onClose,
+}: NoteJsonDrawerProps) {
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, onClose]);
+
+  if (!open || !note) return null;
+
+  const payload = {
+    $id: note.id,
+    $type: "note",
+    $ownerId: note.ownerId,
+    $dataContractId: contractId,
+    $revision: note.revision,
+    $createdAt: note.createdAt,
+    $updatedAt: note.updatedAt,
+    title: note.title,
+    message: note.message,
+  };
+
+  return (
+    <div
+      role="dialog"
+      aria-label="Document JSON"
+      className="fixed inset-0 z-40 flex justify-end bg-black/40"
+      onClick={onClose}
+    >
+      <aside
+        onClick={(e) => e.stopPropagation()}
+        className="flex h-full w-full max-w-[480px] flex-col border-l border-line bg-surface shadow-[0_30px_70px_-22px_rgba(0,0,0,0.7)]"
+      >
+        <div className="flex items-center justify-between border-b border-line px-5 py-3">
+          <div className="flex items-center gap-2">
+            <span className="text-[10px] font-semibold uppercase tracking-[0.12em] text-ink-4">
+              Document
+            </span>
+            <span className="rounded-full bg-surface-2 px-2 py-0.5 font-mono text-[10px] text-accent">
+              rev {note.revision}
+            </span>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            className="text-ink-4 hover:text-ink"
+          >
+            ×
+          </button>
+        </div>
+        <pre className="flex-1 overflow-auto px-5 py-4 font-mono text-[12px] leading-[1.65] text-ink-2">
+          {JSON.stringify(payload, null, 2)}
+        </pre>
+      </aside>
+    </div>
+  );
+}

--- a/example-apps/dashnote/src/components/NoteList.tsx
+++ b/example-apps/dashnote/src/components/NoteList.tsx
@@ -15,6 +15,7 @@ interface NoteListProps {
   onSelect: (noteId: string) => void;
   onNew: () => void;
   canCreate: boolean;
+  newButtonLabel?: string;
 }
 
 export function NoteList({
@@ -25,6 +26,7 @@ export function NoteList({
   onSelect,
   onNew,
   canCreate,
+  newButtonLabel = "New note",
 }: NoteListProps) {
   const [search, setSearch] = useState("");
   const searchRef = useRef<HTMLInputElement>(null);
@@ -106,7 +108,7 @@ export function NoteList({
             onClick={onNew}
             className="rounded-full bg-accent px-3 py-1.5 text-[12px] font-semibold text-bg transition hover:bg-accent-dim max-md:hidden"
           >
-            New note
+            {newButtonLabel}
           </button>
         )}
       </div>

--- a/example-apps/dashnote/src/components/NoteList.tsx
+++ b/example-apps/dashnote/src/components/NoteList.tsx
@@ -1,8 +1,7 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 import type { NoteRecord } from "../dash/queries";
 import {
-  formatCompactTimestamp,
   formatRelativeTime,
   noteDisplayTitle,
   notePreview,
@@ -28,6 +27,23 @@ export function NoteList({
   canCreate,
 }: NoteListProps) {
   const [search, setSearch] = useState("");
+  const searchRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== "/") return;
+      const target = e.target;
+      const editable =
+        target instanceof HTMLInputElement ||
+        target instanceof HTMLTextAreaElement ||
+        (target instanceof HTMLElement && target.isContentEditable);
+      if (editable) return;
+      e.preventDefault();
+      searchRef.current?.focus();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, []);
 
   const filteredNotes = useMemo(() => {
     const q = search.trim().toLowerCase();
@@ -114,12 +130,19 @@ export function NoteList({
             <path d="m21 21-4.3-4.3" />
           </svg>
           <input
+            ref={searchRef}
             type="search"
             value={search}
             onChange={(event) => setSearch(event.target.value)}
             placeholder="Search"
             className="w-full rounded-full border border-line bg-bg px-9 py-2 text-[13px] text-ink outline-none transition focus:border-accent-dim"
           />
+          <span
+            aria-hidden="true"
+            className="pointer-events-none absolute right-2.5 top-1/2 -translate-y-1/2 rounded border border-line bg-bg px-1.5 py-px font-mono text-[10px] text-ink-4"
+          >
+            /
+          </span>
         </label>
       </div>
 
@@ -165,28 +188,33 @@ export function NoteList({
                   key={note.id}
                   type="button"
                   onClick={() => onSelect(note.id)}
-                  className={`block w-full rounded-[18px] border px-3 py-3 text-left transition ${
+                  className={`relative block w-full overflow-hidden rounded-lg px-3 py-3 text-left transition ${
                     active
-                      ? "border-accent bg-surface-2 shadow-[0_16px_35px_-28px_rgba(0,0,0,0.5)]"
-                      : "border-transparent bg-transparent hover:border-line hover:bg-surface-2"
+                      ? "bg-surface-2"
+                      : "bg-transparent hover:bg-surface-2"
                   }`}
                 >
-                  <div className="flex items-start justify-between gap-3">
-                    <div className="min-w-0">
-                      <div className="truncate text-[13px] font-semibold text-ink">
+                  {active && (
+                    <span
+                      aria-hidden="true"
+                      className="absolute inset-y-3 left-0 w-0.5 rounded-r-sm bg-accent"
+                    />
+                  )}
+                  <div className="relative">
+                    <div className="flex items-baseline justify-between gap-3">
+                      <div
+                        className={`min-w-0 truncate text-[13.5px] font-semibold tracking-[-0.005em] text-ink ${
+                          note.title?.trim() ? "" : "italic text-ink-2"
+                        }`}
+                      >
                         {noteDisplayTitle(note)}
                       </div>
-                      <div className="mt-1 line-clamp-2 text-[12px] leading-5 text-ink-3">
-                        {notePreview(note.message)}
-                      </div>
-                    </div>
-                    <div className="shrink-0 text-right">
-                      <div className="text-[10px] font-medium text-ink-4">
+                      <div className="shrink-0 text-[10.5px] text-ink-4">
                         {formatRelativeTime(note.updatedAt)}
                       </div>
-                      <div className="mt-1 font-mono text-[10px] text-ink-4">
-                        {formatCompactTimestamp(note.updatedAt)}
-                      </div>
+                    </div>
+                    <div className="mt-1 line-clamp-2 text-[12px] leading-5 text-ink-3">
+                      {notePreview(note.message)}
                     </div>
                   </div>
                 </button>

--- a/example-apps/dashnote/src/components/NotesToolbar.tsx
+++ b/example-apps/dashnote/src/components/NotesToolbar.tsx
@@ -1,0 +1,58 @@
+import type { ReactNode } from "react";
+
+interface NotesToolbarProps {
+  title: string;
+  onOpenActivity?: () => void;
+  rightSlot?: ReactNode;
+}
+
+/**
+ * Slim page-title row used on the notes tab in place of the heavy
+ * header card. Settings + How-it-works keep the card pattern.
+ */
+export function NotesToolbar({
+  title,
+  onOpenActivity,
+  rightSlot,
+}: NotesToolbarProps) {
+  return (
+    <div className="flex items-center justify-between gap-3 px-2 max-md:hidden">
+      <div className="flex items-center gap-2.5">
+        <h1 className="text-[22px] font-bold tracking-[-0.02em] text-ink">
+          {title}
+        </h1>
+        <span className="rounded-full bg-surface-2 px-2 py-0.5 font-mono text-[11px] text-ink-4">
+          testnet
+        </span>
+      </div>
+      <div className="flex items-center gap-2">
+        {onOpenActivity && (
+          <button
+            type="button"
+            onClick={onOpenActivity}
+            className="inline-flex items-center gap-1.5 rounded-full border border-line bg-surface px-3 py-1.5 text-[12px] font-medium text-ink-3 hover:border-line-2 hover:text-ink"
+          >
+            <svg
+              width="13"
+              height="13"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.8"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden
+            >
+              <path d="M22 12h-4l-3 9L9 3l-3 9H2" />
+            </svg>
+            Activity
+            <span className="rounded border border-line bg-bg px-1 font-mono text-[9px] text-ink-4">
+              ⌘L
+            </span>
+          </button>
+        )}
+        {rightSlot}
+      </div>
+    </div>
+  );
+}

--- a/example-apps/dashnote/src/components/NotesToolbar.tsx
+++ b/example-apps/dashnote/src/components/NotesToolbar.tsx
@@ -47,7 +47,7 @@ export function NotesToolbar({
             </svg>
             Activity
             <span className="rounded border border-line bg-bg px-1 font-mono text-[9px] text-ink-4">
-              ⌘L
+              ⌘/Ctrl L
             </span>
           </button>
         )}

--- a/example-apps/dashnote/src/components/NotesWorkspace.tsx
+++ b/example-apps/dashnote/src/components/NotesWorkspace.tsx
@@ -735,23 +735,23 @@ function EmptyState({
 
 function SignInHero({ onOpenLogin }: { onOpenLogin: () => void }) {
   return (
-    <section className="relative overflow-hidden rounded-[24px] border border-line bg-surface px-12 py-14 max-md:px-6 max-md:py-10">
+    <section className="relative overflow-hidden rounded-[24px] border border-line bg-surface px-12 py-14 max-md:flex max-md:flex-1 max-md:flex-col max-md:justify-center max-md:rounded-none max-md:border-0 max-md:px-6 max-md:py-10">
       <div className="pointer-events-none absolute -right-32 -top-32 h-96 w-96 rounded-full bg-[radial-gradient(circle,color-mix(in_oklab,var(--color-accent)_22%,transparent),transparent_60%)]" />
       <div className="relative grid grid-cols-1 gap-10 lg:grid-cols-[1.05fr_0.95fr]">
-        <div>
+        <div className="max-md:text-center">
           <div className="text-[11px] font-bold uppercase tracking-[0.18em] text-accent">
             Dash Platform tutorial
           </div>
           <h2 className="mt-3 text-balance text-[36px] font-bold leading-[1.05] tracking-[-0.025em] text-ink max-md:text-[28px]">
             Personal notes, stored on a public blockchain.
           </h2>
-          <p className="mt-3 max-w-[440px] text-pretty text-[14.5px] leading-[1.6] text-ink-2">
+          <p className="mt-3 max-w-[440px] text-pretty text-[14.5px] leading-[1.6] text-ink-2 max-md:mx-auto">
             Dashnote stores notes against your testnet identity. Sign in with a
             Dash Platform identity to create, edit, and review your notes — or
             read the source to see how a small app registers a contract, writes
             documents, and queries them back.
           </p>
-          <div className="mt-5 flex flex-wrap gap-2.5">
+          <div className="mt-5 flex flex-wrap gap-2.5 max-md:justify-center">
             <button
               type="button"
               onClick={onOpenLogin}

--- a/example-apps/dashnote/src/components/NotesWorkspace.tsx
+++ b/example-apps/dashnote/src/components/NotesWorkspace.tsx
@@ -430,7 +430,13 @@ export function NotesWorkspace({
   }
 
   function handleNew() {
-    if (!canMutate) return;
+    if (!canMutate) {
+      // Browsing with a remembered identity: prompt the user to sign in so
+      // they can author. Anonymous "idle" state never reaches this branch
+      // because the button is hidden when the user can't even read.
+      if (canRead) onOpenLogin();
+      return;
+    }
     if (!confirmDiscard()) return;
     resetDraft();
   }
@@ -621,7 +627,8 @@ export function NotesWorkspace({
               selectedId={selectedId}
               onSelect={handleSelect}
               onNew={handleNew}
-              canCreate={canMutate}
+              canCreate={canMutate || isBrowsing}
+              newButtonLabel={canMutate ? "New note" : "Sign in to create"}
             />
           </div>
           <div

--- a/example-apps/dashnote/src/components/NotesWorkspace.tsx
+++ b/example-apps/dashnote/src/components/NotesWorkspace.tsx
@@ -584,31 +584,7 @@ export function NotesWorkspace({
   return (
     <div className="space-y-5 max-md:flex max-md:min-h-0 max-md:flex-1 max-md:flex-col max-md:space-y-2">
       {!canRead ? (
-        <EmptyState
-          icon={
-            <svg
-              width="32"
-              height="32"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="1.75"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              aria-hidden="true"
-            >
-              <rect width="18" height="11" x="3" y="11" rx="2" />
-              <path d="M7 11V7a5 5 0 0 1 10 0v4" />
-            </svg>
-          }
-          title="Sign in to see your notes"
-          description="Dashnote stores notes against your testnet identity. Sign in with a Dash Platform identity to create, edit, and review your notes."
-          actionLabel="Sign in"
-          onAction={onOpenLogin}
-          secondaryHref="https://bridge.thepasta.org/"
-          secondaryLabel="Need an identity? Create one on Dash Bridge"
-          footnote="Notes are not private. They are stored publicly on Dash Platform."
-        />
+        <SignInHero onOpenLogin={onOpenLogin} />
       ) : !contractReady ? (
         <EmptyState
           icon={
@@ -747,5 +723,108 @@ function EmptyState({
         </div>
       )}
     </div>
+  );
+}
+
+function SignInHero({ onOpenLogin }: { onOpenLogin: () => void }) {
+  return (
+    <section className="relative overflow-hidden rounded-[24px] border border-line bg-surface px-12 py-14 max-md:px-6 max-md:py-10">
+      <div className="pointer-events-none absolute -right-32 -top-32 h-96 w-96 rounded-full bg-[radial-gradient(circle,color-mix(in_oklab,var(--color-accent)_22%,transparent),transparent_60%)]" />
+      <div className="relative grid grid-cols-1 gap-10 lg:grid-cols-[1.05fr_0.95fr]">
+        <div>
+          <div className="text-[11px] font-bold uppercase tracking-[0.18em] text-accent">
+            Dash Platform tutorial
+          </div>
+          <h2 className="mt-3 text-balance text-[36px] font-bold leading-[1.05] tracking-[-0.025em] text-ink max-md:text-[28px]">
+            Personal notes, stored on a public blockchain.
+          </h2>
+          <p className="mt-3 max-w-[440px] text-pretty text-[14.5px] leading-[1.6] text-ink-2">
+            Dashnote stores notes against your testnet identity. Sign in with a
+            Dash Platform identity to create, edit, and review your notes — or
+            read the source to see how a small app registers a contract, writes
+            documents, and queries them back.
+          </p>
+          <div className="mt-5 flex flex-wrap gap-2.5">
+            <button
+              type="button"
+              onClick={onOpenLogin}
+              className="inline-flex items-center gap-2 rounded-full bg-accent px-5 py-2.5 text-[13px] font-semibold text-bg hover:bg-accent-dim"
+            >
+              Sign in
+            </button>
+            <a
+              href="https://github.com/dashpay/platform-tutorials/tree/main/example-apps/dashnote"
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex items-center gap-2 rounded-full border border-line-2 px-5 py-2.5 text-[13px] font-semibold text-ink-2 hover:border-accent-dim"
+            >
+              <svg
+                width="14"
+                height="14"
+                viewBox="0 0 16 16"
+                fill="currentColor"
+                aria-hidden="true"
+              >
+                <path d="M8 0C3.58 0 0 3.58 0 8a8 8 0 0 0 5.47 7.59c.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8Z" />
+              </svg>
+              View source
+            </a>
+          </div>
+          <div className="mt-4 text-[12px] text-ink-4">
+            Need a testnet identity?{" "}
+            <a
+              href="https://bridge.thepasta.org/"
+              target="_blank"
+              rel="noreferrer"
+              className="font-medium text-accent underline-offset-2 hover:underline"
+            >
+              Create one on Dash Bridge →
+            </a>
+          </div>
+        </div>
+
+        {/* Sample note peek — mirrors the real NoteEditor (header pill + footer mono strip) */}
+        <div className="relative max-lg:hidden" aria-hidden="true">
+          <div className="overflow-hidden rounded-[18px] border border-line bg-bg shadow-[0_30px_70px_-36px_rgba(0,0,0,0.55)] [transform:rotate(-0.4deg)]">
+            <div className="flex items-center gap-3 border-b border-line px-4 py-3">
+              <span className="inline-flex shrink-0 items-center gap-1.5 whitespace-nowrap rounded-full bg-[color:color-mix(in_oklab,var(--color-accent)_14%,transparent)] px-2.5 py-1 font-mono text-[11px] font-semibold text-accent">
+                <svg
+                  width="11"
+                  height="11"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2.2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+                  <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+                </svg>
+                Revision 4
+              </span>
+              <span className="text-[12px] text-ink-3">Updated last week</span>
+            </div>
+            <div className="px-5 py-4">
+              <div className="text-[18px] font-bold tracking-[-0.015em] text-ink">
+                Q4 product retro
+              </div>
+              <div className="mt-1.5 text-[13px] leading-[1.55] text-ink-2">
+                Wins: shipped the tutorial app to staging, two contracts
+                published, byte-budget editor unblocks long docs…
+              </div>
+            </div>
+            <div className="flex items-center justify-between gap-3 border-t border-line bg-surface/40 px-5 py-3 font-mono text-[10.5px] text-ink-4">
+              <span>
+                <span className="text-ink-3">$createdAt</span> 5/5/2026, 1:48 PM
+              </span>
+              <span>
+                <span className="text-ink-3">$updatedAt</span> 5/5/2026, 4:43 PM
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
   );
 }

--- a/example-apps/dashnote/src/components/NotesWorkspace.tsx
+++ b/example-apps/dashnote/src/components/NotesWorkspace.tsx
@@ -785,7 +785,7 @@ function SignInHero({ onOpenLogin }: { onOpenLogin: () => void }) {
 
         {/* Sample note peek — mirrors the real NoteEditor (header pill + footer mono strip) */}
         <div className="relative max-lg:hidden" aria-hidden="true">
-          <div className="overflow-hidden rounded-[18px] border border-line bg-bg shadow-[0_30px_70px_-36px_rgba(0,0,0,0.55)] [transform:rotate(-0.4deg)]">
+          <div className="overflow-hidden rounded-lg border border-line bg-bg shadow-[0_30px_70px_-36px_rgba(0,0,0,0.55)] [transform:rotate(-0.4deg)]">
             <div className="flex items-center gap-3 border-b border-line px-4 py-3">
               <span className="inline-flex shrink-0 items-center gap-1.5 whitespace-nowrap rounded-full bg-[color:color-mix(in_oklab,var(--color-accent)_14%,transparent)] px-2.5 py-1 font-mono text-[11px] font-semibold text-accent">
                 <svg

--- a/example-apps/dashnote/src/components/NotesWorkspace.tsx
+++ b/example-apps/dashnote/src/components/NotesWorkspace.tsx
@@ -14,7 +14,7 @@ import { updateNote } from "../dash/updateNote";
 import { DeleteNoteModal } from "./DeleteNoteModal";
 import { useMediaQuery } from "../hooks/useMediaQuery";
 import { byteLength, FIELD_BYTE_LIMIT } from "../lib/fieldLimits";
-import { errorMessage } from "../lib/logger";
+import { errorMessage, normalizeLogOptions, type Logger } from "../lib/logger";
 import {
   BACKGROUND_REFRESH_MS,
   FOCUS_REFRESH_MIN_MS,
@@ -31,6 +31,16 @@ const STALE_EDIT_WARNING =
   "This note changed on the network. Your unsaved edits are still here — saving will overwrite the newer version.";
 
 type SelectedNoteId = string | "new" | null;
+
+// Wrap the session logger so `info` rows from src/dash/* helpers (which only
+// pass a string) pick up the activity-panel `detail` for the operation. The
+// helpers stay terse; presentation lives here in the caller.
+function withDetail(log: Logger, detail: string): Logger {
+  return (message, levelOrOptions) => {
+    const opts = normalizeLogOptions(levelOrOptions);
+    log(message, { ...opts, detail: opts.detail ?? detail });
+  };
+}
 
 export function NotesWorkspace({
   onOpenLogin,
@@ -469,7 +479,11 @@ export function NotesWorkspace({
           contractId,
           title,
           message,
-          log,
+          log: withDetail(log, "documents.create"),
+        });
+        log("Note created.", {
+          level: "success",
+          detail: `id ${noteId.slice(0, 8)}…`,
         });
         // Advance baselines so the post-save reload doesn't see wasDirty=true
         // and trip the conflict detector against its own write.
@@ -479,14 +493,18 @@ export function NotesWorkspace({
         setBaselineMessage(submittedMessage);
         await reloadNotes(noteId);
       } else {
-        await updateNote({
+        const newRevision = await updateNote({
           sdk,
           keyManager,
           contractId,
           noteId: selectedId,
           title,
           message,
-          log,
+          log: withDetail(log, "documents.get → replace"),
+        });
+        log("Note saved.", {
+          level: "success",
+          detail: `rev ${newRevision.toString()}`,
         });
         baselineTitleRef.current = submittedTitle;
         baselineMessageRef.current = submittedMessage;
@@ -575,7 +593,11 @@ export function NotesWorkspace({
         keyManager,
         contractId,
         noteId: selectedId,
-        log,
+        log: withDetail(log, "documents.delete"),
+      });
+      log("Note deleted.", {
+        level: "success",
+        detail: `id ${selectedId.slice(0, 8)}…`,
       });
       setDeleteRequested(false);
       await reloadNotes();

--- a/example-apps/dashnote/src/components/NotesWorkspace.tsx
+++ b/example-apps/dashnote/src/components/NotesWorkspace.tsx
@@ -634,7 +634,7 @@ export function NotesWorkspace({
           onAction={onOpenSettings}
         />
       ) : (
-        <div className="gap-5 max-md:flex max-md:min-h-0 max-md:flex-1 max-md:flex-col md:grid md:h-[calc(100vh-220px)] md:min-h-[520px] md:grid-cols-[260px_minmax(0,1fr)] md:gap-0 md:overflow-hidden md:rounded-[24px] md:border md:border-line md:bg-surface md:shadow-[0_20px_60px_-36px_rgba(0,0,0,0.45)] lg:grid-cols-[340px_minmax(0,1fr)]">
+        <div className="gap-5 max-md:flex max-md:min-h-0 max-md:flex-1 max-md:flex-col md:grid md:h-[calc(100vh-175px)] md:min-h-[520px] md:grid-cols-[260px_minmax(0,1fr)] md:gap-0 md:overflow-hidden md:rounded-[24px] md:border md:border-line md:bg-surface md:shadow-[0_20px_60px_-36px_rgba(0,0,0,0.45)] lg:grid-cols-[340px_minmax(0,1fr)]">
           <div
             className={`min-h-0 max-md:flex-1 ${selectedId !== null ? "hidden md:flex" : "flex"} flex-col`}
           >
@@ -674,7 +674,9 @@ export function NotesWorkspace({
               messageBytes={messageBytes}
               messageOversize={messageOversize}
               contractReady={contractReady}
-              error={error ?? conflictWarning}
+              contractId={contractId}
+              error={error}
+              conflictWarning={conflictWarning}
               onOpenLogin={onOpenLogin}
               onOpenSettings={onOpenSettings}
             />

--- a/example-apps/dashnote/src/dash/createNote.ts
+++ b/example-apps/dashnote/src/dash/createNote.ts
@@ -24,7 +24,7 @@ export async function createNote({
   message,
   log,
 }: CreateNoteParams): Promise<string> {
-  log?.("Creating note…", { level: "info", detail: "documents.create" });
+  log?.("Creating note…");
   const { identity, identityKey, signer } = await keyManager.getAuth();
   const { Document } = await loadSdkModule();
   const trimmedTitle = title?.trim();
@@ -52,9 +52,6 @@ export async function createNote({
   if (!noteId) {
     throw new Error("Created note returned no ID.");
   }
-  log?.("Note created.", {
-    level: "success",
-    detail: `id ${noteId.slice(0, 8)}…`,
-  });
+  log?.("Note created.", "success");
   return noteId;
 }

--- a/example-apps/dashnote/src/dash/createNote.ts
+++ b/example-apps/dashnote/src/dash/createNote.ts
@@ -24,7 +24,7 @@ export async function createNote({
   message,
   log,
 }: CreateNoteParams): Promise<string> {
-  log?.("Creating note…");
+  log?.("Creating note…", { level: "info", detail: "documents.create" });
   const { identity, identityKey, signer } = await keyManager.getAuth();
   const { Document } = await loadSdkModule();
   const trimmedTitle = title?.trim();
@@ -52,6 +52,9 @@ export async function createNote({
   if (!noteId) {
     throw new Error("Created note returned no ID.");
   }
-  log?.("Note created.", "success");
+  log?.("Note created.", {
+    level: "success",
+    detail: `id ${noteId.slice(0, 8)}…`,
+  });
   return noteId;
 }

--- a/example-apps/dashnote/src/dash/deleteNote.ts
+++ b/example-apps/dashnote/src/dash/deleteNote.ts
@@ -21,10 +21,7 @@ export async function deleteNote({
   noteId,
   log,
 }: DeleteNoteParams): Promise<void> {
-  log?.(`Deleting note ${noteId.slice(0, 8)}…`, {
-    level: "info",
-    detail: "documents.delete",
-  });
+  log?.(`Deleting note ${noteId}…`);
   const { identity, identityKey, signer } = await keyManager.getAuth();
   await sdk.documents.delete({
     document: {
@@ -36,8 +33,5 @@ export async function deleteNote({
     identityKey,
     signer,
   });
-  log?.("Note deleted.", {
-    level: "success",
-    detail: `id ${noteId.slice(0, 8)}…`,
-  });
+  log?.("Note deleted.", "success");
 }

--- a/example-apps/dashnote/src/dash/deleteNote.ts
+++ b/example-apps/dashnote/src/dash/deleteNote.ts
@@ -21,7 +21,10 @@ export async function deleteNote({
   noteId,
   log,
 }: DeleteNoteParams): Promise<void> {
-  log?.(`Deleting note ${noteId}…`);
+  log?.(`Deleting note ${noteId.slice(0, 8)}…`, {
+    level: "info",
+    detail: "documents.delete",
+  });
   const { identity, identityKey, signer } = await keyManager.getAuth();
   await sdk.documents.delete({
     document: {
@@ -33,5 +36,8 @@ export async function deleteNote({
     identityKey,
     signer,
   });
-  log?.("Note deleted.", "success");
+  log?.("Note deleted.", {
+    level: "success",
+    detail: `id ${noteId.slice(0, 8)}…`,
+  });
 }

--- a/example-apps/dashnote/src/dash/updateNote.ts
+++ b/example-apps/dashnote/src/dash/updateNote.ts
@@ -28,11 +28,8 @@ export async function updateNote({
   title,
   message,
   log,
-}: UpdateNoteParams): Promise<void> {
-  log?.(`Saving note ${noteId.slice(0, 8)}…`, {
-    level: "info",
-    detail: "documents.get → replace",
-  });
+}: UpdateNoteParams): Promise<bigint> {
+  log?.(`Saving note ${noteId}…`);
   const { identity, identityKey, signer } = await keyManager.getAuth();
   const existingDoc = await sdk.documents.get(contractId, "note", noteId);
   if (!existingDoc) {
@@ -59,8 +56,6 @@ export async function updateNote({
     identityKey,
     signer,
   });
-  log?.("Note saved.", {
-    level: "success",
-    detail: `rev ${revision.toString()}`,
-  });
+  log?.("Note saved.", "success");
+  return revision;
 }

--- a/example-apps/dashnote/src/dash/updateNote.ts
+++ b/example-apps/dashnote/src/dash/updateNote.ts
@@ -29,7 +29,10 @@ export async function updateNote({
   message,
   log,
 }: UpdateNoteParams): Promise<void> {
-  log?.(`Saving note ${noteId}…`);
+  log?.(`Saving note ${noteId.slice(0, 8)}…`, {
+    level: "info",
+    detail: "documents.get → replace",
+  });
   const { identity, identityKey, signer } = await keyManager.getAuth();
   const existingDoc = await sdk.documents.get(contractId, "note", noteId);
   if (!existingDoc) {
@@ -56,5 +59,8 @@ export async function updateNote({
     identityKey,
     signer,
   });
-  log?.("Note saved.", "success");
+  log?.("Note saved.", {
+    level: "success",
+    detail: `rev ${revision.toString()}`,
+  });
 }

--- a/example-apps/dashnote/src/lib/logger.ts
+++ b/example-apps/dashnote/src/lib/logger.ts
@@ -3,7 +3,36 @@
  */
 export type LogLevel = "info" | "success" | "error";
 
-export type Logger = (message: string, level?: LogLevel) => void;
+export interface LogOptions {
+  level?: LogLevel;
+  detail?: string;
+}
+
+// Positional `LogLevel` second arg is accepted for backwards-compatibility with
+// existing call sites (`log("…", "success")`); new code should pass the object
+// form so it can carry `detail` for the activity panel.
+export type Logger = (
+  message: string,
+  levelOrOptions?: LogLevel | LogOptions,
+) => void;
+
+export interface LogEntry {
+  id: string;
+  level: LogLevel;
+  message: string;
+  detail?: string;
+  timestamp: number;
+}
+
+export const ACTIVITY_LOG_LIMIT = 200;
+
+export function normalizeLogOptions(
+  levelOrOptions?: LogLevel | LogOptions,
+): LogOptions {
+  if (!levelOrOptions) return {};
+  if (typeof levelOrOptions === "string") return { level: levelOrOptions };
+  return levelOrOptions;
+}
 
 export function errorMessage(err: unknown): string {
   if (err instanceof Error) return err.message;

--- a/example-apps/dashnote/src/session/SessionContext.tsx
+++ b/example-apps/dashnote/src/session/SessionContext.tsx
@@ -16,7 +16,13 @@ import {
 import { resolveDpnsName } from "../dash/resolveDpnsName";
 import type { DashKeyManager, DashSdk } from "../dash/types";
 import { detectSecretShape } from "../lib/detectSecretShape";
-import { errorMessage, type Logger } from "../lib/logger";
+import {
+  ACTIVITY_LOG_LIMIT,
+  errorMessage,
+  normalizeLogOptions,
+  type LogEntry,
+  type Logger,
+} from "../lib/logger";
 import { clearCachedNotes } from "../lib/notesCache";
 import {
   clearRememberedIdentity,
@@ -70,6 +76,8 @@ export interface SessionValue {
   dpnsName: string | null;
   setContractId: (id: string | null) => void;
   log: Logger;
+  activityLog: LogEntry[];
+  clearActivityLog: () => void;
   login: (secret: string, options?: LoginOptions) => Promise<void>;
   enterReadOnly: () => Promise<void>;
   viewAsRemembered: () => Promise<void>;
@@ -101,13 +109,34 @@ export function SessionProvider({ children }: { children: ReactNode }) {
     initialRemembered?.name ?? null,
   );
 
-  const log = useCallback<Logger>((message, level = "info") => {
+  const [activityLog, setActivityLog] = useState<LogEntry[]>([]);
+
+  const log = useCallback<Logger>((message, levelOrOptions) => {
+    const { level = "info", detail } = normalizeLogOptions(levelOrOptions);
     const method =
       level === "error" ? "error" : level === "success" ? "info" : "log";
-    console[method](`[${level}] ${message}`);
+    console[method](`[${level}] ${message}${detail ? ` (${detail})` : ""}`);
+    const entry: LogEntry = {
+      id:
+        typeof crypto !== "undefined" && "randomUUID" in crypto
+          ? crypto.randomUUID()
+          : `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`,
+      level,
+      message,
+      detail,
+      timestamp: Date.now(),
+    };
+    setActivityLog((prev) => {
+      const next = [entry, ...prev];
+      return next.length > ACTIVITY_LOG_LIMIT
+        ? next.slice(0, ACTIVITY_LOG_LIMIT)
+        : next;
+    });
     if (level === "success") toast.success(message);
     if (level === "error") toast.error(message);
   }, []);
+
+  const clearActivityLog = useCallback(() => setActivityLog([]), []);
 
   const setContractId = useCallback(
     (id: string | null) => {
@@ -134,11 +163,17 @@ export function SessionProvider({ children }: { children: ReactNode }) {
   const connect = useCallback(async () => {
     setStatus("connecting");
     setError(null);
-    log("Connecting to Dash Platform testnet…");
+    log("Connecting to Dash Platform testnet…", {
+      level: "info",
+      detail: 'createClient("testnet")',
+    });
     const { createClient } = await loadSdkModule();
     const connected = (await createClient("testnet")) as unknown as DashSdk;
     setSdk(connected);
-    log("Connected to Dash Platform testnet.");
+    log("Connected to Dash Platform testnet.", {
+      level: "info",
+      detail: "sdk.connect",
+    });
     return connected;
   }, [log]);
 
@@ -188,7 +223,13 @@ export function SessionProvider({ children }: { children: ReactNode }) {
         const resolvedId = resolvedKeyManager.identityId ?? null;
         setIdentityId(resolvedId ?? null);
         setStatus("authenticated");
-        log(`Identity resolved: ${resolvedId ?? "(unknown)"}`, "success");
+        log(`Identity resolved: ${resolvedId ?? "(unknown)"}`, {
+          level: "success",
+          detail:
+            shape === "mnemonic"
+              ? "IdentityKeyManager.create"
+              : "loginWithPrivateKey",
+        });
 
         // Resolve the DPNS name after auth so we can persist it alongside
         // the identity ID — DPNS bindings are permanent, so what we save
@@ -346,6 +387,8 @@ export function SessionProvider({ children }: { children: ReactNode }) {
       dpnsName,
       setContractId,
       log,
+      activityLog,
+      clearActivityLog,
       login,
       enterReadOnly,
       viewAsRemembered,
@@ -363,6 +406,8 @@ export function SessionProvider({ children }: { children: ReactNode }) {
       dpnsName,
       setContractId,
       log,
+      activityLog,
+      clearActivityLog,
       login,
       enterReadOnly,
       viewAsRemembered,

--- a/example-apps/dashnote/src/styles/globals.css
+++ b/example-apps/dashnote/src/styles/globals.css
@@ -92,35 +92,3 @@ code {
   outline: 2px solid var(--color-accent-dim);
   outline-offset: 2px;
 }
-
-@keyframes conn-pulse {
-  0%,
-  100% {
-    opacity: 1;
-  }
-  50% {
-    opacity: 0.4;
-  }
-}
-
-.conn-dot {
-  width: 8px;
-  height: 8px;
-  border-radius: 9999px;
-  background: var(--color-ink-4);
-}
-
-.conn-dot.connecting {
-  background: var(--color-accent);
-  animation: conn-pulse 1s infinite;
-}
-
-.conn-dot.connected,
-.conn-dot.authenticated,
-.conn-dot.readonly {
-  background: oklch(70% 0.16 150);
-}
-
-.conn-dot.error {
-  background: var(--color-danger);
-}

--- a/example-apps/dashnote/test/ActivityPanel.test.tsx
+++ b/example-apps/dashnote/test/ActivityPanel.test.tsx
@@ -1,0 +1,117 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ActivityPanel } from "../src/components/ActivityPanel";
+import type { LogEntry } from "../src/lib/logger";
+
+const { mockUseSession, mockClearActivityLog } = vi.hoisted(() => ({
+  mockUseSession: vi.fn(),
+  mockClearActivityLog: vi.fn(),
+}));
+
+vi.mock("../src/session/useSession", () => ({
+  useSession: mockUseSession,
+}));
+
+function makeEntries(): LogEntry[] {
+  return [
+    {
+      id: "entry-1",
+      level: "success",
+      message: "Note saved.",
+      detail: "rev 2",
+      timestamp: Date.now(),
+    },
+    {
+      id: "entry-2",
+      level: "info",
+      message: "Saving note abc12345…",
+      detail: "documents.get → replace",
+      timestamp: Date.now() - 1000,
+    },
+    {
+      id: "entry-3",
+      level: "error",
+      message: "Login failed: bad key",
+      timestamp: Date.now() - 2000,
+    },
+  ];
+}
+
+beforeEach(() => {
+  mockUseSession.mockReset();
+  mockClearActivityLog.mockReset();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("ActivityPanel", () => {
+  it("renders nothing when closed", () => {
+    mockUseSession.mockReturnValue({
+      activityLog: makeEntries(),
+      clearActivityLog: mockClearActivityLog,
+    });
+    const { container } = render(
+      <ActivityPanel open={false} onClose={vi.fn()} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders an empty-state message when there is no activity", () => {
+    mockUseSession.mockReturnValue({
+      activityLog: [],
+      clearActivityLog: mockClearActivityLog,
+    });
+    render(<ActivityPanel open onClose={vi.fn()} />);
+    expect(screen.getByText(/no activity yet/i)).toBeTruthy();
+  });
+
+  it("renders entries with messages and details", () => {
+    mockUseSession.mockReturnValue({
+      activityLog: makeEntries(),
+      clearActivityLog: mockClearActivityLog,
+    });
+    render(<ActivityPanel open onClose={vi.fn()} />);
+
+    expect(screen.getByText("Note saved.")).toBeTruthy();
+    expect(screen.getByText("rev 2")).toBeTruthy();
+    expect(screen.getByText("documents.get → replace")).toBeTruthy();
+    expect(screen.getByText("Login failed: bad key")).toBeTruthy();
+  });
+
+  it("clears the log when Clear is clicked", () => {
+    mockUseSession.mockReturnValue({
+      activityLog: makeEntries(),
+      clearActivityLog: mockClearActivityLog,
+    });
+    render(<ActivityPanel open onClose={vi.fn()} />);
+    fireEvent.click(screen.getByRole("button", { name: /clear/i }));
+    expect(mockClearActivityLog).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onClose when Escape is pressed", () => {
+    mockUseSession.mockReturnValue({
+      activityLog: makeEntries(),
+      clearActivityLog: mockClearActivityLog,
+    });
+    const onClose = vi.fn();
+    render(<ActivityPanel open onClose={onClose} />);
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("calls onClose when the scrim is clicked", () => {
+    mockUseSession.mockReturnValue({
+      activityLog: makeEntries(),
+      clearActivityLog: mockClearActivityLog,
+    });
+    const onClose = vi.fn();
+    render(<ActivityPanel open onClose={onClose} />);
+    fireEvent.click(screen.getByRole("dialog"));
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/example-apps/dashnote/test/App.test.tsx
+++ b/example-apps/dashnote/test/App.test.tsx
@@ -61,6 +61,31 @@ vi.mock("../src/components/LoginModal", () => ({
   LoginModal: ({ open }: { open: boolean }) => <div>login:{String(open)}</div>,
 }));
 
+vi.mock("../src/components/ActivityPanel", () => ({
+  ActivityPanel: ({ open }: { open: boolean }) => (
+    <div>activity:{String(open)}</div>
+  ),
+}));
+
+vi.mock("../src/components/NotesToolbar", () => ({
+  NotesToolbar: ({
+    title,
+    onOpenActivity,
+  }: {
+    title: string;
+    onOpenActivity?: () => void;
+  }) => (
+    <div>
+      toolbar:{title}
+      {onOpenActivity && (
+        <button type="button" onClick={onOpenActivity}>
+          Open activity
+        </button>
+      )}
+    </div>
+  ),
+}));
+
 function makeSession(overrides: Record<string, unknown> = {}) {
   return {
     status: "idle",
@@ -139,6 +164,23 @@ describe("App", () => {
 
     fireEvent.click(screen.getByRole("button", { name: /open settings/i }));
     expect(screen.getByText("login:true")).toBeTruthy();
+  });
+
+  it("opens the activity panel via ⌘L hotkey and toolbar button", () => {
+    mockUseSession.mockReturnValue(makeSession({ status: "readonly" }));
+
+    render(<App />);
+    expect(screen.getByText("activity:false")).toBeTruthy();
+
+    fireEvent.keyDown(window, { key: "l", metaKey: true });
+    expect(screen.getByText("activity:true")).toBeTruthy();
+
+    // Toggling again closes it.
+    fireEvent.keyDown(window, { key: "l", metaKey: true });
+    expect(screen.getByText("activity:false")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: /open activity/i }));
+    expect(screen.getByText("activity:true")).toBeTruthy();
   });
 
   it("renders SettingsPanel when the settings tab is selected", () => {

--- a/example-apps/dashnote/test/DeleteNoteModal.test.tsx
+++ b/example-apps/dashnote/test/DeleteNoteModal.test.tsx
@@ -90,10 +90,14 @@ describe("DeleteNoteModal", () => {
       />,
     );
     expect(
-      screen.getByRole("button", { name: /deleting…/i }).hasAttribute("disabled"),
+      screen
+        .getByRole("button", { name: /deleting…/i })
+        .hasAttribute("disabled"),
     ).toBe(true);
     expect(
-      screen.getByRole("button", { name: /^cancel$/i }).hasAttribute("disabled"),
+      screen
+        .getByRole("button", { name: /^cancel$/i })
+        .hasAttribute("disabled"),
     ).toBe(true);
   });
 

--- a/example-apps/dashnote/test/HowItWorks.test.tsx
+++ b/example-apps/dashnote/test/HowItWorks.test.tsx
@@ -1,0 +1,121 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { HowItWorks } from "../src/components/HowItWorks";
+
+const REPO =
+  "https://github.com/dashpay/platform-tutorials/blob/main/example-apps/dashnote/src/dash/";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("HowItWorks", () => {
+  it("renders the four-step pipeline diagram", () => {
+    render(<HowItWorks />);
+
+    for (const label of ["UI", "Helper", "Evo SDK", "Platform"]) {
+      expect(screen.getByText(label)).toBeTruthy();
+    }
+    expect(screen.getByText(/data flow/i)).toBeTruthy();
+  });
+
+  it("renders an operations link per dash helper, each pointing at the GitHub source", () => {
+    render(<HowItWorks />);
+
+    const cases = [
+      { op: "Create a note", file: "createNote.ts" },
+      { op: "Update a note", file: "updateNote.ts" },
+      { op: "Delete a note", file: "deleteNote.ts" },
+      { op: "List my notes", file: "queries.ts" },
+      { op: "Register a contract", file: "contract.ts" },
+    ];
+
+    for (const { op, file } of cases) {
+      const link = screen.getByRole("link", { name: new RegExp(op, "i") });
+      expect(link.getAttribute("href")).toBe(`${REPO}${file}`);
+      expect(link.getAttribute("target")).toBe("_blank");
+      // Anchors that open in a new tab need rel="noreferrer" for safety.
+      expect(link.getAttribute("rel")).toMatch(/noreferrer/);
+    }
+  });
+
+  it("renders an inline code peek referencing sdk.documents.create", () => {
+    render(<HowItWorks />);
+
+    // "src/dash/createNote.ts" appears in both the code peek header and the
+    // suggested reading order list — accept either; we only care the file
+    // name is anchored somewhere.
+    expect(
+      screen.getAllByText(/src\/dash\/createNote\.ts/).length,
+    ).toBeGreaterThan(0);
+    // "sdk.documents.create" appears in the code peek snippet AND in the
+    // intro paragraph above it — accept either; one is enough.
+    expect(
+      screen.getAllByText((content) => content.includes("sdk.documents.create"))
+        .length,
+    ).toBeGreaterThan(0);
+  });
+
+  it("renders the suggested reading order list", () => {
+    render(<HowItWorks />);
+
+    const list = screen.getByRole("list");
+    const items = list.querySelectorAll("li");
+    expect(items.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it("renders each pipeline card as a link to its canonical URL", () => {
+    render(<HowItWorks />);
+
+    const cases = [
+      {
+        label: "UI",
+        href: "https://github.com/dashpay/platform-tutorials/blob/main/example-apps/dashnote/src/components/NoteEditor.tsx",
+      },
+      {
+        label: "Helper",
+        href: "https://github.com/dashpay/platform-tutorials/tree/main/example-apps/dashnote/src/dash",
+      },
+      {
+        label: "Evo SDK",
+        href: "https://www.npmjs.com/package/@dashevo/evo-sdk",
+      },
+      // Platform card points at the testnet explorer.
+      { label: "Platform", href: /platform-explorer/i },
+    ];
+
+    for (const { label, href } of cases) {
+      const link = screen.getByRole("link", { name: new RegExp(label, "i") });
+      if (typeof href === "string") {
+        expect(link.getAttribute("href")).toBe(href);
+      } else {
+        expect(link.getAttribute("href")).toMatch(href);
+      }
+      expect(link.getAttribute("target")).toBe("_blank");
+      expect(link.getAttribute("rel")).toMatch(/noreferrer/);
+    }
+  });
+
+  it("renders each reading-order row as a link to its GitHub source", () => {
+    render(<HowItWorks />);
+
+    const files = [
+      "src/dash/contract.ts",
+      "src/dash/createNote.ts",
+      "src/dash/updateNote.ts",
+      "src/components/NotesWorkspace.tsx",
+    ];
+
+    for (const file of files) {
+      const link = screen.getByRole("link", { name: new RegExp(file, "i") });
+      expect(link.getAttribute("href")).toBe(
+        `https://github.com/dashpay/platform-tutorials/blob/main/example-apps/dashnote/${file}`,
+      );
+      expect(link.getAttribute("target")).toBe("_blank");
+      expect(link.getAttribute("rel")).toMatch(/noreferrer/);
+    }
+  });
+});

--- a/example-apps/dashnote/test/IdentityCard.test.tsx
+++ b/example-apps/dashnote/test/IdentityCard.test.tsx
@@ -159,10 +159,10 @@ describe("IdentityCard", () => {
     expect(onLoginClick).toHaveBeenCalled();
   });
 
-  // In browsing mode the user has no signed-in key to switch *from*, so the
-  // menu entry is labeled Sign in (not Switch identity). It still calls
-  // onLoginClick — only the affordance changes.
-  it("labels the login entry 'Sign in' in browsing mode and calls onLoginClick", () => {
+  // Browsing = logged out with a remembered identity hint. The card has
+  // no menu in this state — a click on the card itself opens the login
+  // modal directly, the same way the readonly card does.
+  it("calls onLoginClick on click when browsing, without opening a menu", () => {
     const onLoginClick = vi.fn();
     renderCard({
       status: "browsing",
@@ -170,12 +170,40 @@ describe("IdentityCard", () => {
       dpnsName: null,
       onLoginClick,
     });
-    fireEvent.click(screen.getByRole("button", { expanded: false }));
-    expect(
-      screen.queryByRole("menuitem", { name: /switch identity/i }),
-    ).toBeNull();
-    fireEvent.click(screen.getByRole("menuitem", { name: /^sign in$/i }));
+    const trigger = screen.getByRole("button");
+    fireEvent.click(trigger);
     expect(onLoginClick).toHaveBeenCalled();
+    expect(screen.queryByRole("menu")).toBeNull();
+  });
+
+  // Each card variant pairs an eyebrow (state name) with a subtitle
+  // (capability). These strings are the public contract the e2e specs and
+  // fixtures depend on — assert them at the unit level so drift fails
+  // fast instead of waiting for the slow Playwright suite.
+  it("labels the readonly card as 'Guest' over 'Connected'", () => {
+    renderCard({ status: "readonly", identityId: null, dpnsName: null });
+    expect(screen.getByText("Guest")).toBeTruthy();
+    expect(screen.getByText("Connected")).toBeTruthy();
+  });
+
+  it("labels the browsing card as 'Signed out' over 'Read-only access'", () => {
+    renderCard({
+      status: "browsing",
+      identityId: IDENTITY_ID,
+      dpnsName: "alice",
+    });
+    expect(screen.getByText("Signed out")).toBeTruthy();
+    expect(screen.getByText("Read-only access")).toBeTruthy();
+  });
+
+  it("labels the authenticated card as 'Signed in' over 'Full access'", () => {
+    renderCard({
+      status: "authenticated",
+      identityId: IDENTITY_ID,
+      dpnsName: "alice",
+    });
+    expect(screen.getByText("Signed in")).toBeTruthy();
+    expect(screen.getByText("Full access")).toBeTruthy();
   });
 
   it("calls session.logout when Log out is chosen from the menu", () => {
@@ -189,15 +217,5 @@ describe("IdentityCard", () => {
     fireEvent.click(screen.getByRole("button", { expanded: false }));
     fireEvent.click(screen.getByRole("menuitem", { name: /log out/i }));
     expect(logout).toHaveBeenCalled();
-  });
-
-  it("hides Log out when browsing read-only", () => {
-    renderCard({
-      status: "browsing",
-      identityId: IDENTITY_ID,
-      dpnsName: null,
-    });
-    fireEvent.click(screen.getByRole("button", { expanded: false }));
-    expect(screen.queryByRole("menuitem", { name: /log out/i })).toBeNull();
   });
 });

--- a/example-apps/dashnote/test/NoteEditor.test.tsx
+++ b/example-apps/dashnote/test/NoteEditor.test.tsx
@@ -1,0 +1,126 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { NoteEditor } from "../src/components/NoteEditor";
+import type { NoteRecord } from "../src/dash/queries";
+
+const NOW = Date.now();
+
+function makeNote(overrides: Partial<NoteRecord> = {}): NoteRecord {
+  return {
+    id: "note-a",
+    ownerId: "identity-1",
+    title: "Meeting agenda",
+    message: "Read this in browsing mode.",
+    createdAt: NOW - 60_000,
+    updatedAt: NOW - 60_000,
+    revision: 1,
+    ...overrides,
+  };
+}
+
+type EditorOverrides = Partial<React.ComponentProps<typeof NoteEditor>>;
+
+function renderEditor(overrides: EditorOverrides = {}) {
+  const props: React.ComponentProps<typeof NoteEditor> = {
+    selectedId: "note-a",
+    note: makeNote(),
+    title: "Meeting agenda",
+    message: "Read this in browsing mode.",
+    onTitleChange: vi.fn(),
+    onMessageChange: vi.fn(),
+    onSave: vi.fn(),
+    onDelete: vi.fn(),
+    onBack: vi.fn(),
+    loading: false,
+    saving: false,
+    deleting: false,
+    canEdit: false,
+    canDelete: false,
+    dirty: false,
+    messageBytes: 0,
+    messageOversize: false,
+    contractReady: true,
+    contractId: "contract-1",
+    error: null,
+    conflictWarning: null,
+    onOpenLogin: vi.fn(),
+    onOpenSettings: vi.fn(),
+    isReadOnly: false,
+    isDesktop: true,
+    ...overrides,
+  };
+  return { props, ...render(<NoteEditor {...props} />) };
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("NoteEditor read-only sign-in surface", () => {
+  it("renders a click-to-sign-in overlay over the editor body when read-only", () => {
+    const onOpenLogin = vi.fn();
+    renderEditor({ isReadOnly: true, onOpenLogin });
+
+    const overlay = screen.getByRole("button", {
+      name: /sign in to edit this note/i,
+    });
+    fireEvent.click(overlay);
+    expect(onOpenLogin).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not render the click-to-sign-in overlay in edit mode", () => {
+    renderEditor({ isReadOnly: false, canEdit: true });
+
+    expect(
+      screen.queryByRole("button", { name: /sign in to edit this note/i }),
+    ).toBeNull();
+  });
+
+  it("no longer renders the old 'Sign in to edit' toolbar button when read-only", () => {
+    renderEditor({ isReadOnly: true });
+
+    // The old button name was "Sign in to edit"; the overlay's aria-label is
+    // "Sign in to edit this note". Anchor the regex to avoid a substring match.
+    expect(
+      screen.queryByRole("button", { name: /^sign in to edit$/i }),
+    ).toBeNull();
+  });
+
+  it("does not render the Save button when read-only", () => {
+    renderEditor({ isReadOnly: true });
+
+    expect(screen.queryByRole("button", { name: /^save$/i })).toBeNull();
+  });
+
+  it("positions the read-only overlay above the inputs (last sibling, absolute, z-10)", () => {
+    renderEditor({ isReadOnly: true });
+
+    const overlay = screen.getByRole("button", {
+      name: /sign in to edit this note/i,
+    });
+
+    // Paint order: in a position:relative parent with two stacking-context
+    // peers at the same z-index, the later sibling wins. The overlay must be
+    // the last child of the label so clicks on the input region hit it.
+    const parent = overlay.parentElement;
+    expect(parent).not.toBeNull();
+    expect(parent?.lastElementChild).toBe(overlay);
+
+    // jsdom doesn't run layout, so we can't simulate hit-testing — verify the
+    // classes that drive stacking instead. Regressing any of these (z-index,
+    // absolute positioning, or inset) would break click capture in a browser.
+    expect(overlay.className).toMatch(/\babsolute\b/);
+    expect(overlay.className).toMatch(/\binset-0\b/);
+    expect(overlay.className).toMatch(/\bz-10\b/);
+
+    // And the disabled-input fallback: even if the overlay regresses, the
+    // underlying fields stay non-editable so clicks can't mutate state.
+    const titleInput = screen.getByLabelText(/title/i) as HTMLInputElement;
+    const bodyInput = screen.getByLabelText(/body/i) as HTMLTextAreaElement;
+    expect(titleInput.disabled).toBe(true);
+    expect(bodyInput.disabled).toBe(true);
+  });
+});

--- a/example-apps/dashnote/test/NoteJsonDrawer.test.tsx
+++ b/example-apps/dashnote/test/NoteJsonDrawer.test.tsx
@@ -1,0 +1,143 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { NoteJsonDrawer } from "../src/components/NoteJsonDrawer";
+import type { NoteRecord } from "../src/dash/queries";
+
+const note: NoteRecord = {
+  id: "note-abc",
+  ownerId: "owner-1",
+  title: "Groceries",
+  message: "milk, eggs",
+  createdAt: 1_700_000_000_000,
+  updatedAt: 1_700_000_005_000,
+  revision: 2,
+};
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("NoteJsonDrawer", () => {
+  it("renders nothing when closed", () => {
+    const { container } = render(
+      <NoteJsonDrawer
+        open={false}
+        note={note}
+        contractId="contract-1"
+        onClose={vi.fn()}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders nothing when note is null", () => {
+    const { container } = render(
+      <NoteJsonDrawer
+        open
+        note={null}
+        contractId="contract-1"
+        onClose={vi.fn()}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders the document payload as pretty JSON with revision badge", () => {
+    render(
+      <NoteJsonDrawer
+        open
+        note={note}
+        contractId="contract-1"
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText(/rev 2/)).toBeTruthy();
+    const pre = screen.getByRole("dialog").querySelector("pre");
+    expect(pre).not.toBeNull();
+    const payload = JSON.parse(pre!.textContent ?? "");
+    expect(payload).toEqual({
+      $id: "note-abc",
+      $type: "note",
+      $ownerId: "owner-1",
+      $dataContractId: "contract-1",
+      $revision: 2,
+      $createdAt: 1_700_000_000_000,
+      $updatedAt: 1_700_000_005_000,
+      title: "Groceries",
+      message: "milk, eggs",
+    });
+  });
+
+  it("calls onClose when Escape is pressed", () => {
+    const onClose = vi.fn();
+    render(
+      <NoteJsonDrawer
+        open
+        note={note}
+        contractId="contract-1"
+        onClose={onClose}
+      />,
+    );
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onClose when the scrim is clicked but not the inner panel", () => {
+    const onClose = vi.fn();
+    render(
+      <NoteJsonDrawer
+        open
+        note={note}
+        contractId="contract-1"
+        onClose={onClose}
+      />,
+    );
+
+    const dialog = screen.getByRole("dialog");
+    fireEvent.click(dialog.querySelector("aside")!);
+    expect(onClose).not.toHaveBeenCalled();
+
+    fireEvent.click(dialog);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onClose when the Close button is clicked", () => {
+    const onClose = vi.fn();
+    render(
+      <NoteJsonDrawer
+        open
+        note={note}
+        contractId="contract-1"
+        onClose={onClose}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /close/i }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("detaches the Escape listener when closed", () => {
+    const onClose = vi.fn();
+    const { rerender } = render(
+      <NoteJsonDrawer
+        open
+        note={note}
+        contractId="contract-1"
+        onClose={onClose}
+      />,
+    );
+    rerender(
+      <NoteJsonDrawer
+        open={false}
+        note={note}
+        contractId="contract-1"
+        onClose={onClose}
+      />,
+    );
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/example-apps/dashnote/test/NoteList.test.tsx
+++ b/example-apps/dashnote/test/NoteList.test.tsx
@@ -1,0 +1,103 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { NoteList } from "../src/components/NoteList";
+import type { NoteRecord } from "../src/dash/queries";
+
+const NOW = Date.now();
+
+function makeNote(overrides: Partial<NoteRecord> = {}): NoteRecord {
+  return {
+    id: "note-a",
+    ownerId: "identity-1",
+    title: "Meeting agenda",
+    message: "Draft notes for the kickoff meeting.",
+    createdAt: NOW - 60_000,
+    updatedAt: NOW - 60_000,
+    revision: 1,
+    ...overrides,
+  };
+}
+
+function renderList(notes: NoteRecord[]) {
+  return render(
+    <NoteList
+      notes={notes}
+      loading={false}
+      selectedId={null}
+      onSelect={vi.fn()}
+      onNew={vi.fn()}
+      canCreate
+    />,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("NoteList P6 row layout", () => {
+  it("renders a single relative timestamp on the right (no second mono timestamp line)", () => {
+    renderList([makeNote()]);
+
+    expect(screen.getByText(/ago|just now/i)).toBeTruthy();
+    // The old layout had a second timestamp line like "5/14/2026, 11:00 AM" —
+    // a numeric date pattern with slashes. Guard against it returning.
+    expect(screen.queryByText(/\d+\/\d+\/\d+/)).toBeNull();
+  });
+
+  it("italicizes the title when the note has no title (uses the fallback)", () => {
+    renderList([
+      makeNote({
+        id: "no-title",
+        title: null,
+        message: "Body of an untitled note",
+      }),
+      makeNote({
+        id: "titled",
+        title: "Meeting agenda",
+        message: "Body of a titled note",
+      }),
+    ]);
+
+    // The title is the .truncate element inside each row button; matching by
+    // text alone is ambiguous because the body preview repeats the fallback.
+    const fallbackTitle = screen
+      .getAllByText("Body of an untitled note")
+      .find((el) => el.className.includes("truncate"));
+    expect(fallbackTitle?.className).toMatch(/italic/);
+
+    const titled = screen.getByText("Meeting agenda");
+    expect(titled.className).not.toMatch(/italic/);
+  });
+
+  it("focuses the search input when '/' is pressed outside a text field", () => {
+    renderList([makeNote()]);
+
+    const search = screen.getByPlaceholderText(/search/i) as HTMLInputElement;
+    expect(document.activeElement).not.toBe(search);
+
+    fireEvent.keyDown(window, { key: "/" });
+
+    expect(document.activeElement).toBe(search);
+  });
+
+  it("does not steal '/' keystrokes typed inside the search input itself", () => {
+    renderList([makeNote()]);
+
+    const search = screen.getByPlaceholderText(/search/i) as HTMLInputElement;
+    search.focus();
+    const event = new KeyboardEvent("keydown", {
+      key: "/",
+      bubbles: true,
+      cancelable: true,
+    });
+    search.dispatchEvent(event);
+
+    // Listener must bail when the event originates in a text field, so the
+    // default behavior (the "/" character reaching the input) is preserved.
+    expect(event.defaultPrevented).toBe(false);
+  });
+});

--- a/example-apps/dashnote/test/NotesToolbar.test.tsx
+++ b/example-apps/dashnote/test/NotesToolbar.test.tsx
@@ -1,0 +1,45 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { NotesToolbar } from "../src/components/NotesToolbar";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("NotesToolbar", () => {
+  it("renders the title and testnet badge", () => {
+    render(<NotesToolbar title="Notes Workspace" />);
+    expect(
+      screen.getByRole("heading", { name: "Notes Workspace" }),
+    ).toBeTruthy();
+    expect(screen.getByText("testnet")).toBeTruthy();
+  });
+
+  it("omits the Activity button when onOpenActivity is undefined", () => {
+    render(<NotesToolbar title="Notes" />);
+    expect(screen.queryByRole("button", { name: /activity/i })).toBeNull();
+  });
+
+  it("renders the Activity button with a cross-platform shortcut hint", () => {
+    const onOpenActivity = vi.fn();
+    render(<NotesToolbar title="Notes" onOpenActivity={onOpenActivity} />);
+
+    const button = screen.getByRole("button", { name: /activity/i });
+    expect(button.textContent).toMatch(/⌘\/Ctrl\s*L/);
+    fireEvent.click(button);
+    expect(onOpenActivity).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders the rightSlot content", () => {
+    render(
+      <NotesToolbar
+        title="Notes"
+        rightSlot={<button type="button">Right action</button>}
+      />,
+    );
+    expect(screen.getByRole("button", { name: "Right action" })).toBeTruthy();
+  });
+});

--- a/example-apps/dashnote/test/NotesWorkspace.test.tsx
+++ b/example-apps/dashnote/test/NotesWorkspace.test.tsx
@@ -99,7 +99,7 @@ afterEach(() => {
 });
 
 describe("NotesWorkspace", () => {
-  it("shows auth gating when the session is not authenticated", () => {
+  it("shows the sign-in hero when the session is not authenticated", () => {
     mockUseSession.mockReturnValue(
       makeSession({
         status: "readonly",
@@ -113,11 +113,24 @@ describe("NotesWorkspace", () => {
       <NotesWorkspace onOpenLogin={onOpenLogin} onOpenSettings={vi.fn()} />,
     );
 
-    expect(screen.getByText(/sign in to see your notes/i)).toBeTruthy();
+    expect(
+      screen.getByText(/personal notes, stored on a public blockchain/i),
+    ).toBeTruthy();
+    expect(
+      screen.getByText(/dashnote stores notes against your testnet identity/i),
+    ).toBeTruthy();
+    // The old EmptyState copy must not regress alongside the new hero.
+    expect(screen.queryByText(/sign in to see your notes/i)).toBeNull();
+
     const loginButton = screen.getByRole("button", { name: /^sign in$/i });
     fireEvent.click(loginButton);
     expect(onOpenLogin).toHaveBeenCalled();
     expect(screen.queryByRole("button", { name: /new note/i })).toBeNull();
+
+    const sourceLink = screen.getByRole("link", { name: /view source/i });
+    expect(sourceLink.getAttribute("href")).toBe(
+      "https://github.com/dashpay/platform-tutorials/tree/main/example-apps/dashnote",
+    );
 
     const bridgeLink = screen.getByRole("link", { name: /dash bridge/i });
     expect(bridgeLink.getAttribute("href")).toBe(

--- a/example-apps/dashnote/test/NotesWorkspace.test.tsx
+++ b/example-apps/dashnote/test/NotesWorkspace.test.tsx
@@ -258,7 +258,7 @@ describe("NotesWorkspace", () => {
     const updated = { ...note, title: "Edited", updatedAt: 3000, revision: 3 };
     mockListMyNotes.mockResolvedValue([note]);
     mockGetNote.mockResolvedValueOnce(note).mockResolvedValueOnce(updated);
-    mockUpdateNote.mockResolvedValue(undefined);
+    mockUpdateNote.mockResolvedValue(3n);
     mockDeleteNote.mockResolvedValue(undefined);
 
     render(<NotesWorkspace onOpenLogin={vi.fn()} onOpenSettings={vi.fn()} />);
@@ -457,7 +457,7 @@ describe("NotesWorkspace", () => {
         .mockResolvedValue(remote); // post-success reload
       mockUpdateNote
         .mockRejectedValueOnce(new Error("Identity nonce is stale"))
-        .mockResolvedValue(undefined);
+        .mockResolvedValue(3n);
 
       render(<NotesWorkspace onOpenLogin={vi.fn()} onOpenSettings={vi.fn()} />);
 
@@ -508,7 +508,7 @@ describe("NotesWorkspace", () => {
       mockGetNote
         .mockResolvedValueOnce(initial) // initial detail load
         .mockResolvedValue(saved); // post-save reload
-      mockUpdateNote.mockResolvedValue(undefined);
+      mockUpdateNote.mockResolvedValue(2n);
 
       render(<NotesWorkspace onOpenLogin={vi.fn()} onOpenSettings={vi.fn()} />);
 

--- a/example-apps/dashnote/test/NotesWorkspace.test.tsx
+++ b/example-apps/dashnote/test/NotesWorkspace.test.tsx
@@ -201,6 +201,49 @@ describe("NotesWorkspace", () => {
     expect(screen.getByText(/0 notes/i)).toBeTruthy();
   });
 
+  it("in browsing mode, the desktop 'Sign in to create' button opens the login modal", async () => {
+    mockUseSession.mockReturnValue(
+      makeSession({
+        status: "browsing",
+        keyManager: null,
+      }),
+    );
+    mockListMyNotes.mockResolvedValue([]);
+
+    const onOpenLogin = vi.fn();
+    render(
+      <NotesWorkspace onOpenLogin={onOpenLogin} onOpenSettings={vi.fn()} />,
+    );
+
+    const desktopButton = await screen.findByRole("button", {
+      name: /sign in to create/i,
+    });
+    fireEvent.click(desktopButton);
+    expect(onOpenLogin).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole("button", { name: /^new note$/i })).toBeNull();
+  });
+
+  it("in browsing mode, the mobile compose '+' button also opens the login modal", async () => {
+    mockUseSession.mockReturnValue(
+      makeSession({
+        status: "browsing",
+        keyManager: null,
+      }),
+    );
+    mockListMyNotes.mockResolvedValue([]);
+
+    const onOpenLogin = vi.fn();
+    render(
+      <NotesWorkspace onOpenLogin={onOpenLogin} onOpenSettings={vi.fn()} />,
+    );
+
+    const composeButton = await screen.findByRole("button", {
+      name: /compose note/i,
+    });
+    fireEvent.click(composeButton);
+    expect(onOpenLogin).toHaveBeenCalledTimes(1);
+  });
+
   it("updates an existing note and shows delete flow", async () => {
     mockUseSession.mockReturnValue(makeSession());
     const note = {

--- a/example-apps/dashnote/test/SessionContext.test.tsx
+++ b/example-apps/dashnote/test/SessionContext.test.tsx
@@ -647,4 +647,98 @@ describe("SessionProvider", () => {
       expect.stringContaining("checksum"),
     );
   });
+
+  describe("activity log", () => {
+    it("appends entries with default info level and a generated id", () => {
+      const ref = mountSession();
+      expect(ref.current.activityLog).toEqual([]);
+
+      act(() => {
+        ref.current.log("hello");
+      });
+
+      expect(ref.current.activityLog).toHaveLength(1);
+      const [entry] = ref.current.activityLog;
+      expect(entry.message).toBe("hello");
+      expect(entry.level).toBe("info");
+      expect(entry.detail).toBeUndefined();
+      expect(typeof entry.id).toBe("string");
+      expect(entry.id.length).toBeGreaterThan(0);
+      expect(typeof entry.timestamp).toBe("number");
+    });
+
+    it("accepts the legacy string-level call shape", () => {
+      const ref = mountSession();
+      act(() => {
+        ref.current.log("done", "success");
+      });
+      expect(ref.current.activityLog[0].level).toBe("success");
+    });
+
+    it("accepts the object-form call shape and carries detail", () => {
+      const ref = mountSession();
+      act(() => {
+        ref.current.log("saving", { level: "info", detail: "documents.get" });
+      });
+      const [entry] = ref.current.activityLog;
+      expect(entry.level).toBe("info");
+      expect(entry.detail).toBe("documents.get");
+    });
+
+    it("prepends new entries so the newest is first", () => {
+      const ref = mountSession();
+      act(() => {
+        ref.current.log("first");
+      });
+      act(() => {
+        ref.current.log("second");
+      });
+      expect(ref.current.activityLog.map((e) => e.message)).toEqual([
+        "second",
+        "first",
+      ]);
+    });
+
+    it("caps the log at ACTIVITY_LOG_LIMIT (200) entries", () => {
+      const ref = mountSession();
+      act(() => {
+        for (let i = 0; i < 205; i += 1) ref.current.log(`msg-${i}`);
+      });
+      expect(ref.current.activityLog).toHaveLength(200);
+      // Newest first; oldest five (msg-0..msg-4) should have been evicted.
+      expect(ref.current.activityLog[0].message).toBe("msg-204");
+      expect(
+        ref.current.activityLog.find((e) => e.message === "msg-4"),
+      ).toBeUndefined();
+      expect(
+        ref.current.activityLog.find((e) => e.message === "msg-5"),
+      ).toBeDefined();
+    });
+
+    it("clearActivityLog empties the log", () => {
+      const ref = mountSession();
+      act(() => {
+        ref.current.log("a");
+        ref.current.log("b");
+      });
+      expect(ref.current.activityLog).toHaveLength(2);
+      act(() => {
+        ref.current.clearActivityLog();
+      });
+      expect(ref.current.activityLog).toEqual([]);
+    });
+
+    it("fires toast.success and toast.error matching the log level", () => {
+      const ref = mountSession();
+      act(() => {
+        ref.current.log("ok", "success");
+        ref.current.log("nope", "error");
+        ref.current.log("info-line");
+      });
+      expect(mockToastSuccess).toHaveBeenCalledWith("ok");
+      expect(mockToastError).toHaveBeenCalledWith("nope");
+      expect(mockToastSuccess).toHaveBeenCalledTimes(1);
+      expect(mockToastError).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/example-apps/dashnote/test/e2e/auth.spec.ts
+++ b/example-apps/dashnote/test/e2e/auth.spec.ts
@@ -14,7 +14,7 @@ test.describe.configure({ mode: "serial" });
 // Each test starts from a clean session: no remembered identity, no
 // contract override. The base `page` fixture in fixtures.ts already
 // waits for the SDK to connect on `/`, so the IdentityCard renders
-// "Connected" (readonly) by default.
+// "Guest" (readonly) by default with the subtitle "Connected".
 test.beforeEach(async ({ page }) => {
   await page.evaluate(() => {
     try {
@@ -25,9 +25,11 @@ test.beforeEach(async ({ page }) => {
     }
   });
   await page.reload();
-  await expect(page.locator(".conn-dot.connected").first()).toBeVisible({
-    timeout: 60_000,
-  });
+  await expect(
+    page
+      .locator('aside[aria-label="Main navigation"]')
+      .getByText("Connected", { exact: true }),
+  ).toBeVisible({ timeout: 60_000 });
 });
 
 test("login with a mnemonic, then logout via the IdentityCard menu", async ({
@@ -38,13 +40,19 @@ test("login with a mnemonic, then logout via the IdentityCard menu", async ({
   await openIdentityMenu(page);
   await page.getByRole("menuitem", { name: /^log out$/i }).click();
 
-  // No remembered identity → session drops back to readonly. The readonly
-  // IdentityCard paints "Connected" twice: once as the eyebrow label
-  // above the card, and once as the inline status text next to the
-  // connection dot — hence count=2, not 1.
+  // No remembered identity → session drops back to readonly. The
+  // readonly IdentityCard paints "Guest" as the eyebrow and "Connected"
+  // as the subtitle.
   await expect(
-    page.locator('aside[aria-label="Main navigation"]').getByText("Connected"),
-  ).toHaveCount(2, { timeout: 30_000 });
+    page
+      .locator('aside[aria-label="Main navigation"]')
+      .getByText("Guest", { exact: true }),
+  ).toBeVisible({ timeout: 30_000 });
+  await expect(
+    page
+      .locator('aside[aria-label="Main navigation"]')
+      .getByText("Connected", { exact: true }),
+  ).toBeVisible();
 });
 
 test("remember-me persists the identity hint across reloads", async ({
@@ -56,7 +64,7 @@ test("remember-me persists the identity hint across reloads", async ({
   // A fresh load drops the keyManager, so the remembered identity boots
   // into "browsing" (read-only) rather than authenticated.
   await expect(
-    page.getByText("Browsing (read-only)", { exact: true }),
+    page.getByText("Read-only access", { exact: true }),
   ).toBeVisible({ timeout: 30_000 });
 });
 
@@ -72,11 +80,13 @@ test("forget-this-device via the Settings panel drops back to readonly", async (
   // After forgetting, this session stays authenticated; the localStorage
   // hint is gone, so a reload drops to readonly (not browsing).
   await page.reload();
-  await expect(page.locator(".conn-dot.connected").first()).toBeVisible({
-    timeout: 30_000,
-  });
   await expect(
-    page.getByText("Browsing (read-only)", { exact: true }),
+    page
+      .locator('aside[aria-label="Main navigation"]')
+      .getByText("Connected", { exact: true }),
+  ).toBeVisible({ timeout: 30_000 });
+  await expect(
+    page.getByText("Read-only access", { exact: true }),
   ).toBeHidden();
 });
 
@@ -110,7 +120,7 @@ test("Settings tab is reachable from both the IdentityCard menu and the sidebar 
   // handles the mobile drawer open dance.
   await (await navButton(page, /how it works/i)).click();
   await expect(
-    page.getByRole("heading", { name: /How Dashnote works/i }),
+    page.getByRole("heading", { name: /walkthrough of every sdk call/i }),
   ).toBeVisible();
 
   await (await navButton(page, /settings$/i)).click();

--- a/example-apps/dashnote/test/e2e/auth.spec.ts
+++ b/example-apps/dashnote/test/e2e/auth.spec.ts
@@ -62,9 +62,13 @@ test("remember-me persists the identity hint across reloads", async ({
 
   await page.reload();
   // A fresh load drops the keyManager, so the remembered identity boots
-  // into "browsing" (read-only) rather than authenticated.
+  // into "browsing" (signed-out with identity hint) rather than
+  // authenticated. The IdentityCard renders the "Read-only access"
+  // subtitle under a "Signed out" eyebrow.
   await expect(
-    page.getByText("Read-only access", { exact: true }),
+    page
+      .locator('aside[aria-label="Main navigation"]')
+      .getByText("Read-only access", { exact: true }),
   ).toBeVisible({ timeout: 30_000 });
 });
 
@@ -86,7 +90,9 @@ test("forget-this-device via the Settings panel drops back to readonly", async (
       .getByText("Connected", { exact: true }),
   ).toBeVisible({ timeout: 30_000 });
   await expect(
-    page.getByText("Read-only access", { exact: true }),
+    page
+      .locator('aside[aria-label="Main navigation"]')
+      .getByText("Read-only access", { exact: true }),
   ).toBeHidden();
 });
 

--- a/example-apps/dashnote/test/e2e/fixtures.ts
+++ b/example-apps/dashnote/test/e2e/fixtures.ts
@@ -2,11 +2,10 @@
  * Shared Playwright fixtures for dashnote E2E tests.
  *
  * Runs against real Dash Platform testnet — no SDK mocks. The base `page`
- * fixture navigates to `/` and waits for the IdentityCard's connected dot
- * (`.conn-dot.connected`) to appear so spec bodies always have a usable
- * SDK. We anchor on the dot rather than the text label because the
- * readonly card paints "Connected" twice (eyebrow + status line) which
- * would trip Playwright's strict-mode matchers.
+ * fixture navigates to `/` and waits for the IdentityCard to paint its
+ * readonly subtitle text "Connected" so spec bodies always have a usable
+ * SDK. The eyebrow above that subtitle reads "Guest" (not "Connected"),
+ * so the subtitle is uniquely identifiable inside the sidebar.
  *
  * The sidebar is rendered as `<aside aria-label="Main navigation">`, not a
  * `<nav>` landmark — scope nav-button lookups through `navButton(page, …)`
@@ -30,14 +29,15 @@ export { base as rawTest };
 export const test = base.extend<AppFixture>({
   page: async ({ page }, provide) => {
     await page.goto("/");
-    // The IdentityCard renders a `<span class="conn-dot connected">` once
-    // createClient() resolves, regardless of session.status (readonly /
-    // authenticated / browsing). Anchor the wait on the dot itself so we
-    // don't have to disambiguate between the duplicated "Connected" /
-    // eyebrow labels that the readonly card paints.
-    await expect(page.locator(".conn-dot.connected").first()).toBeVisible({
-      timeout: 60_000,
-    });
+    // The readonly IdentityCard renders the text "Connected" as its
+    // subtitle once createClient() resolves. The eyebrow above it reads
+    // "Guest", so the subtitle is uniquely identifiable inside the
+    // sidebar — anchor the boot wait on it.
+    await expect(
+      page
+        .locator('aside[aria-label="Main navigation"]')
+        .getByText("Connected", { exact: true }),
+    ).toBeVisible({ timeout: 60_000 });
     await provide(page);
   },
 });
@@ -105,7 +105,7 @@ export async function openIdentityMenu(page: Page) {
 
 /**
  * Open the LoginModal, fill the mnemonic from PLATFORM_MNEMONIC, submit,
- * and wait for the IdentityCard to report `Authenticated`.
+ * and wait for the IdentityCard to report `Full access`.
  *
  * The entry point depends on session state: in `idle/connecting/readonly`
  * the sidebar exposes a "Sign in" NavButton; in `browsing` (remembered
@@ -129,7 +129,7 @@ export async function loginViaModal(
   }
 
   const browsing = await page
-    .getByText("Browsing (read-only)", { exact: true })
+    .getByText("Read-only access", { exact: true })
     .isVisible()
     .catch(() => false);
 
@@ -152,7 +152,7 @@ export async function loginViaModal(
   await dialog.getByRole("button", { name: /^Sign in$/ }).click();
 
   await expect(dialog).toBeHidden({ timeout: 60_000 });
-  await expect(page.getByText("Authenticated", { exact: true })).toBeVisible({
+  await expect(page.getByText("Full access", { exact: true })).toBeVisible({
     timeout: 60_000,
   });
 }

--- a/example-apps/dashnote/test/e2e/fixtures.ts
+++ b/example-apps/dashnote/test/e2e/fixtures.ts
@@ -109,9 +109,9 @@ export async function openIdentityMenu(page: Page) {
  *
  * The entry point depends on session state: in `idle/connecting/readonly`
  * the sidebar exposes a "Sign in" NavButton; in `browsing` (remembered
- * identity after reload) the sidebar entry is hidden and the modal is
- * reached via the IdentityCard menu instead. We detect which surface
- * exists and use whichever one is visible.
+ * identity after reload) the sidebar entry is hidden and the IdentityCard
+ * itself opens the modal on click. We detect which surface exists and use
+ * whichever one is visible.
  *
  * Defaults to `rememberMe: false` (the modal's default is true) so tests
  * start from a clean localStorage; opt in explicitly when exercising the
@@ -129,13 +129,19 @@ export async function loginViaModal(
   }
 
   const browsing = await page
+    .locator('aside[aria-label="Main navigation"]')
     .getByText("Read-only access", { exact: true })
     .isVisible()
     .catch(() => false);
 
   if (browsing) {
-    await openIdentityMenu(page);
-    await page.getByRole("menuitem", { name: /^sign in$/i }).click();
+    // In browsing mode the IdentityCard is itself the click target; no
+    // menu opens. The card is the only sidebar button containing the
+    // "Read-only access" subtitle, so use that as the selector.
+    await page
+      .locator('aside[aria-label="Main navigation"]')
+      .locator("button", { hasText: "Read-only access" })
+      .click();
   } else {
     await (await navButton(page, /sign in$/i)).click();
   }
@@ -152,9 +158,11 @@ export async function loginViaModal(
   await dialog.getByRole("button", { name: /^Sign in$/ }).click();
 
   await expect(dialog).toBeHidden({ timeout: 60_000 });
-  await expect(page.getByText("Full access", { exact: true })).toBeVisible({
-    timeout: 60_000,
-  });
+  await expect(
+    page
+      .locator('aside[aria-label="Main navigation"]')
+      .getByText("Full access", { exact: true }),
+  ).toBeVisible({ timeout: 60_000 });
 }
 
 /**

--- a/example-apps/dashnote/test/e2e/notes.spec.ts
+++ b/example-apps/dashnote/test/e2e/notes.spec.ts
@@ -217,7 +217,9 @@ test("two contexts can sequentially save the same note without conflict", async 
     // subtitle as the readiness gate.
     await page2.reload();
     await expect(
-      page2.getByText("Read-only access", { exact: true }),
+      page2
+        .locator('aside[aria-label="Main navigation"]')
+        .getByText("Read-only access", { exact: true }),
     ).toBeVisible({ timeout: 60_000 });
     await loginViaModal(page2, { rememberMe: true });
     await expect(
@@ -242,7 +244,9 @@ test("two contexts can sequentially save the same note without conflict", async 
     // the browsing subtitle as the readiness gate.
     await page1.reload();
     await expect(
-      page1.getByText("Read-only access", { exact: true }),
+      page1
+        .locator('aside[aria-label="Main navigation"]')
+        .getByText("Read-only access", { exact: true }),
     ).toBeVisible({ timeout: 60_000 });
     await loginViaModal(page1, { rememberMe: true });
     await page1.locator("button", { hasText: title }).first().click();

--- a/example-apps/dashnote/test/e2e/notes.spec.ts
+++ b/example-apps/dashnote/test/e2e/notes.spec.ts
@@ -27,9 +27,11 @@ test.beforeEach(async ({ page }) => {
     }
   });
   await page.reload();
-  await expect(page.locator(".conn-dot.connected").first()).toBeVisible({
-    timeout: 60_000,
-  });
+  await expect(
+    page
+      .locator('aside[aria-label="Main navigation"]')
+      .getByText("Connected", { exact: true }),
+  ).toBeVisible({ timeout: 60_000 });
   await loginViaModal(page);
 });
 
@@ -194,9 +196,11 @@ test("two contexts can sequentially save the same note without conflict", async 
   try {
     for (const p of [page1, page2]) {
       await p.goto("/");
-      await expect(p.locator(".conn-dot.connected").first()).toBeVisible({
-        timeout: 60_000,
-      });
+      await expect(
+        p
+          .locator('aside[aria-label="Main navigation"]')
+          .getByText("Connected", { exact: true }),
+      ).toBeVisible({ timeout: 60_000 });
       await loginViaModal(p, { rememberMe: true });
     }
 
@@ -208,11 +212,13 @@ test("two contexts can sequentially save the same note without conflict", async 
 
     // Page2 needs to see the note created by page1. Reload to bypass
     // the 30s background refresh and re-login (rememberMe means the
-    // login form pre-fills with the remembered identity hint).
+    // login form pre-fills with the remembered identity hint). A
+    // remembered identity boots into browsing, so wait for that
+    // subtitle as the readiness gate.
     await page2.reload();
-    await expect(page2.locator(".conn-dot.connected").first()).toBeVisible({
-      timeout: 60_000,
-    });
+    await expect(
+      page2.getByText("Read-only access", { exact: true }),
+    ).toBeVisible({ timeout: 60_000 });
     await loginViaModal(page2, { rememberMe: true });
     await expect(
       page2.locator("button", { hasText: title }).first(),
@@ -231,11 +237,13 @@ test("two contexts can sequentially save the same note without conflict", async 
       timeout: 60_000,
     });
 
-    // Page1 reloads + re-logs to see page2's edit, then makes its own change.
+    // Page1 reloads + re-logs to see page2's edit, then makes its own
+    // change. Remembered identity → browsing on reload, so wait for
+    // the browsing subtitle as the readiness gate.
     await page1.reload();
-    await expect(page1.locator(".conn-dot.connected").first()).toBeVisible({
-      timeout: 60_000,
-    });
+    await expect(
+      page1.getByText("Read-only access", { exact: true }),
+    ).toBeVisible({ timeout: 60_000 });
     await loginViaModal(page1, { rememberMe: true });
     await page1.locator("button", { hasText: title }).first().click();
     await expect(page1.getByLabel("Body")).toHaveValue("round 2 (from page2)", {

--- a/example-apps/dashnote/test/e2e/notes.spec.ts
+++ b/example-apps/dashnote/test/e2e/notes.spec.ts
@@ -278,7 +278,7 @@ test("activity panel opens via ⌘L, lists entries, clears, and closes via Escap
   // Login alone produces several info-level log entries
   // (SessionContext.tsx logs "Connecting…", "Connected…", "Identity resolved",
   // etc.), so we don't need to save a note before opening the panel.
-  await page.keyboard.press("Meta+l");
+  await page.keyboard.press("ControlOrMeta+l");
   const dialog = page.getByRole("dialog", { name: /activity log/i });
   await expect(dialog).toBeVisible();
 

--- a/example-apps/dashnote/test/e2e/notes.spec.ts
+++ b/example-apps/dashnote/test/e2e/notes.spec.ts
@@ -271,3 +271,27 @@ test("two contexts can sequentially save the same note without conflict", async 
     await ctx2.close();
   }
 });
+
+test("activity panel opens via ⌘L, lists entries, clears, and closes via Escape", async ({
+  page,
+}) => {
+  // Login alone produces several info-level log entries
+  // (SessionContext.tsx logs "Connecting…", "Connected…", "Identity resolved",
+  // etc.), so we don't need to save a note before opening the panel.
+  await page.keyboard.press("Meta+l");
+  const dialog = page.getByRole("dialog", { name: /activity log/i });
+  await expect(dialog).toBeVisible();
+
+  // At least one log entry should be visible.
+  await expect(
+    dialog.getByText(/connected to dash platform testnet/i).first(),
+  ).toBeVisible({ timeout: 10_000 });
+
+  // Clear empties the log and renders the empty-state copy.
+  await dialog.getByRole("button", { name: /^clear$/i }).click();
+  await expect(dialog.getByText(/no activity yet/i)).toBeVisible();
+
+  // Escape detaches the dialog.
+  await page.keyboard.press("Escape");
+  await expect(dialog).toBeHidden();
+});

--- a/example-apps/dashnote/test/e2e/settings.spec.ts
+++ b/example-apps/dashnote/test/e2e/settings.spec.ts
@@ -24,9 +24,11 @@ test.describe("settings (readonly)", () => {
       }
     });
     await page.reload();
-    await expect(page.locator(".conn-dot.connected").first()).toBeVisible({
-      timeout: 60_000,
-    });
+    await expect(
+      page
+        .locator('aside[aria-label="Main navigation"]')
+        .getByText("Connected", { exact: true }),
+    ).toBeVisible({ timeout: 60_000 });
 
     // In readonly mode the IdentityCard menu trigger is absent, so reach
     // the Settings tab via the sidebar nav button instead.
@@ -52,9 +54,11 @@ test.describe("settings (authenticated)", () => {
       }
     });
     await page.reload();
-    await expect(page.locator(".conn-dot.connected").first()).toBeVisible({
-      timeout: 60_000,
-    });
+    await expect(
+      page
+        .locator('aside[aria-label="Main navigation"]')
+        .getByText("Connected", { exact: true }),
+    ).toBeVisible({ timeout: 60_000 });
     await loginViaModal(page);
   });
 

--- a/example-apps/dashnote/test/e2e/smoke.spec.ts
+++ b/example-apps/dashnote/test/e2e/smoke.spec.ts
@@ -7,10 +7,14 @@ test.describe("boot", () => {
   test("SDK connects and the IdentityCard reports a live connection", async ({
     page,
   }) => {
-    // The base fixture already waits for the connected dot. This test
-    // re-asserts the same locator so failures here flag a regression in
-    // the connection gate itself, not a downstream selector.
-    await expect(page.locator(".conn-dot.connected").first()).toBeVisible();
+    // The base fixture already waits for the readonly subtitle to paint
+    // "Connected". This test re-asserts that signal so failures here
+    // flag a regression in the connection gate itself.
+    await expect(
+      page
+        .locator('aside[aria-label="Main navigation"]')
+        .getByText("Connected", { exact: true }),
+    ).toBeVisible();
   });
 
   test("page title is Dashnote", async ({ page }) => {
@@ -29,7 +33,7 @@ test.describe("tab navigation", () => {
 
     await (await navButton(page, /how it works/i)).click();
     await expect(
-      page.getByRole("heading", { name: /How Dashnote works/i }),
+      page.getByRole("heading", { name: /walkthrough of every sdk call/i }),
     ).toBeVisible();
 
     await (await navButton(page, /notes$/i)).click();

--- a/example-apps/dashnote/test/e2e/smoke.spec.ts
+++ b/example-apps/dashnote/test/e2e/smoke.spec.ts
@@ -23,7 +23,7 @@ test.describe("tab navigation", () => {
     // Notes tab is the default.
     await expect(
       page.getByRole("heading", {
-        name: /Personal notes on Dash Platform/i,
+        name: /personal notes, stored on a public blockchain/i,
       }),
     ).toBeVisible();
 
@@ -35,7 +35,7 @@ test.describe("tab navigation", () => {
     await (await navButton(page, /notes$/i)).click();
     await expect(
       page.getByRole("heading", {
-        name: /Personal notes on Dash Platform/i,
+        name: /personal notes, stored on a public blockchain/i,
       }),
     ).toBeVisible();
   });

--- a/example-apps/dashnote/test/e2e/smoke.spec.ts
+++ b/example-apps/dashnote/test/e2e/smoke.spec.ts
@@ -72,6 +72,24 @@ test.describe("login modal", () => {
     await expect(dialog.getByPlaceholder(/mnemonic phrase|wif/i)).toBeVisible();
   });
 
+  test("Bridge card is visible when no identity is remembered", async ({
+    page,
+  }) => {
+    // localStorage is empty on a fresh boot, so the remembered-identity
+    // panel is hidden and the Bridge card surfaces in its place.
+    await (await navButton(page, /sign in$/i)).click();
+    const dialog = page.getByRole("dialog");
+    const bridgeLink = dialog.getByRole("link", {
+      name: /create one on dash bridge/i,
+    });
+    await expect(bridgeLink).toBeVisible();
+    await expect(bridgeLink).toHaveAttribute(
+      "href",
+      "https://bridge.thepasta.org/",
+    );
+    await expect(dialog.getByText(/~30 seconds/i)).toBeVisible();
+  });
+
   test("Cancel button closes the modal", async ({ page }) => {
     await (await navButton(page, /sign in$/i)).click();
     const dialog = page.getByRole("dialog");

--- a/example-apps/dashnote/test/logger.test.ts
+++ b/example-apps/dashnote/test/logger.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import { errorMessage, normalizeLogOptions } from "../src/lib/logger";
+
+describe("normalizeLogOptions", () => {
+  it("returns an empty options object when no argument is given", () => {
+    expect(normalizeLogOptions()).toEqual({});
+    expect(normalizeLogOptions(undefined)).toEqual({});
+  });
+
+  it("wraps a positional LogLevel string into the object form", () => {
+    expect(normalizeLogOptions("success")).toEqual({ level: "success" });
+    expect(normalizeLogOptions("error")).toEqual({ level: "error" });
+    expect(normalizeLogOptions("info")).toEqual({ level: "info" });
+  });
+
+  it("passes through an options object unchanged", () => {
+    const opts = { level: "error" as const, detail: "boom" };
+    expect(normalizeLogOptions(opts)).toBe(opts);
+  });
+});
+
+describe("errorMessage", () => {
+  it("returns the message of an Error instance", () => {
+    expect(errorMessage(new Error("kaboom"))).toBe("kaboom");
+  });
+
+  it("returns string errors as-is", () => {
+    expect(errorMessage("just a string")).toBe("just a string");
+  });
+
+  it("extracts message from a plain object that has one", () => {
+    expect(errorMessage({ message: "object message" })).toBe("object message");
+  });
+
+  it("JSON-stringifies plain objects without a message", () => {
+    expect(errorMessage({ code: 42 })).toBe('{"code":42}');
+  });
+
+  it("falls back to String() for non-serializable inputs", () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    expect(errorMessage(circular)).toBe(String(circular));
+  });
+
+  it("handles null and undefined safely", () => {
+    expect(errorMessage(null)).toBe("null");
+    expect(errorMessage(undefined)).toBe("undefined");
+  });
+});


### PR DESCRIPTION
## Summary
- Reworks the dashnote example app UI: adds a slim notes toolbar, editor metadata strip, and activity log panel; refreshes note list rows and selection styling.
- Adds a signed-out experience — sign-in hero with editor preview, click-to-sign-in on the read-only editor, and a Login modal with a real header and Bridge card; collapses the prior "Remembered" state into the signed-out variant.
- Rebuilds the **How it works** tab as a full tutorial-style page led by an in-page header.
- Tightens identity card status labels, centers the splash on mobile, and moves the activity-panel detail emit out of `src/dash/*` helpers so dash helpers stay UI-agnostic.

## Notable changes
- New components: `ActivityPanel`, `NotesToolbar`, `NoteJsonDrawer`
- Expanded `HowItWorks`, `NoteEditor`, `NotesWorkspace`, `LoginModal`, `IdentityCard`
- New unit tests for `ActivityPanel`, `App`, `HowItWorks`, `NoteEditor`, `NoteList`; updated e2e specs (`auth`, `notes`, `settings`, `smoke`) and fixtures to match the new UI

## Test plan
- [x] `npm run build` and `npm run test` inside `example-apps/dashnote`
- [x] Playwright e2e suite passes
- [ ] Manual: signed-out hero → click editor opens login; Bridge card visible; How it works tab renders new layout; activity log records note ops; mobile splash centered


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Activity panel with Ctrl/Cmd+L toggle and toolbar access
  * JSON document drawer for notes
  * Desktop notes toolbar and updated compose button label
  * Editor conflict warning and read‑only overlay that prompts sign‑in

* **Improvements**
  * Richer activity logging (details, timestamps, clear)
  * Updated identity UI and login modal copy
  * Reworked How‑it‑Works walkthrough and note editor metadata/actions
  * Search shortcut (/) focuses note search

* **Tests**
  * Expanded unit and e2e coverage for these flows

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dashpay/platform-tutorials/pull/83)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->