### PR TITLE
feat(dashmint-lab)!: gate minting on DashMint token burn (evo-sdk 3.1.0-dev.6)

### DIFF
--- a/example-apps/dashmint-lab/.gitignore
+++ b/example-apps/dashmint-lab/.gitignore
@@ -13,6 +13,7 @@ dist-ssr
 *.local
 
 # Artifacts
+coverage
 playwright-report/
 test-results/
 

--- a/example-apps/dashmint-lab/CLAUDE.md
+++ b/example-apps/dashmint-lab/CLAUDE.md
@@ -8,6 +8,7 @@ React + TypeScript + Vite app for minting, viewing, transferring, and trading NF
 - `npm run build` — typecheck (`tsc -b`) then bundle
 - `npm run lint` — ESLint
 - `npm run test` — Vitest suite in [test/](test/)
+- `npm run test:coverage` — Vitest with v8 coverage (text + HTML report in `coverage/`)
 - `npm run test:e2e` — Playwright suite in [test/e2e/](test/e2e/) (auto-boots Vite on :5180)
 - `npm run test:e2e:ui` — Playwright with the interactive UI runner
 - `npm run format` / `format:check` — Prettier

--- a/example-apps/dashmint-lab/CLAUDE.md
+++ b/example-apps/dashmint-lab/CLAUDE.md
@@ -15,7 +15,7 @@ React + TypeScript + Vite app for minting, viewing, transferring, and trading NF
 
 ## Architecture
 
-- **[src/dash/](src/dash/)** — one file per Platform SDK operation. Each exports an async function with a leading JSDoc block. No hooks, no wrappers — the SDK call is the function. Includes the `classifyRecipientInput` / `resolveRecipient` DPNS helpers.
+- **[src/dash/](src/dash/)** — one file per Platform SDK operation. Each exports an async function with a leading JSDoc block. No hooks, no wrappers — the SDK call is the function. Includes the `classifyRecipientInput` / `resolveRecipient` DPNS helpers and [dashMintToken.ts](src/dash/dashMintToken.ts), which holds fixed-supply token constants, token payment metadata, and balance lookup for constrained minting.
 - **Shared SDK core** — [src/dash/client.ts](src/dash/client.ts) and [src/dash/keyManager.ts](src/dash/keyManager.ts) re-export directly from `../../../../setupDashClient-core.mjs` (the canonical browser-safe core at the host repo root). No vendoring, no backport step. The `@dashevo/evo-sdk` bare specifier is aliased to the app's local copy via [vite.config.ts](vite.config.ts).
 - **[src/session/](src/session/)** — `SessionContext.tsx` provides the context (SDK, keyManager, identityId, contractId, contractOwnerId, balance, activity log) and calls `sdk.identities.balance` inline; `useSession.ts` is the consumer hook. Mnemonic lives only in the keyManager closure — never in state, never in localStorage.
 - **[src/components/](src/components/)** — standard React. Modals call `src/dash/` functions directly. Notable: [HowItWorks.tsx](src/components/HowItWorks.tsx) (static education tab), [CardArt.tsx](src/components/CardArt.tsx) (deterministic themed SVG), [OddsTable.tsx](src/components/OddsTable.tsx).
@@ -29,7 +29,8 @@ React + TypeScript + Vite app for minting, viewing, transferring, and trading NF
 
 ## SDK Patterns
 
-- **Minting**: `sdk.documents.create({ document, identityKey, signer })`
+- **Minting**: `sdk.documents.create({ document, identityKey, signer, tokenPaymentInfo })`; `card.tokenCost.create` burns 1 DashMint token, so supply is constrained by the fixed token supply.
+- **DashMint token balance**: `sdk.tokens.calculateId(contractId, 0)` + `sdk.tokens.identityBalances(identityId, [tokenId])`
 - **Transfer**: `sdk.documents.transfer({ document, recipientId, identityKey, signer })`
 - **Set price**: `sdk.documents.setPrice({ document, price: BigInt, identityKey, signer })`
 - **Purchase**: `sdk.documents.purchase({ document, buyerId, price: BigInt, identityKey, signer })`
@@ -45,11 +46,12 @@ All mutations except mint flow through [withAuthedCard.ts](src/dash/withAuthedCa
 - All document mutations (transfer, setPrice, purchase) require fetching the document first and incrementing `document.revision = BigInt(document.revision) + 1n`
 - Transfer/trade operations use AUTHENTICATION keys, not TRANSFER purpose keys — the SDK rejects TRANSFER purpose for these state transitions
 - Attack/defense are randomly generated (1–10) on mint; rarity is derived client-side in [rarity.ts](src/lib/rarity.ts) (common ≤10, rare 11–14, legendary ≥15) and is not persisted
+- Mint capacity is real, but rarity is not enforced by the contract: card creation burns one fixed-supply DashMint token, while stats/rarity are still client-generated demo data
 - Browse-only mode sets `keyManager` to null — `withAuthedCard` guards this; check session status before any write operation
 - `listMarketplaceCards` filters client-side for `$price` (no server-side trade-mode index available yet)
 - DPNS names are normalized to lowercase + `.dash` suffix before resolving; `classifyRecipientInput` distinguishes identity IDs from names by character set, not length
 - Contract ID stored in `localStorage['dashmint-lab.contractId']` (public, safe to persist); clearing falls back to `DEFAULT_CONTRACT_ID` in [contract.ts](src/dash/contract.ts) so browse-only mode always has something queryable
-- The mint tab is gated to the contract owner — non-owners see an informative overlay
+- The mint tab is login-gated. Any authenticated identity with DashMint tokens can mint; identities without tokens see minting disabled by balance state or rejected by Platform.
 - The Evo SDK WASM bundle is ~8MB; this is expected and not a build error
 - `allowJs: true` in tsconfig so TypeScript can import the JSDoc-typed `.mjs` core at the host repo root
 - Deploys to GitHub Pages via `VITE_BASE_PATH`; the workflow lives at the repo root under `.github/workflows/`

--- a/example-apps/dashmint-lab/README.md
+++ b/example-apps/dashmint-lab/README.md
@@ -33,7 +33,7 @@ npm run format:check  # Prettier (check only)
 - Write operations require a funded Platform identity; browse-only mode works without login.
 - Trading flows are easiest to test with a second funded identity.
 - The active contract ID can be swapped or a new one can be registered from Settings.
-- Minting is restricted to the contract owner by the schema (`creationRestrictionMode: 1`); non-owners see an overlay on the Mint tab.
+- Minting is gated by a fixed-supply DashMint token. Creating a card burns 1 DashMint token through `card.tokenCost.create`, so any identity with a token can mint.
 - The browser bundle is intentionally heavy because it includes the full `@dashevo/evo-sdk` (~8MB WASM).
 
 ## Platform operations at a glance
@@ -45,7 +45,8 @@ Every SDK call lives in its own file under [`src/dash/`](src/dash/). Open the fi
 | Connect to testnet   | [`src/dash/client.ts`](src/dash/client.ts)                     | `EvoSDK.testnetTrusted()` + `sdk.connect()` |
 | Derive identity keys | [`src/dash/keyManager.ts`](src/dash/keyManager.ts)             | `wallet.deriveKeyFromSeedWithPath`          |
 | Deploy card contract | [`src/dash/contract.ts`](src/dash/contract.ts)                 | `sdk.contracts.publish`                     |
-| Mint a card          | [`src/dash/mintCard.ts`](src/dash/mintCard.ts)                 | `sdk.documents.create`                      |
+| Token mint capacity  | [`src/dash/dashMintToken.ts`](src/dash/dashMintToken.ts)       | `sdk.tokens.identityBalances`               |
+| Mint a card          | [`src/dash/mintCard.ts`](src/dash/mintCard.ts)                 | `sdk.documents.create` + `tokenPaymentInfo` |
 | Transfer a card      | [`src/dash/transferCard.ts`](src/dash/transferCard.ts)         | `sdk.documents.transfer`                    |
 | Set / remove price   | [`src/dash/setPrice.ts`](src/dash/setPrice.ts)                 | `sdk.documents.setPrice`                    |
 | Purchase a card      | [`src/dash/purchaseCard.ts`](src/dash/purchaseCard.ts)         | `sdk.documents.purchase`                    |
@@ -53,11 +54,12 @@ Every SDK call lives in its own file under [`src/dash/`](src/dash/). Open the fi
 | Query cards          | [`src/dash/queries.ts`](src/dash/queries.ts)                   | `sdk.documents.query`                       |
 | Resolve DPNS name    | [`src/dash/resolveRecipient.ts`](src/dash/resolveRecipient.ts) | `sdk.dpns.resolveName`                      |
 
-Balance is fetched inline from `SessionContext` via `sdk.identities.balance(identityId)` — it's a one-liner, so there's no dedicated `src/dash/` file for it.
+Credit balance is fetched inline from `SessionContext` via `sdk.identities.balance(identityId)` — it's a one-liner, so there's no dedicated `src/dash/` file for it. DashMint token balance lives in [`src/dash/dashMintToken.ts`](src/dash/dashMintToken.ts), because it is part of the token-burn minting flow.
 
 Supporting files:
 
 - **[`src/dash/withAuthedCard.ts`](src/dash/withAuthedCard.ts)** — shared mutation prelude used by transfer, setPrice, purchase, and burn. Fetches the document, bumps its revision, and resolves the authentication signer.
+- **[`src/dash/dashMintToken.ts`](src/dash/dashMintToken.ts)** — fixed-supply DashMint token constants, token payment metadata, and balance lookup. The contract burns 1 token to create each card document.
 - **[`src/dash/classifyRecipientInput.ts`](src/dash/classifyRecipientInput.ts)** — decides whether a recipient string looks like a DPNS name or an identity ID by character set.
 - **[`src/dash/logger.ts`](src/dash/logger.ts)** — shared `Logger` type so every operation can stream progress messages to the UI.
 
@@ -65,7 +67,7 @@ Supporting files:
 
 Recommended order for understanding how the app works:
 
-1. **[`src/dash/`](src/dash/)** — start here. One file per Platform operation, each with a JSDoc block explaining what / why / which SDK method. Read [`mintCard.ts`](src/dash/mintCard.ts) first (simplest create flow), then [`withAuthedCard.ts`](src/dash/withAuthedCard.ts) (shared pattern for mutations that need the current document).
+1. **[`src/dash/`](src/dash/)** — start here. One file per Platform operation, each with a JSDoc block explaining what / why / which SDK method. Read [`contract.ts`](src/dash/contract.ts), [`dashMintToken.ts`](src/dash/dashMintToken.ts), and [`mintCard.ts`](src/dash/mintCard.ts) together to see how fixed supply, token burn, and document creation combine. Then read [`withAuthedCard.ts`](src/dash/withAuthedCard.ts) for mutations that need the current document.
 
 2. **[`src/session/SessionContext.tsx`](src/session/SessionContext.tsx)** — manages the SDK connection, identity, contract ID, contract-owner ID, credit balance, and activity log. The mnemonic never enters React state; it lives only inside the `keyManager` closure and is garbage-collected on logout. The consumer hook lives in [`useSession.ts`](src/session/useSession.ts).
 

--- a/example-apps/dashmint-lab/package-lock.json
+++ b/example-apps/dashmint-lab/package-lock.json
@@ -8,7 +8,7 @@
       "name": "dashmint-lab",
       "version": "0.0.0",
       "dependencies": {
-        "@dashevo/evo-sdk": "3.1.0-dev.1",
+        "@dashevo/evo-sdk": "3.1.0-dev.6",
         "@tailwindcss/vite": "^4.2.2",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
@@ -423,20 +423,20 @@
       }
     },
     "node_modules/@dashevo/evo-sdk": {
-      "version": "3.1.0-dev.1",
-      "resolved": "https://registry.npmjs.org/@dashevo/evo-sdk/-/evo-sdk-3.1.0-dev.1.tgz",
-      "integrity": "sha512-afVJhPXkgrg2vlLgyAgcWqUeugXhA5XkfssQZWQGNXlZkH7/22yB9sd37UX+tWtvoqEjxKzygryzTngt1SI44w==",
+      "version": "3.1.0-dev.6",
+      "resolved": "https://registry.npmjs.org/@dashevo/evo-sdk/-/evo-sdk-3.1.0-dev.6.tgz",
+      "integrity": "sha512-v5Yey90/KVipZoqiAKQjs4GFUEVFauvOC96dDA1EtRQvlJQ1zFMChngcA3TwJrFbxt1/F+xnX9Zr/GMLjyp+LQ==",
       "dependencies": {
-        "@dashevo/wasm-sdk": "3.1.0-dev.1"
+        "@dashevo/wasm-sdk": "3.1.0-dev.6"
       },
       "engines": {
         "node": ">=18.18"
       }
     },
     "node_modules/@dashevo/wasm-sdk": {
-      "version": "3.1.0-dev.1",
-      "resolved": "https://registry.npmjs.org/@dashevo/wasm-sdk/-/wasm-sdk-3.1.0-dev.1.tgz",
-      "integrity": "sha512-s4ECro2+zCehfag7XVqbxrsDqOAZN2yMIGhMNjjeFesaOqOl1bUWffs3QMtEeuMZdYtKcZxUrlKsW1KlfLN/WQ==",
+      "version": "3.1.0-dev.6",
+      "resolved": "https://registry.npmjs.org/@dashevo/wasm-sdk/-/wasm-sdk-3.1.0-dev.6.tgz",
+      "integrity": "sha512-fe0qrv6DcZapsAI+WBeYnzjFDhxhEPK1IdiSVxbEe/6P1JWYZ83/dzN1g4Y+h/UdxIjFeLhattfSuKowxucLfA==",
       "engines": {
         "node": ">=18.18"
       }

--- a/example-apps/dashmint-lab/package-lock.json
+++ b/example-apps/dashmint-lab/package-lock.json
@@ -23,6 +23,7 @@
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.1",
+        "@vitest/coverage-v8": "^4.1.5",
         "dotenv": "^17.3.1",
         "eslint": "^9.39.4",
         "eslint-plugin-react-hooks": "^7.0.1",
@@ -190,9 +191,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -200,9 +201,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -234,13 +235,13 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
-      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -294,17 +295,27 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@csstools/color-helpers": {
@@ -1732,17 +1743,48 @@
         }
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.7.tgz",
+      "integrity": "sha512-qsYPeXc5Q9dFLd1i8Ap+Bx8sQgcp+rFVQo4R0dDsWNBzl26ldVF1qOO+RL24K7FDrR6pA+50XedRLSoSG24bVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.7",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.7",
+        "vitest": "4.1.7"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
-      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.7.tgz",
+      "integrity": "sha512-1R+tw0ortHEbZDGMymm+pN7/AFQ/RkFFdtd7EN+VBpynKmLbP8A3rpEXdshBJ7+8hQ9zBJh/i1s0yKNtxAnU7w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.5",
-        "@vitest/utils": "4.1.5",
+        "@vitest/spy": "4.1.7",
+        "@vitest/utils": "4.1.7",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -1751,13 +1793,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
-      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.7.tgz",
+      "integrity": "sha512-vY7nuamKgfvpA1Koa3oYIw/k7D6kZnpGyNMZW8loow2bsBYla1TFdqTaXncWdRn4pgwNs+90RhnXhJScDwQeJA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.5",
+        "@vitest/spy": "4.1.7",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -1778,9 +1820,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
-      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.7.tgz",
+      "integrity": "sha512-umgCarTOYQWIaDMvGDRZij+6b9oVeLIyJzfN+AS88e0ZOU3QTgNNSTtjQOpcvWr3np1N0j4WgZj+sb3oYBDscw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1791,13 +1833,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
-      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.7.tgz",
+      "integrity": "sha512-BapjmAQ2aI78WdMEfeUWivnfVzB+VPGwWRQcJE0OUq7qEeEcBsCSf+0T5iREBNE5nBb4wA5Ya0W6IA+sghdEFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.5",
+        "@vitest/utils": "4.1.7",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -1805,14 +1847,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
-      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.7.tgz",
+      "integrity": "sha512-ZacLzja+TmJeZ1h14xW2FB/WpeimUD3haBXQPyJqxvo8jQTmfeA8zv58mtjN2C7EHXZDYVcVYdYmAxjkWVvKCw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.5",
-        "@vitest/utils": "4.1.5",
+        "@vitest/pretty-format": "4.1.7",
+        "@vitest/utils": "4.1.7",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -1821,9 +1863,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
-      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.7.tgz",
+      "integrity": "sha512-kbkI5LMWakyuTIvs6fUJ5qdIVb1XVKsYJAT4OJ938cHMROYMSfmoQdZy0aaAnjbbc8F61vkoTqz/Az+/HiIu5Q==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1831,13 +1873,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
-      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.7.tgz",
+      "integrity": "sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.5",
+        "@vitest/pretty-format": "4.1.7",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -1949,6 +1991,25 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.2.tgz",
+      "integrity": "sha512-dKmJxJsGItLmc5CYZKuEjuG6GnBs6PG4gohMhyFOWKaNQoYCuRZJDECaBlHmcG0lv2wc2E0uU8lESmBEumC3DQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -2682,6 +2743,13 @@
         "node": ">=18"
       }
     },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -2796,6 +2864,45 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/jiti": {
       "version": "2.6.1",
@@ -3237,6 +3344,47 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
+      "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.3",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/minimatch": {
@@ -4093,19 +4241,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
-      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.7.tgz",
+      "integrity": "sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.5",
-        "@vitest/mocker": "4.1.5",
-        "@vitest/pretty-format": "4.1.5",
-        "@vitest/runner": "4.1.5",
-        "@vitest/snapshot": "4.1.5",
-        "@vitest/spy": "4.1.5",
-        "@vitest/utils": "4.1.5",
+        "@vitest/expect": "4.1.7",
+        "@vitest/mocker": "4.1.7",
+        "@vitest/pretty-format": "4.1.7",
+        "@vitest/runner": "4.1.7",
+        "@vitest/snapshot": "4.1.7",
+        "@vitest/spy": "4.1.7",
+        "@vitest/utils": "4.1.7",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -4133,12 +4281,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.5",
-        "@vitest/browser-preview": "4.1.5",
-        "@vitest/browser-webdriverio": "4.1.5",
-        "@vitest/coverage-istanbul": "4.1.5",
-        "@vitest/coverage-v8": "4.1.5",
-        "@vitest/ui": "4.1.5",
+        "@vitest/browser-playwright": "4.1.7",
+        "@vitest/browser-preview": "4.1.7",
+        "@vitest/browser-webdriverio": "4.1.7",
+        "@vitest/coverage-istanbul": "4.1.7",
+        "@vitest/coverage-v8": "4.1.7",
+        "@vitest/ui": "4.1.7",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"

--- a/example-apps/dashmint-lab/package.json
+++ b/example-apps/dashmint-lab/package.json
@@ -12,6 +12,7 @@
     "format:check": "prettier --check .",
     "lint": "eslint .",
     "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "preview": "vite preview"
@@ -33,6 +34,7 @@
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
+    "@vitest/coverage-v8": "^4.1.5",
     "eslint": "^9.39.4",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.5.2",

--- a/example-apps/dashmint-lab/package.json
+++ b/example-apps/dashmint-lab/package.json
@@ -17,7 +17,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@dashevo/evo-sdk": "3.1.0-dev.1",
+    "@dashevo/evo-sdk": "3.1.0-dev.6",
     "@tailwindcss/vite": "^4.2.2",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",

--- a/example-apps/dashmint-lab/public/dashmint-lite.html
+++ b/example-apps/dashmint-lab/public/dashmint-lite.html
@@ -121,9 +121,10 @@
     // identically against the same testnet contract.
     import { EvoSDK } from 'https://esm.sh/@dashevo/evo-sdk@3.1.0-dev.1';
 
-    // The "card" data contract is already published on testnet by the React app.
-    // Anyone querying with the same contract id hits the same documents.
-    const CONTRACT_ID = '4eJR4pgV9mQdyoodfTTwFUp3SYBRJbUrJ5X1ViN2zBhY';
+    // The token-enabled "card" data contract is already published on testnet by
+    // the React app. Anyone querying with the same contract id hits the same
+    // documents.
+    const CONTRACT_ID = 'k4FEoJPLGtoF6S36sLvQy11Jcqfm8WyMKtfVRYtE9sE';
     const DOC_TYPE = 'card';
 
     // Connect to testnet. testnetTrusted() uses the SDK's bundled list of trusted

--- a/example-apps/dashmint-lab/public/dashmint-lite.html
+++ b/example-apps/dashmint-lab/public/dashmint-lite.html
@@ -124,7 +124,7 @@
     // The token-enabled "card" data contract is already published on testnet by
     // the React app. Anyone querying with the same contract id hits the same
     // documents.
-    const CONTRACT_ID = 'k4FEoJPLGtoF6S36sLvQy11Jcqfm8WyMKtfVRYtE9sE';
+    const CONTRACT_ID = 'GDBN1h52Zcs8hSSKBoz67WDyWmUwcRyCSJjXBgKPty94';
     const DOC_TYPE = 'card';
 
     // Connect to testnet. testnetTrusted() uses the SDK's bundled list of trusted

--- a/example-apps/dashmint-lab/public/dashmint-lite.html
+++ b/example-apps/dashmint-lab/public/dashmint-lite.html
@@ -119,7 +119,7 @@
     // package and serves it as a browser-native ES module. Pinned to the same
     // version the React app at ../package.json depends on so both UIs behave
     // identically against the same testnet contract.
-    import { EvoSDK } from 'https://esm.sh/@dashevo/evo-sdk@3.1.0-dev.1';
+    import { EvoSDK } from 'https://esm.sh/@dashevo/evo-sdk@3.1.0-dev.6';
 
     // The token-enabled "card" data contract is already published on testnet by
     // the React app. Anyone querying with the same contract id hits the same

--- a/example-apps/dashmint-lab/src/App.tsx
+++ b/example-apps/dashmint-lab/src/App.tsx
@@ -151,7 +151,8 @@ function App() {
     },
     mint: {
       title: "Mint",
-      subtitle: "Burn 1 DashMint token to create a new card document.",
+      subtitle:
+        "Create collectible cards on Dash Platform using DashMint tokens.",
     },
     "how-it-works": {
       title: "How it works",

--- a/example-apps/dashmint-lab/src/App.tsx
+++ b/example-apps/dashmint-lab/src/App.tsx
@@ -41,8 +41,8 @@ function App() {
     sdk,
     identityId,
     contractId,
-    contractOwnerId,
     balance,
+    dashMintTokenBalance,
     refreshBalance,
     log,
     browseOnly,
@@ -151,7 +151,7 @@ function App() {
     },
     mint: {
       title: "Mint",
-      subtitle: "Create a new card document on the contract.",
+      subtitle: "Burn 1 DashMint token to create a new card document.",
     },
     "how-it-works": {
       title: "How it works",
@@ -253,7 +253,7 @@ function App() {
             {status !== "authenticated" && (
               <div className="absolute inset-0 z-10 flex flex-col items-center justify-center gap-3 rounded-lg bg-bg/55 backdrop-blur-sm">
                 <p className="text-sm text-ink-2">
-                  Login as contract owner to access this feature
+                  Login to burn DashMint tokens and create cards
                 </p>
                 <button
                   type="button"
@@ -264,28 +264,13 @@ function App() {
                 </button>
               </div>
             )}
-            {/* Overlay: logged in but not the contract owner */}
-            {status === "authenticated" &&
-              contractOwnerId &&
-              identityId !== contractOwnerId && (
-                <div className="absolute inset-0 z-10 flex flex-col items-center justify-center gap-3 rounded-lg bg-bg/55 backdrop-blur-sm">
-                  <p className="max-w-sm text-center text-sm text-ink-2">
-                    Only the contract owner can mint new cards. Register your
-                    own new contract in Settings to try this feature.
-                  </p>
-                  <button
-                    type="button"
-                    onClick={() => setLoginOpen(true)}
-                    className="rounded-md bg-accent px-6 py-2.5 text-sm font-semibold text-bg transition hover:bg-accent-dim"
-                  >
-                    Settings
-                  </button>
-                </div>
-              )}
-
             {contractId && (
               <div className="mx-auto max-w-[540px]">
-                <MintForm contractId={contractId} onMinted={refresh} />
+                <MintForm
+                  contractId={contractId}
+                  dashMintTokenBalance={dashMintTokenBalance}
+                  onMinted={refresh}
+                />
               </div>
             )}
           </section>

--- a/example-apps/dashmint-lab/src/App.tsx
+++ b/example-apps/dashmint-lab/src/App.tsx
@@ -13,7 +13,10 @@ import { useSession } from "./session/useSession";
 import { AppShell } from "./components/AppShell";
 import { BurnModal } from "./components/BurnModal";
 import { CardGrid } from "./components/CardGrid";
-import { CollectionToolbar } from "./components/CollectionToolbar";
+import {
+  CollectionToolbar,
+  RefreshSpinner,
+} from "./components/CollectionToolbar";
 import { LoginModal } from "./components/LoginModal";
 import { MintForm } from "./components/MintForm";
 import { PurchaseModal } from "./components/PurchaseModal";
@@ -58,13 +61,18 @@ function App() {
 
   const [sortKey, setSortKey] = useState<SortKey>("rarity");
 
-  const [cards, setCards] = useState<Card[]>([]);
+  const [cardsBySubTab, setCardsBySubTab] = useState<
+    Partial<Record<CollectionSubTab, Card[]>>
+  >({});
   const [loadingCards, setLoadingCards] = useState(false);
   const [refreshNonce, setRefreshNonce] = useState(0);
   const refresh = useCallback(() => {
+    setCardsBySubTab({});
     setRefreshNonce((n) => n + 1);
     refreshBalance();
   }, [refreshBalance]);
+
+  const cards = cardsBySubTab[subTab];
 
   // Auto-connect in browse-only mode so read tabs work without login.
   // Defer to the next frame so the shell paints before the SDK chunk
@@ -82,11 +90,11 @@ function App() {
   }, [status]);
 
   // Load cards for the current sub-tab whenever dependencies change.
+  // Keeps any previously-cached results visible while refetching so tab
+  // switches don't tear down the grid — only the first load shows the
+  // full "Loading…" placeholder.
   useEffect(() => {
-    if (!sdk || !contractId) {
-      setCards([]);
-      return;
-    }
+    if (!sdk || !contractId) return;
     let cancelled = false;
     (async () => {
       setLoadingCards(true);
@@ -99,11 +107,13 @@ function App() {
         } else {
           result = await listAllCards({ sdk, contractId, log });
         }
-        if (!cancelled) setCards(result);
+        if (!cancelled) {
+          setCardsBySubTab((prev) => ({ ...prev, [subTab]: result }));
+        }
       } catch (err) {
         if (!cancelled) {
           log(`Query failed: ${errorMessage(err)}`, "error");
-          setCards([]);
+          setCardsBySubTab((prev) => ({ ...prev, [subTab]: [] }));
         }
       } finally {
         if (!cancelled) setLoadingCards(false);
@@ -116,6 +126,7 @@ function App() {
 
   // Sort cards for the collection grid.
   const sortedCards = useMemo(() => {
+    if (!cards) return [];
     if (sortKey === "rarity") {
       return [...cards].sort((a, b) => {
         const sa = (a.data.attack ?? 0) + (a.data.defense ?? 0);
@@ -204,11 +215,18 @@ function App() {
         {tab === "collection" && (
           <section>
             <div className="flex items-end justify-between">
-              <SubTabs
-                value={subTab}
-                onChange={setSubTab}
-                showMy={status === "authenticated"}
-              />
+              <div className="relative">
+                <SubTabs
+                  value={subTab}
+                  onChange={setSubTab}
+                  showMy={status === "authenticated"}
+                />
+                {loadingCards && cards !== undefined && (
+                  <span className="pointer-events-none absolute top-[9px] left-full ml-3 -translate-y-1/2">
+                    <RefreshSpinner />
+                  </span>
+                )}
+              </div>
               <CollectionToolbar
                 sortLabel={SORT_LABELS[sortKey]}
                 onSortClick={() =>
@@ -220,7 +238,7 @@ function App() {
               />
             </div>
             <div className="mt-4">
-              {loadingCards ? (
+              {loadingCards && cards === undefined ? (
                 <div className="rounded-lg border border-dashed border-line px-6 py-12 text-center text-ink-4">
                   Loading…
                 </div>

--- a/example-apps/dashmint-lab/src/components/CollectionToolbar.tsx
+++ b/example-apps/dashmint-lab/src/components/CollectionToolbar.tsx
@@ -21,3 +21,13 @@ export function CollectionToolbar({
     </button>
   );
 }
+
+export function RefreshSpinner() {
+  return (
+    <span
+      aria-label="Refreshing"
+      role="status"
+      className="inline-block h-3 w-3 animate-spin rounded-full border border-ink-4 border-t-transparent"
+    />
+  );
+}

--- a/example-apps/dashmint-lab/src/components/HowItWorks.tsx
+++ b/example-apps/dashmint-lab/src/components/HowItWorks.tsx
@@ -27,7 +27,7 @@ const OPERATIONS: { op: string; file: string; method: string }[] = [
   {
     op: "Read token balance",
     file: "src/dash/dashMintToken.ts",
-    method: "sdk.tokens.identityBalances",
+    method: "sdk.tokens.calculateId → sdk.tokens.identityBalances",
   },
   {
     op: "Transfer card",

--- a/example-apps/dashmint-lab/src/components/HowItWorks.tsx
+++ b/example-apps/dashmint-lab/src/components/HowItWorks.tsx
@@ -22,7 +22,12 @@ const OPERATIONS: { op: string; file: string; method: string }[] = [
   {
     op: "Mint card",
     file: "src/dash/mintCard.ts",
-    method: "sdk.documents.create",
+    method: "sdk.documents.create + tokenPaymentInfo",
+  },
+  {
+    op: "Read token balance",
+    file: "src/dash/dashMintToken.ts",
+    method: "sdk.tokens.identityBalances",
   },
   {
     op: "Transfer card",
@@ -74,9 +79,14 @@ const COMPARISONS: { dimension: string; dash: string; ethereum: string }[] = [
   },
   {
     dimension: "Minting",
-    dash: "Create a document — one SDK call",
+    dash: "Burn 1 fixed-supply DashMint token, then create a card document",
     ethereum:
       "Upload metadata to IPFS, then call a contract function to mint a token",
+  },
+  {
+    dimension: "Supply cap",
+    dash: "The DashMint token supply caps how many card documents can be created",
+    ethereum: "Usually enforced by smart-contract mint logic",
   },
   {
     dimension: "Transfer",
@@ -110,8 +120,16 @@ const COMPARISONS: { dimension: string; dash: string; ethereum: string }[] = [
 
 const READING_ORDER = [
   {
+    file: "src/dash/contract.ts",
+    desc: "Defines the card schema, DashMint token, and one-token burn rule.",
+  },
+  {
+    file: "src/dash/dashMintToken.ts",
+    desc: "Token payment metadata and DashMint token balance lookup.",
+  },
+  {
     file: "src/dash/mintCard.ts",
-    desc: "Simplest create flow — one SDK call.",
+    desc: "Creates a card document while agreeing to burn one DashMint token.",
   },
   {
     file: "src/dash/withAuthedCard.ts",
@@ -138,7 +156,8 @@ export function HowItWorks() {
         <p className="mt-2 text-[13.5px] leading-[1.55] text-ink-2">
           DashMint Lab lets you create and trade NFT-style collectibles on Dash
           Platform. Each card is a document owned by an identity — transferable,
-          tradeable, and stored on-chain.
+          tradeable, and stored on-chain. Mint capacity is constrained by a
+          fixed-supply DashMint token.
         </p>
 
         {/* Core idea callout */}
@@ -147,11 +166,12 @@ export function HowItWorks() {
             Core idea
           </div>
           <p className="text-[13px] leading-[1.55] text-ink-2">
-            These cards aren't tokens — they're documents stored on Dash
-            Platform:
+            Cards are documents stored on Dash Platform. The DashMint token is
+            the minting resource that makes creation scarce:
           </p>
           <ul className="mt-2 list-disc space-y-1 pl-4 text-[13px] leading-[1.55] text-ink-2">
-            <li>Creating a card = creating a document</li>
+            <li>Creating a card = burning 1 DashMint token</li>
+            <li>Each successful mint creates a new card document</li>
             <li>Ownership = which identity controls that document</li>
             <li>Transfer = updating ownership via a state transition</li>
           </ul>

--- a/example-apps/dashmint-lab/src/components/LoginModal.tsx
+++ b/example-apps/dashmint-lab/src/components/LoginModal.tsx
@@ -126,7 +126,8 @@ export function LoginModal({ open, onClose }: LoginModalProps) {
               </button>
             </div>
             <p className="text-[11px] text-ink-4">
-              Register deploys a fresh NFT card contract to testnet (one-time).
+              Register deploys a fresh NFT card contract with 100 DashMint
+              tokens to testnet.
             </p>
           </div>
 

--- a/example-apps/dashmint-lab/src/components/MintForm.tsx
+++ b/example-apps/dashmint-lab/src/components/MintForm.tsx
@@ -6,15 +6,21 @@ import { useState, type FormEvent } from "react";
 import { drawStarterPack, STARTER_PACK_SIZE } from "../data/starterPack";
 import { errorMessage } from "../dash/logger";
 import { mintCard } from "../dash/mintCard";
+import { DASHMINT_TOKEN_COST } from "../dash/dashMintToken";
 import { useSession } from "../session/useSession";
 import { OddsTable } from "./OddsTable";
 
 export interface MintFormProps {
   contractId: string;
+  dashMintTokenBalance?: bigint | null;
   onMinted?: () => void;
 }
 
-export function MintForm({ contractId, onMinted }: MintFormProps) {
+export function MintForm({
+  contractId,
+  dashMintTokenBalance = null,
+  onMinted,
+}: MintFormProps) {
   const session = useSession();
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
@@ -24,7 +30,7 @@ export function MintForm({ contractId, onMinted }: MintFormProps) {
   async function handleSubmit(e: FormEvent) {
     e.preventDefault();
     if (!session.sdk || !session.keyManager) return;
-    if (submitting || mintingPack) return;
+    if (submitting || mintingPack || dashMintTokenBalance === 0n) return;
     setSubmitting(true);
     try {
       await mintCard({
@@ -46,7 +52,14 @@ export function MintForm({ contractId, onMinted }: MintFormProps) {
 
   async function handleStarterPack() {
     if (!session.sdk || !session.keyManager) return;
-    if (submitting || mintingPack) return;
+    if (
+      submitting ||
+      mintingPack ||
+      (dashMintTokenBalance !== null &&
+        dashMintTokenBalance < BigInt(STARTER_PACK_SIZE))
+    ) {
+      return;
+    }
     setMintingPack(true);
     session.log(`Minting starter pack (${STARTER_PACK_SIZE} cards)…`);
     try {
@@ -75,8 +88,22 @@ export function MintForm({ contractId, onMinted }: MintFormProps) {
         <div>
           <h2 className="text-[14px] font-semibold text-ink">New card</h2>
           <p className="mt-1 max-w-[44ch] text-[12px] leading-[1.55] text-ink-3">
-            Creates a document on the Dash Platform contract. Attack and defense
-            are randomly chosen.
+            Burn 1 DashMint token to mint a document on the Dash Platform
+            contract. Attack and defense are randomly chosen.
+          </p>
+        </div>
+
+        <div className="rounded-md border border-line bg-bg px-3 py-2">
+          <div className="text-[10px] font-semibold uppercase tracking-[0.12em] text-ink-4">
+            DashMint tokens
+          </div>
+          <div className="mt-1 font-mono text-[14px] text-ink">
+            {dashMintTokenBalance === null
+              ? "Unavailable"
+              : dashMintTokenBalance.toString()}
+          </div>
+          <p className="mt-1 text-[11px] leading-[1.45] text-ink-4">
+            Fresh contracts start with 100 DashMint tokens.
           </p>
         </div>
 
@@ -123,10 +150,16 @@ export function MintForm({ contractId, onMinted }: MintFormProps) {
 
         <button
           type="submit"
-          disabled={submitting || mintingPack || !name.trim()}
+          disabled={
+            submitting ||
+            mintingPack ||
+            !name.trim() ||
+            (dashMintTokenBalance !== null &&
+              dashMintTokenBalance < DASHMINT_TOKEN_COST)
+          }
           className="h-10 rounded-md bg-accent px-[18px] text-[13px] font-semibold text-bg transition hover:bg-accent-dim disabled:cursor-not-allowed disabled:bg-surface-2 disabled:text-ink-4"
         >
-          {submitting ? "Minting…" : "Mint card"}
+          {submitting ? "Minting…" : "Burn 1 DashMint token"}
         </button>
       </form>
 
@@ -138,16 +171,21 @@ export function MintForm({ contractId, onMinted }: MintFormProps) {
           Starter Pack
         </h2>
         <p className="text-[12px] leading-[1.55] text-ink-3">
-          Mint a random set of {STARTER_PACK_SIZE} sample cards from the
-          tutorial card pool.
+          Burn {STARTER_PACK_SIZE} DashMint tokens to mint a random set of
+          sample cards from the tutorial card pool.
         </p>
         <button
           type="button"
           onClick={handleStarterPack}
-          disabled={submitting || mintingPack}
+          disabled={
+            submitting ||
+            mintingPack ||
+            (dashMintTokenBalance !== null &&
+              dashMintTokenBalance < BigInt(STARTER_PACK_SIZE))
+          }
           className="self-start rounded-md border border-line-2 px-4 py-2 text-[13px] font-semibold text-ink transition hover:border-accent-dim hover:text-ink disabled:cursor-not-allowed disabled:border-line disabled:text-ink-4"
         >
-          {mintingPack ? "Minting…" : "Mint Starter Pack"}
+          {mintingPack ? "Minting…" : "Burn tokens for Starter Pack"}
         </button>
       </div>
     </div>

--- a/example-apps/dashmint-lab/src/components/MintForm.tsx
+++ b/example-apps/dashmint-lab/src/components/MintForm.tsx
@@ -26,11 +26,17 @@ export function MintForm({
   const [description, setDescription] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [mintingPack, setMintingPack] = useState(false);
+  const starterPackTokenCost = BigInt(STARTER_PACK_SIZE);
+  const hasInsufficientTokensForCard =
+    dashMintTokenBalance !== null && dashMintTokenBalance < DASHMINT_TOKEN_COST;
+  const hasInsufficientTokensForStarterPack =
+    dashMintTokenBalance !== null &&
+    dashMintTokenBalance < starterPackTokenCost;
 
   async function handleSubmit(e: FormEvent) {
     e.preventDefault();
     if (!session.sdk || !session.keyManager) return;
-    if (submitting || mintingPack || dashMintTokenBalance === 0n) return;
+    if (submitting || mintingPack || hasInsufficientTokensForCard) return;
     setSubmitting(true);
     try {
       await mintCard({
@@ -52,12 +58,7 @@ export function MintForm({
 
   async function handleStarterPack() {
     if (!session.sdk || !session.keyManager) return;
-    if (
-      submitting ||
-      mintingPack ||
-      (dashMintTokenBalance !== null &&
-        dashMintTokenBalance < BigInt(STARTER_PACK_SIZE))
-    ) {
+    if (submitting || mintingPack || hasInsufficientTokensForStarterPack) {
       return;
     }
     setMintingPack(true);
@@ -88,8 +89,7 @@ export function MintForm({
         <div>
           <h2 className="text-[14px] font-semibold text-ink">New card</h2>
           <p className="mt-1 max-w-[44ch] text-[12px] leading-[1.55] text-ink-3">
-            Burn 1 DashMint token to mint a document on the Dash Platform
-            contract. Attack and defense are randomly chosen.
+            Mint a unique collectible card. Costs 1 DashMint token.
           </p>
         </div>
 
@@ -102,9 +102,15 @@ export function MintForm({
               ? "Unavailable"
               : dashMintTokenBalance.toString()}
           </div>
-          <p className="mt-1 text-[11px] leading-[1.45] text-ink-4">
-            Fresh contracts start with 100 DashMint tokens.
-          </p>
+          {dashMintTokenBalance === 0n ? (
+            <p className="mt-2 rounded-md border border-[oklch(30%_0.08_25)] bg-[oklch(22%_0.04_25)] px-3 py-2 text-[12px] font-medium leading-[1.45] text-danger">
+              You need at least 1 DashMint token to mint a card.
+            </p>
+          ) : (
+            <p className="mt-1 text-[11px] leading-[1.45] text-ink-4">
+              Fresh contracts start with 100 DashMint tokens.
+            </p>
+          )}
         </div>
 
         {/* Name field */}
@@ -154,12 +160,11 @@ export function MintForm({
             submitting ||
             mintingPack ||
             !name.trim() ||
-            (dashMintTokenBalance !== null &&
-              dashMintTokenBalance < DASHMINT_TOKEN_COST)
+            hasInsufficientTokensForCard
           }
           className="h-10 rounded-md bg-accent px-[18px] text-[13px] font-semibold text-bg transition hover:bg-accent-dim disabled:cursor-not-allowed disabled:bg-surface-2 disabled:text-ink-4"
         >
-          {submitting ? "Minting…" : "Burn 1 DashMint token"}
+          {submitting ? "Minting…" : "Mint Card"}
         </button>
       </form>
 
@@ -171,21 +176,23 @@ export function MintForm({
           Starter Pack
         </h2>
         <p className="text-[12px] leading-[1.55] text-ink-3">
-          Burn {STARTER_PACK_SIZE} DashMint tokens to mint a random set of
-          sample cards from the tutorial card pool.
+          Mint a random set of sample cards from the tutorial collection. Costs{" "}
+          {STARTER_PACK_SIZE} DashMint tokens.
         </p>
+        {hasInsufficientTokensForStarterPack && (
+          <p className="rounded-md border border-[oklch(30%_0.08_25)] bg-[oklch(22%_0.04_25)] px-3 py-2 text-[12px] font-medium leading-[1.45] text-danger">
+            You need {STARTER_PACK_SIZE} DashMint tokens to open a Starter Pack.
+          </p>
+        )}
         <button
           type="button"
           onClick={handleStarterPack}
           disabled={
-            submitting ||
-            mintingPack ||
-            (dashMintTokenBalance !== null &&
-              dashMintTokenBalance < BigInt(STARTER_PACK_SIZE))
+            submitting || mintingPack || hasInsufficientTokensForStarterPack
           }
           className="self-start rounded-md border border-line-2 px-4 py-2 text-[13px] font-semibold text-ink transition hover:border-accent-dim hover:text-ink disabled:cursor-not-allowed disabled:border-line disabled:text-ink-4"
         >
-          {mintingPack ? "Minting…" : "Burn tokens for Starter Pack"}
+          {mintingPack ? "Minting…" : "Open Starter Pack"}
         </button>
       </div>
     </div>

--- a/example-apps/dashmint-lab/src/dash/contract.ts
+++ b/example-apps/dashmint-lab/src/dash/contract.ts
@@ -9,7 +9,10 @@
  * The three flags at the top of the schema are what make this an NFT:
  *   transferable: 1         — documents can be sent to another identity (0 to disable)
  *   tradeMode: 1            — documents can be priced and purchased (0 to disable)
- *   creationRestrictionMode: 1 — (1 - only the contract owner can mint; 0 - anyone can mint)
+ *   creationRestrictionMode: 0 — anyone can create when they can pay tokenCost.create
+ *
+ * tokenCost.create burns 1 DashMint token, turning the fixed token
+ * supply into the maximum number of cards that can ever be minted.
  *
  * Storage helpers (loadStoredContractId, saveContractId, …) and the owner
  * lookup live in contractStorage.ts so they can be imported without
@@ -17,10 +20,27 @@
  *
  * SDK methods: new DataContract({ ... }), sdk.contracts.publish(...)
  */
-import { DataContract } from "@dashevo/evo-sdk";
+import {
+  AuthorizedActionTakers,
+  ChangeControlRules,
+  DataContract,
+  TokenConfiguration,
+  TokenConfigurationConvention,
+  TokenConfigurationLocalization,
+  TokenDistributionRules,
+  TokenKeepsHistoryRules,
+  TokenMarketplaceRules,
+  TokenTradeMode,
+} from "@dashevo/evo-sdk";
 
 import { loadStoredContractId, saveContractId } from "./contractStorage";
 import type { Logger } from "./logger";
+import {
+  DASHMINT_TOKEN_NAME,
+  DASHMINT_TOKEN_PLURAL,
+  DASHMINT_TOKEN_POSITION,
+  DASHMINT_TOKEN_SUPPLY,
+} from "./dashMintToken";
 import type { DashKeyManager, DashSdk } from "./types";
 
 export {
@@ -38,7 +58,15 @@ export const CARD_SCHEMAS = {
     canBeDeleted: true,
     transferable: 1,
     tradeMode: 1,
-    creationRestrictionMode: 1,
+    creationRestrictionMode: 0,
+    tokenCost: {
+      create: {
+        tokenPosition: DASHMINT_TOKEN_POSITION,
+        amount: 1,
+        effect: 1,
+        gasFeesPaidBy: 0,
+      },
+    },
     properties: {
       name: {
         type: "string",
@@ -75,6 +103,64 @@ export const CARD_SCHEMAS = {
   },
 } as const;
 
+export function createDashMintTokenConfiguration(ownerId: string) {
+  const contractOwner = AuthorizedActionTakers.ContractOwner();
+  const noOne = AuthorizedActionTakers.NoOne();
+
+  const ownerRules = new ChangeControlRules({
+    authorizedToMakeChange: contractOwner,
+    adminActionTakers: contractOwner,
+    isChangingAuthorizedActionTakersToNoOneAllowed: true,
+    isChangingAdminActionTakersToNoOneAllowed: true,
+    isSelfChangingAdminActionTakersAllowed: true,
+  });
+  const lockedRules = new ChangeControlRules({
+    authorizedToMakeChange: noOne,
+    adminActionTakers: noOne,
+  });
+
+  return new TokenConfiguration({
+    conventions: new TokenConfigurationConvention(
+      {
+        en: new TokenConfigurationLocalization(
+          false,
+          DASHMINT_TOKEN_NAME,
+          DASHMINT_TOKEN_PLURAL,
+        ),
+      },
+      0,
+    ),
+    conventionsChangeRules: ownerRules,
+    baseSupply: DASHMINT_TOKEN_SUPPLY,
+    maxSupply: DASHMINT_TOKEN_SUPPLY,
+    keepsHistory: new TokenKeepsHistoryRules({
+      isKeepingBurningHistory: true,
+      isKeepingTransferHistory: true,
+    }),
+    maxSupplyChangeRules: lockedRules,
+    distributionRules: new TokenDistributionRules({
+      newTokensDestinationIdentity: ownerId,
+      newTokensDestinationIdentityRules: ownerRules,
+      mintingAllowChoosingDestination: false,
+      mintingAllowChoosingDestinationRules: ownerRules,
+      perpetualDistributionRules: lockedRules,
+      changeDirectPurchasePricingRules: lockedRules,
+    }),
+    marketplaceRules: new TokenMarketplaceRules(
+      TokenTradeMode.NotTradeable(),
+      lockedRules,
+    ),
+    manualMintingRules: lockedRules,
+    manualBurningRules: lockedRules,
+    freezeRules: lockedRules,
+    unfreezeRules: lockedRules,
+    destroyFrozenFundsRules: lockedRules,
+    emergencyActionRules: lockedRules,
+    mainControlGroupCanBeModified: noOne,
+    description: "Fixed-supply DashMint token burned to mint demo cards.",
+  });
+}
+
 /**
  * Register a fresh NFT card data contract on Platform and persist its ID.
  *
@@ -96,6 +182,11 @@ export async function registerContract({
     ownerId: identity.id,
     identityNonce: (identityNonce || 0n) + 1n,
     schemas: CARD_SCHEMAS,
+    tokens: {
+      [DASHMINT_TOKEN_POSITION]: createDashMintTokenConfiguration(
+        identity.id.toString(),
+      ),
+    },
     fullValidation: true,
   });
 

--- a/example-apps/dashmint-lab/src/dash/contractStorage.ts
+++ b/example-apps/dashmint-lab/src/dash/contractStorage.ts
@@ -16,7 +16,7 @@ const STORAGE_KEY = "dashmint-lab.contractId";
  * the Settings modal or register their own.
  */
 export const DEFAULT_CONTRACT_ID =
-  "k4FEoJPLGtoF6S36sLvQy11Jcqfm8WyMKtfVRYtE9sE";
+  "GDBN1h52Zcs8hSSKBoz67WDyWmUwcRyCSJjXBgKPty94";
 
 export function loadStoredContractId(): string | null {
   return localStorage.getItem(STORAGE_KEY) ?? DEFAULT_CONTRACT_ID;

--- a/example-apps/dashmint-lab/src/dash/contractStorage.ts
+++ b/example-apps/dashmint-lab/src/dash/contractStorage.ts
@@ -11,12 +11,12 @@ const STORAGE_KEY = "dashmint-lab.contractId";
 
 /**
  * Default contract ID baked into the tutorial so browse-only mode works
- * on a fresh machine without any setup. Comes from the original
- * HTML tutorial's pre-deployed testnet contract. Users can override it
- * in the Settings modal or register their own.
+ * on a fresh machine without any setup. This is the token-enabled testnet
+ * contract used by the token-burn minting demo. Users can override it in
+ * the Settings modal or register their own.
  */
 export const DEFAULT_CONTRACT_ID =
-  "4eJR4pgV9mQdyoodfTTwFUp3SYBRJbUrJ5X1ViN2zBhY";
+  "k4FEoJPLGtoF6S36sLvQy11Jcqfm8WyMKtfVRYtE9sE";
 
 export function loadStoredContractId(): string | null {
   return localStorage.getItem(STORAGE_KEY) ?? DEFAULT_CONTRACT_ID;

--- a/example-apps/dashmint-lab/src/dash/dashMintToken.ts
+++ b/example-apps/dashmint-lab/src/dash/dashMintToken.ts
@@ -1,0 +1,40 @@
+/**
+ * DashMint token constants and helpers.
+ *
+ * The data contract defines token position 0 as a fixed-supply DashMint token.
+ * Creating a `card` document burns one token via `card.tokenCost.create`.
+ * UI code uses this file to build tokenPaymentInfo and display the signed-in
+ * identity's remaining DashMint token balance.
+ */
+import type { DashSdk } from "./types";
+
+export const DASHMINT_TOKEN_POSITION = 0;
+export const DASHMINT_TOKEN_COST = 1n;
+export const DASHMINT_TOKEN_SUPPLY = 100n;
+export const DASHMINT_TOKEN_NAME = "DashMint";
+export const DASHMINT_TOKEN_PLURAL = "DashMint";
+
+// Agreement passed to sdk.documents.create() to satisfy the contract's
+// one-token burn requirement for card creation.
+export const DASHMINT_TOKEN_PAYMENT_INFO = {
+  tokenContractPosition: DASHMINT_TOKEN_POSITION,
+  maximumTokenCost: DASHMINT_TOKEN_COST,
+  gasFeesPaidBy: "documentOwner" as const,
+};
+
+export async function fetchDashMintTokenBalance({
+  sdk,
+  contractId,
+  identityId,
+}: {
+  sdk: DashSdk;
+  contractId: string;
+  identityId: string;
+}): Promise<bigint> {
+  const tokenId = await sdk.tokens.calculateId(
+    contractId,
+    DASHMINT_TOKEN_POSITION,
+  );
+  const balances = await sdk.tokens.identityBalances(identityId, [tokenId]);
+  return balances.get(tokenId) ?? 0n;
+}

--- a/example-apps/dashmint-lab/src/dash/mintCard.ts
+++ b/example-apps/dashmint-lab/src/dash/mintCard.ts
@@ -4,11 +4,18 @@
  * Attack and defense are rolled client-side (1-10 each). Name is required,
  * description is optional.
  *
- * SDK method: sdk.documents.create({ document, identityKey, signer })
+ * Scarcity comes from the contract, not this function: the `card` document
+ * type has `tokenCost.create` configured to burn 1 token at position 0.
+ * Passing `tokenPaymentInfo` below is the caller's agreement to spend that
+ * DashMint token, so each successful document create consumes one fixed-supply
+ * token and reduces the remaining mint capacity.
+ *
+ * SDK method: sdk.documents.create({ document, identityKey, signer, tokenPaymentInfo })
  */
 import { Document } from "@dashevo/evo-sdk";
 
 import type { Logger } from "./logger";
+import { DASHMINT_TOKEN_PAYMENT_INFO } from "./dashMintToken";
 import type { DashKeyManager, DashSdk } from "./types";
 
 export interface MintCardInput {
@@ -46,7 +53,9 @@ export async function mintCard({
   const defense = card.defense ?? rollStat();
   const description = card.description?.trim();
 
-  log?.(`Minting "${name}" (ATK ${attack} / DEF ${defense})…`);
+  log?.(
+    `Burning 1 DashMint token to mint "${name}" (ATK ${attack} / DEF ${defense})…`,
+  );
 
   const { identity, identityKey, signer } = await keyManager.getAuth();
 
@@ -60,6 +69,11 @@ export async function mintCard({
     ownerId: identity.id,
   });
 
-  await sdk.documents.create({ document: doc, identityKey, signer });
+  await sdk.documents.create({
+    document: doc,
+    identityKey,
+    signer,
+    tokenPaymentInfo: DASHMINT_TOKEN_PAYMENT_INFO,
+  });
   log?.(`Card "${name}" minted!`, "success");
 }

--- a/example-apps/dashmint-lab/src/dash/types.ts
+++ b/example-apps/dashmint-lab/src/dash/types.ts
@@ -21,6 +21,20 @@ export interface DashDocumentLike {
   [key: string]: unknown;
 }
 
+export interface DashDocumentTokenPaymentInfo {
+  paymentTokenContractId?: string;
+  tokenContractPosition: number;
+  minimumTokenCost?: bigint;
+  maximumTokenCost?: bigint;
+  gasFeesPaidBy?:
+    | "documentOwner"
+    | "contractOwner"
+    | "preferContractOwner"
+    | 0
+    | 1
+    | 2;
+}
+
 export interface DashSdk {
   contracts: {
     fetch(contractId: string): Promise<{
@@ -52,6 +66,7 @@ export interface DashSdk {
       document: unknown;
       identityKey: IdentityPublicKey | undefined;
       signer: IdentitySigner;
+      tokenPaymentInfo?: DashDocumentTokenPaymentInfo;
     }): Promise<unknown>;
     transfer(args: {
       document: DashDocumentLike | undefined;
@@ -86,6 +101,13 @@ export interface DashSdk {
   identities: {
     nonce(identityId: string): Promise<bigint | null | undefined>;
     balance(identityId: string): Promise<bigint>;
+  };
+  tokens: {
+    calculateId(contractId: string, tokenPosition: number): Promise<string>;
+    identityBalances(
+      identityId: string,
+      tokenIds: string[],
+    ): Promise<Map<string, bigint>>;
   };
   dpns: {
     username(identityId: string): Promise<string | null | undefined>;

--- a/example-apps/dashmint-lab/src/session/SessionContext.tsx
+++ b/example-apps/dashmint-lab/src/session/SessionContext.tsx
@@ -31,6 +31,7 @@ import {
   saveContractId,
 } from "../dash/contractStorage";
 import { errorMessage, type Logger } from "../dash/logger";
+import { fetchDashMintTokenBalance } from "../dash/dashMintToken";
 import type { DashKeyManager, DashSdk } from "../dash/types";
 
 // The SDK + IdentityKeyManager pull in @dashevo/evo-sdk (and its ~8MB WASM
@@ -85,6 +86,9 @@ export interface SessionValue {
   /** Signed-in identity's credit balance. Null while loading or logged out. */
   balance: bigint | null;
 
+  /** Signed-in identity's DashMint token balance. Null if unavailable. */
+  dashMintTokenBalance: bigint | null;
+
   /** Refetch the balance. Called by App's `refresh` after mutations. */
   refreshBalance: () => void;
 
@@ -118,6 +122,9 @@ export function SessionProvider({ children }: { children: ReactNode }) {
   );
   const [contractOwnerId, setContractOwnerId] = useState<string | null>(null);
   const [balance, setBalance] = useState<bigint | null>(null);
+  const [dashMintTokenBalance, setDashMintTokenBalance] = useState<
+    bigint | null
+  >(null);
   const [balanceNonce, setBalanceNonce] = useState(0);
   const refreshBalance = useCallback(() => {
     setBalanceNonce((n) => n + 1);
@@ -166,6 +173,23 @@ export function SessionProvider({ children }: { children: ReactNode }) {
       cancelled = true;
     };
   }, [sdk, identityId, balanceNonce, log]);
+
+  // Fetch the signed-in identity's DashMint token balance. If the active
+  // contract does not expose the token, unavailable is represented as null.
+  useEffect(() => {
+    if (!sdk || !identityId || !contractId) return;
+    let cancelled = false;
+    fetchDashMintTokenBalance({ sdk, contractId, identityId })
+      .then((tokens) => {
+        if (!cancelled) setDashMintTokenBalance(tokens);
+      })
+      .catch(() => {
+        if (!cancelled) setDashMintTokenBalance(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [sdk, identityId, contractId, balanceNonce]);
 
   const setContractId = useCallback((id: string | null) => {
     if (id) {
@@ -227,6 +251,7 @@ export function SessionProvider({ children }: { children: ReactNode }) {
       setKeyManager(null);
       setIdentityId(null);
       setBalance(null);
+      setDashMintTokenBalance(null);
       setStatus("browsing");
       log("Browse-only mode (not logged in).", "info");
     } catch (e) {
@@ -241,6 +266,7 @@ export function SessionProvider({ children }: { children: ReactNode }) {
     setKeyManager(null);
     setIdentityId(null);
     setBalance(null);
+    setDashMintTokenBalance(null);
     setStatus(sdk ? "browsing" : "idle");
     log("Logged out.", "info");
   }, [sdk, log]);
@@ -255,6 +281,7 @@ export function SessionProvider({ children }: { children: ReactNode }) {
       contractId,
       contractOwnerId,
       balance,
+      dashMintTokenBalance,
       refreshBalance,
       setContractId,
       log,
@@ -271,6 +298,7 @@ export function SessionProvider({ children }: { children: ReactNode }) {
       contractId,
       contractOwnerId,
       balance,
+      dashMintTokenBalance,
       refreshBalance,
       setContractId,
       log,

--- a/example-apps/dashmint-lab/src/styles/globals.css
+++ b/example-apps/dashmint-lab/src/styles/globals.css
@@ -63,6 +63,12 @@ body,
   font-family: var(--font-sans);
 }
 
+/* Reserve scrollbar gutter so tabs with overflowing content don't shift
+ * the centered card grid relative to tabs that fit in the viewport. */
+html {
+  scrollbar-gutter: stable;
+}
+
 /* ── Focus ring (accessibility) ───────────────────────────────────── */
 
 :focus-visible {

--- a/example-apps/dashmint-lab/test/App.test.tsx
+++ b/example-apps/dashmint-lab/test/App.test.tsx
@@ -204,7 +204,11 @@ vi.mock("../src/components/BurnModal", () => ({
 }));
 
 vi.mock("../src/components/MintForm", () => ({
-  MintForm: () => <div>Mint Form</div>,
+  MintForm: ({
+    dashMintTokenBalance,
+  }: {
+    dashMintTokenBalance?: bigint | null;
+  }) => <div>Mint Form tokens:{String(dashMintTokenBalance)}</div>,
 }));
 
 vi.mock("../src/components/HowItWorks", () => ({
@@ -219,6 +223,7 @@ function makeSession(overrides: Partial<ReturnType<typeof makeSession>> = {}) {
     contractId: "contract-1",
     contractOwnerId: null as string | null,
     balance: null as bigint | null,
+    dashMintTokenBalance: null as bigint | null,
     refreshBalance: vi.fn(),
     log: vi.fn(),
     browseOnly: vi.fn().mockResolvedValue(undefined),
@@ -526,20 +531,21 @@ describe("App", () => {
     fireEvent.click(screen.getByRole("button", { name: "Mint Tab" }));
 
     expect(
-      screen.getByText("Login as contract owner to access this feature"),
+      screen.getByText("Login to burn DashMint tokens and create cards"),
     ).toBeTruthy();
     fireEvent.click(screen.getByRole("button", { name: "Login" }));
     expect(screen.getByTestId("login-modal").textContent).toContain(
       "open:true",
     );
-    expect(screen.getByText("Mint Form")).toBeTruthy();
+    expect(screen.getByText("Mint Form tokens:null")).toBeTruthy();
   });
 
-  it("shows the owner gate on the mint screen for authenticated non-owners", async () => {
+  it("allows authenticated non-owners to mint when they hold DashMint tokens", async () => {
     const session = makeSession({
       status: "authenticated" as const,
       identityId: "identity-1",
       contractOwnerId: "owner-2",
+      dashMintTokenBalance: 3n,
     });
     mockUseSession.mockReturnValue(session);
     mockListMyCards.mockResolvedValue([cards[1]]);
@@ -548,16 +554,10 @@ describe("App", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Mint Tab" }));
 
+    expect(screen.getByText("Mint Form tokens:3")).toBeTruthy();
     expect(
-      screen.getByText(
-        "Only the contract owner can mint new cards. Register your own new contract in Settings to try this feature.",
-      ),
-    ).toBeTruthy();
-    fireEvent.click(screen.getByRole("button", { name: "Settings" }));
-    expect(screen.getByTestId("login-modal").textContent).toContain(
-      "open:true",
-    );
-    expect(screen.getByText("Mint Form")).toBeTruthy();
+      screen.queryByText(/Only the contract owner can mint new cards/),
+    ).toBeNull();
   });
 
   it("does not show a gate on the mint screen for the contract owner", async () => {
@@ -573,9 +573,9 @@ describe("App", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Mint Tab" }));
 
-    expect(screen.getByText("Mint Form")).toBeTruthy();
+    expect(screen.getByText("Mint Form tokens:null")).toBeTruthy();
     expect(
-      screen.queryByText("Login as contract owner to access this feature"),
+      screen.queryByText("Login to burn DashMint tokens and create cards"),
     ).toBeNull();
     expect(
       screen.queryByText(/Only the contract owner can mint new cards/),

--- a/example-apps/dashmint-lab/test/MintForm.test.tsx
+++ b/example-apps/dashmint-lab/test/MintForm.test.tsx
@@ -68,7 +68,7 @@ describe("MintForm", () => {
     render(<MintForm contractId="contract-1" onMinted={vi.fn()} />);
 
     const submit = screen.getByRole("button", {
-      name: "Mint card",
+      name: "Burn 1 DashMint token",
     }) as HTMLButtonElement;
     expect(submit.disabled).toBe(true);
 
@@ -99,7 +99,9 @@ describe("MintForm", () => {
         target: { value: "Fast and bright." },
       },
     );
-    fireEvent.click(screen.getByRole("button", { name: "Mint card" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Burn 1 DashMint token" }),
+    );
 
     await waitFor(() => {
       expect(mockMintCard).toHaveBeenCalledWith({
@@ -139,7 +141,9 @@ describe("MintForm", () => {
     fireEvent.change(screen.getByPlaceholderText("e.g. Fire Dragon"), {
       target: { value: "Sky Hunter" },
     });
-    fireEvent.click(screen.getByRole("button", { name: "Mint card" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Burn 1 DashMint token" }),
+    );
 
     await waitFor(() => {
       expect(log).toHaveBeenCalledWith("Mint error: Mint failed", "error");
@@ -157,7 +161,9 @@ describe("MintForm", () => {
 
     render(<MintForm contractId="contract-1" onMinted={onMinted} />);
 
-    fireEvent.click(screen.getByRole("button", { name: "Mint Starter Pack" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Burn tokens for Starter Pack" }),
+    );
 
     await waitFor(() => {
       expect(mockMintCard).toHaveBeenCalledTimes(3);
@@ -209,7 +215,9 @@ describe("MintForm", () => {
 
     render(<MintForm contractId="contract-1" onMinted={onMinted} />);
 
-    fireEvent.click(screen.getByRole("button", { name: "Mint Starter Pack" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Burn tokens for Starter Pack" }),
+    );
 
     await waitFor(() => {
       expect(mockMintCard).toHaveBeenCalledTimes(2);
@@ -224,5 +232,36 @@ describe("MintForm", () => {
     );
     expect(log).not.toHaveBeenCalledWith("Starter pack minted!", "success");
     expect(onMinted).not.toHaveBeenCalled();
+  });
+
+  it("shows token-burn copy and disables minting when the token balance is zero", () => {
+    mockUseSession.mockReturnValue(sessionValue);
+
+    render(
+      <MintForm
+        contractId="contract-1"
+        dashMintTokenBalance={0n}
+        onMinted={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByText(/Burn 1 DashMint token to mint a document/),
+    ).toBeTruthy();
+    expect(screen.getByText("DashMint tokens")).toBeTruthy();
+    expect(screen.getByText("0")).toBeTruthy();
+
+    fireEvent.change(screen.getByPlaceholderText("e.g. Fire Dragon"), {
+      target: { value: "Sky Hunter" },
+    });
+
+    expect(
+      (
+        screen.getByRole("button", {
+          name: "Burn 1 DashMint token",
+        }) as HTMLButtonElement
+      ).disabled,
+    ).toBe(true);
+    expect(mockMintCard).not.toHaveBeenCalled();
   });
 });

--- a/example-apps/dashmint-lab/test/MintForm.test.tsx
+++ b/example-apps/dashmint-lab/test/MintForm.test.tsx
@@ -68,7 +68,7 @@ describe("MintForm", () => {
     render(<MintForm contractId="contract-1" onMinted={vi.fn()} />);
 
     const submit = screen.getByRole("button", {
-      name: "Burn 1 DashMint token",
+      name: "Mint Card",
     }) as HTMLButtonElement;
     expect(submit.disabled).toBe(true);
 
@@ -99,9 +99,7 @@ describe("MintForm", () => {
         target: { value: "Fast and bright." },
       },
     );
-    fireEvent.click(
-      screen.getByRole("button", { name: "Burn 1 DashMint token" }),
-    );
+    fireEvent.click(screen.getByRole("button", { name: "Mint Card" }));
 
     await waitFor(() => {
       expect(mockMintCard).toHaveBeenCalledWith({
@@ -141,9 +139,7 @@ describe("MintForm", () => {
     fireEvent.change(screen.getByPlaceholderText("e.g. Fire Dragon"), {
       target: { value: "Sky Hunter" },
     });
-    fireEvent.click(
-      screen.getByRole("button", { name: "Burn 1 DashMint token" }),
-    );
+    fireEvent.click(screen.getByRole("button", { name: "Mint Card" }));
 
     await waitFor(() => {
       expect(log).toHaveBeenCalledWith("Mint error: Mint failed", "error");
@@ -161,9 +157,7 @@ describe("MintForm", () => {
 
     render(<MintForm contractId="contract-1" onMinted={onMinted} />);
 
-    fireEvent.click(
-      screen.getByRole("button", { name: "Burn tokens for Starter Pack" }),
-    );
+    fireEvent.click(screen.getByRole("button", { name: "Open Starter Pack" }));
 
     await waitFor(() => {
       expect(mockMintCard).toHaveBeenCalledTimes(3);
@@ -215,9 +209,7 @@ describe("MintForm", () => {
 
     render(<MintForm contractId="contract-1" onMinted={onMinted} />);
 
-    fireEvent.click(
-      screen.getByRole("button", { name: "Burn tokens for Starter Pack" }),
-    );
+    fireEvent.click(screen.getByRole("button", { name: "Open Starter Pack" }));
 
     await waitFor(() => {
       expect(mockMintCard).toHaveBeenCalledTimes(2);
@@ -246,10 +238,20 @@ describe("MintForm", () => {
     );
 
     expect(
-      screen.getByText(/Burn 1 DashMint token to mint a document/),
+      screen.getByText(
+        /Mint a unique collectible card\. Costs 1 DashMint token\./,
+      ),
     ).toBeTruthy();
     expect(screen.getByText("DashMint tokens")).toBeTruthy();
     expect(screen.getByText("0")).toBeTruthy();
+    expect(
+      screen.getByText("You need at least 1 DashMint token to mint a card."),
+    ).toBeTruthy();
+    expect(
+      screen.getByText(
+        `You need ${STARTER_PACK_SIZE} DashMint tokens to open a Starter Pack.`,
+      ),
+    ).toBeTruthy();
 
     fireEvent.change(screen.getByPlaceholderText("e.g. Fire Dragon"), {
       target: { value: "Sky Hunter" },
@@ -258,10 +260,46 @@ describe("MintForm", () => {
     expect(
       (
         screen.getByRole("button", {
-          name: "Burn 1 DashMint token",
+          name: "Mint Card",
         }) as HTMLButtonElement
       ).disabled,
     ).toBe(true);
     expect(mockMintCard).not.toHaveBeenCalled();
+  });
+
+  it("allows a single mint but disables starter pack when balance is below pack size", () => {
+    mockUseSession.mockReturnValue(sessionValue);
+
+    render(
+      <MintForm
+        contractId="contract-1"
+        dashMintTokenBalance={1n}
+        onMinted={vi.fn()}
+      />,
+    );
+
+    fireEvent.change(screen.getByPlaceholderText("e.g. Fire Dragon"), {
+      target: { value: "Sky Hunter" },
+    });
+
+    expect(
+      (
+        screen.getByRole("button", {
+          name: "Mint Card",
+        }) as HTMLButtonElement
+      ).disabled,
+    ).toBe(false);
+    expect(
+      (
+        screen.getByRole("button", {
+          name: "Open Starter Pack",
+        }) as HTMLButtonElement
+      ).disabled,
+    ).toBe(true);
+    expect(
+      screen.getByText(
+        `You need ${STARTER_PACK_SIZE} DashMint tokens to open a Starter Pack.`,
+      ),
+    ).toBeTruthy();
   });
 });

--- a/example-apps/dashmint-lab/test/SessionContext.test.tsx
+++ b/example-apps/dashmint-lab/test/SessionContext.test.tsx
@@ -17,6 +17,8 @@ const {
   mockIdentityKeyManagerCreate,
   mockFetchContractOwnerId,
   mockFetchBalance,
+  mockCalculateTokenId,
+  mockFetchTokenBalances,
   mockLoadStoredContractId,
   mockSaveContractId,
   mockClearStoredContractId,
@@ -27,6 +29,8 @@ const {
   mockIdentityKeyManagerCreate: vi.fn(),
   mockFetchContractOwnerId: vi.fn(),
   mockFetchBalance: vi.fn(),
+  mockCalculateTokenId: vi.fn(),
+  mockFetchTokenBalances: vi.fn(),
   mockLoadStoredContractId: vi.fn(),
   mockSaveContractId: vi.fn(),
   mockClearStoredContractId: vi.fn(),
@@ -60,6 +64,10 @@ vi.mock("../src/dash/contractStorage", () => ({
 const fakeSdk = {
   sdk: "connected" as const,
   identities: { balance: mockFetchBalance, nonce: vi.fn() },
+  tokens: {
+    calculateId: mockCalculateTokenId,
+    identityBalances: mockFetchTokenBalances,
+  },
 };
 
 vi.mock("sonner", () => ({
@@ -81,6 +89,11 @@ function SessionProbe() {
       <div data-testid="owner">{session.contractOwnerId ?? ""}</div>
       <div data-testid="balance">
         {session.balance === null ? "" : session.balance.toString()}
+      </div>
+      <div data-testid="dashmint-token-balance">
+        {session.dashMintTokenBalance === null
+          ? ""
+          : session.dashMintTokenBalance.toString()}
       </div>
       <button type="button" onClick={() => session.refreshBalance()}>
         Refresh Balance
@@ -137,6 +150,10 @@ beforeEach(() => {
   mockFetchContractOwnerId.mockReset();
   mockFetchBalance.mockReset();
   mockFetchBalance.mockResolvedValue(0n);
+  mockCalculateTokenId.mockReset();
+  mockCalculateTokenId.mockResolvedValue("token-1");
+  mockFetchTokenBalances.mockReset();
+  mockFetchTokenBalances.mockResolvedValue(new Map([["token-1", 0n]]));
   mockSaveContractId.mockReset();
   mockClearStoredContractId.mockReset();
   mockToastSuccess.mockReset();
@@ -299,6 +316,28 @@ describe("SessionProvider", () => {
     expect(mockFetchBalance).toHaveBeenCalledWith("identity-456");
   });
 
+  it("fetches the DashMint token balance for the active contract", async () => {
+    mockCreateClient.mockResolvedValue(fakeSdk);
+    mockFetchContractOwnerId.mockResolvedValue("owner-123");
+    mockIdentityKeyManagerCreate.mockResolvedValue({
+      identityId: "identity-456",
+    });
+    mockFetchTokenBalances.mockResolvedValue(new Map([["token-1", 42n]]));
+
+    renderSession();
+    fireEvent.click(screen.getByRole("button", { name: "Login" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("dashmint-token-balance").textContent).toBe(
+        "42",
+      );
+    });
+    expect(mockCalculateTokenId).toHaveBeenCalledWith("stored-contract-id", 0);
+    expect(mockFetchTokenBalances).toHaveBeenCalledWith("identity-456", [
+      "token-1",
+    ]);
+  });
+
   it("clears the balance on logout", async () => {
     mockCreateClient.mockResolvedValue(fakeSdk);
     mockFetchContractOwnerId.mockResolvedValue(null);
@@ -318,6 +357,7 @@ describe("SessionProvider", () => {
     await waitFor(() => {
       expect(screen.getByTestId("balance").textContent).toBe("");
     });
+    expect(screen.getByTestId("dashmint-token-balance").textContent).toBe("");
   });
 
   it("clears the balance when transitioning from authenticated to browse-only", async () => {
@@ -340,6 +380,7 @@ describe("SessionProvider", () => {
       expect(screen.getByTestId("status").textContent).toBe("browsing");
     });
     expect(screen.getByTestId("balance").textContent).toBe("");
+    expect(screen.getByTestId("dashmint-token-balance").textContent).toBe("");
   });
 
   it("refreshBalance() re-runs the fetch", async () => {

--- a/example-apps/dashmint-lab/test/e2e/auth.spec.ts
+++ b/example-apps/dashmint-lab/test/e2e/auth.spec.ts
@@ -39,11 +39,7 @@ test.describe("Authenticated flows (auth-gated)", () => {
       .getByRole("navigation")
       .getByRole("button", { name: /mint/i })
       .click();
-    // The unauthenticated overlay is gone. (A different overlay may appear
-    // for non-contract-owners; we only assert the *unauth* one is hidden.)
-    await expect(
-      page.getByText(/login as contract owner to access this feature/i),
-    ).toBeHidden();
+    await expect(page.getByText(/login to burn dashmint tokens/i)).toBeHidden();
   });
 
   // ─── Modal smokes (open / inspect / cancel) ───────────────────────────────

--- a/example-apps/dashmint-lab/test/e2e/browse.spec.ts
+++ b/example-apps/dashmint-lab/test/e2e/browse.spec.ts
@@ -27,9 +27,7 @@ test("Mint tab shows the login overlay when not logged in", async ({
     .getByRole("navigation")
     .getByRole("button", { name: /mint/i })
     .click();
-  await expect(
-    page.getByText(/login as contract owner to access this feature/i),
-  ).toBeVisible();
+  await expect(page.getByText(/login to burn dashmint tokens/i)).toBeVisible();
 });
 
 // ─── Card rendering ────────────────────────────────────────────────────────

--- a/example-apps/dashmint-lab/test/e2e/card.spec.ts
+++ b/example-apps/dashmint-lab/test/e2e/card.spec.ts
@@ -75,9 +75,9 @@ test("Copy ID writes a 44-char document id to the clipboard", async ({
   await firstCard.getByRole("button", { name: /copy id/i }).click();
 
   const copied = await page.evaluate(() => navigator.clipboard.readText());
-  // Platform document IDs are 32-byte base58 — exactly 44 chars in the base58
-  // alphabet (no 0/O/I/l).
-  expect(copied).toMatch(/^[1-9A-HJ-NP-Za-km-z]{44}$/);
+  // Platform document IDs are 32-byte base58 — 43 or 44 chars depending on the
+  // leading byte (a 32-byte value encodes to 43.7 base58 chars on average).
+  expect(copied).toMatch(/^[1-9A-HJ-NP-Za-km-z]{43,44}$/);
 });
 
 test("Marketplace Buy button opens LoginModal when not authenticated", async ({

--- a/example-apps/dashmint-lab/test/tokenPayment.test.ts
+++ b/example-apps/dashmint-lab/test/tokenPayment.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it, vi } from "vitest";
+
+const { mockDocumentCtor } = vi.hoisted(() => ({
+  mockDocumentCtor: vi.fn(function MockDocument(
+    this: Record<string, unknown>,
+    args: Record<string, unknown>,
+  ) {
+    Object.assign(this, args);
+  }),
+}));
+
+vi.mock("@dashevo/evo-sdk", () => ({
+  Document: mockDocumentCtor,
+  DataContract: class DataContract {},
+  AuthorizedActionTakers: {
+    ContractOwner: () => ({ type: "ContractOwner" }),
+    NoOne: () => ({ type: "NoOne" }),
+  },
+  ChangeControlRules: class ChangeControlRules {
+    constructor(public options: unknown) {}
+  },
+  TokenConfiguration: class TokenConfiguration {
+    constructor(public options: unknown) {}
+  },
+  TokenConfigurationConvention: class TokenConfigurationConvention {
+    constructor(
+      public localizations: unknown,
+      public decimals: number,
+    ) {}
+  },
+  TokenConfigurationLocalization: class TokenConfigurationLocalization {
+    constructor(
+      public shouldCapitalize: boolean,
+      public singularForm: string,
+      public pluralForm: string,
+    ) {}
+  },
+  TokenDistributionRules: class TokenDistributionRules {
+    constructor(public options: unknown) {}
+  },
+  TokenKeepsHistoryRules: class TokenKeepsHistoryRules {
+    constructor(public options: unknown) {}
+  },
+  TokenMarketplaceRules: class TokenMarketplaceRules {
+    constructor(
+      public tradeMode: unknown,
+      public tradeModeChangeRules: unknown,
+    ) {}
+  },
+  TokenTradeMode: {
+    NotTradeable: () => ({ type: "NotTradeable" }),
+  },
+}));
+
+describe("token-paid minting", () => {
+  it("defines card creation as a one-token burn", async () => {
+    const { CARD_SCHEMAS } = await import("../src/dash/contract");
+    const { DASHMINT_TOKEN_POSITION } =
+      await import("../src/dash/dashMintToken");
+
+    expect(CARD_SCHEMAS.card.creationRestrictionMode).toBe(0);
+    expect(CARD_SCHEMAS.card.tokenCost.create).toEqual({
+      tokenPosition: DASHMINT_TOKEN_POSITION,
+      amount: 1,
+      effect: 1,
+      gasFeesPaidBy: 0,
+    });
+  });
+
+  it("uses Platform-valid token names without whitespace", async () => {
+    const { DASHMINT_TOKEN_NAME, DASHMINT_TOKEN_PLURAL } =
+      await import("../src/dash/dashMintToken");
+
+    expect(DASHMINT_TOKEN_NAME).toBe("DashMint");
+    expect(DASHMINT_TOKEN_PLURAL).toBe("DashMint");
+    expect(DASHMINT_TOKEN_NAME).not.toMatch(/[\s\p{C}]/u);
+    expect(DASHMINT_TOKEN_PLURAL).not.toMatch(/[\s\p{C}]/u);
+  });
+
+  it("passes tokenPaymentInfo when minting a card", async () => {
+    const { mintCard } = await import("../src/dash/mintCard");
+    const { DASHMINT_TOKEN_PAYMENT_INFO } =
+      await import("../src/dash/dashMintToken");
+    const identity = { id: "identity-1" };
+    const identityKey = { id: "key-1" };
+    const signer = { id: "signer-1" };
+    const create = vi.fn().mockResolvedValue(undefined);
+    const log = vi.fn();
+
+    await mintCard({
+      sdk: { documents: { create } } as never,
+      keyManager: {
+        async getAuth() {
+          return { identity, identityKey, signer };
+        },
+      } as never,
+      contractId: "contract-1",
+      card: { name: "Sky Hunter", description: "Fast and bright." },
+      log,
+    });
+
+    expect(mockDocumentCtor).toHaveBeenCalledWith({
+      properties: {
+        name: "Sky Hunter",
+        attack: expect.any(Number),
+        defense: expect.any(Number),
+        description: "Fast and bright.",
+      },
+      documentTypeName: "card",
+      dataContractId: "contract-1",
+      ownerId: identity.id,
+    });
+    expect(create).toHaveBeenCalledWith({
+      document: mockDocumentCtor.mock.instances[0],
+      identityKey,
+      signer,
+      tokenPaymentInfo: DASHMINT_TOKEN_PAYMENT_INFO,
+    });
+    expect(log).toHaveBeenCalledWith(
+      expect.stringContaining("Burning 1 DashMint token"),
+    );
+  });
+});

--- a/example-apps/dashmint-lab/vite.config.ts
+++ b/example-apps/dashmint-lab/vite.config.ts
@@ -39,5 +39,11 @@ export default defineConfig({
     environment: "node",
     include: ["test/**/*.test.{ts,tsx}"],
     exclude: ["test/e2e/**", "node_modules/**"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "html"],
+      include: ["src/**/*.{ts,tsx}"],
+      exclude: ["src/main.tsx", "src/**/*.d.ts"],
+    },
   },
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.1-dev",
       "license": "MIT",
       "dependencies": {
-        "@dashevo/evo-sdk": "3.1.0-dev.1",
+        "@dashevo/evo-sdk": "3.1.0-dev.6",
         "dotenv": "17.3.1"
       },
       "devDependencies": {
@@ -30,20 +30,20 @@
       }
     },
     "node_modules/@dashevo/evo-sdk": {
-      "version": "3.1.0-dev.1",
-      "resolved": "https://registry.npmjs.org/@dashevo/evo-sdk/-/evo-sdk-3.1.0-dev.1.tgz",
-      "integrity": "sha512-afVJhPXkgrg2vlLgyAgcWqUeugXhA5XkfssQZWQGNXlZkH7/22yB9sd37UX+tWtvoqEjxKzygryzTngt1SI44w==",
+      "version": "3.1.0-dev.6",
+      "resolved": "https://registry.npmjs.org/@dashevo/evo-sdk/-/evo-sdk-3.1.0-dev.6.tgz",
+      "integrity": "sha512-v5Yey90/KVipZoqiAKQjs4GFUEVFauvOC96dDA1EtRQvlJQ1zFMChngcA3TwJrFbxt1/F+xnX9Zr/GMLjyp+LQ==",
       "dependencies": {
-        "@dashevo/wasm-sdk": "3.1.0-dev.1"
+        "@dashevo/wasm-sdk": "3.1.0-dev.6"
       },
       "engines": {
         "node": ">=18.18"
       }
     },
     "node_modules/@dashevo/wasm-sdk": {
-      "version": "3.1.0-dev.1",
-      "resolved": "https://registry.npmjs.org/@dashevo/wasm-sdk/-/wasm-sdk-3.1.0-dev.1.tgz",
-      "integrity": "sha512-s4ECro2+zCehfag7XVqbxrsDqOAZN2yMIGhMNjjeFesaOqOl1bUWffs3QMtEeuMZdYtKcZxUrlKsW1KlfLN/WQ==",
+      "version": "3.1.0-dev.6",
+      "resolved": "https://registry.npmjs.org/@dashevo/wasm-sdk/-/wasm-sdk-3.1.0-dev.6.tgz",
+      "integrity": "sha512-fe0qrv6DcZapsAI+WBeYnzjFDhxhEPK1IdiSVxbEe/6P1JWYZ83/dzN1g4Y+h/UdxIjFeLhattfSuKowxucLfA==",
       "engines": {
         "node": ">=18.18"
       }
@@ -1913,17 +1913,17 @@
       "dev": true
     },
     "@dashevo/evo-sdk": {
-      "version": "3.1.0-dev.1",
-      "resolved": "https://registry.npmjs.org/@dashevo/evo-sdk/-/evo-sdk-3.1.0-dev.1.tgz",
-      "integrity": "sha512-afVJhPXkgrg2vlLgyAgcWqUeugXhA5XkfssQZWQGNXlZkH7/22yB9sd37UX+tWtvoqEjxKzygryzTngt1SI44w==",
+      "version": "3.1.0-dev.6",
+      "resolved": "https://registry.npmjs.org/@dashevo/evo-sdk/-/evo-sdk-3.1.0-dev.6.tgz",
+      "integrity": "sha512-v5Yey90/KVipZoqiAKQjs4GFUEVFauvOC96dDA1EtRQvlJQ1zFMChngcA3TwJrFbxt1/F+xnX9Zr/GMLjyp+LQ==",
       "requires": {
-        "@dashevo/wasm-sdk": "3.1.0-dev.1"
+        "@dashevo/wasm-sdk": "3.1.0-dev.6"
       }
     },
     "@dashevo/wasm-sdk": {
-      "version": "3.1.0-dev.1",
-      "resolved": "https://registry.npmjs.org/@dashevo/wasm-sdk/-/wasm-sdk-3.1.0-dev.1.tgz",
-      "integrity": "sha512-s4ECro2+zCehfag7XVqbxrsDqOAZN2yMIGhMNjjeFesaOqOl1bUWffs3QMtEeuMZdYtKcZxUrlKsW1KlfLN/WQ=="
+      "version": "3.1.0-dev.6",
+      "resolved": "https://registry.npmjs.org/@dashevo/wasm-sdk/-/wasm-sdk-3.1.0-dev.6.tgz",
+      "integrity": "sha512-fe0qrv6DcZapsAI+WBeYnzjFDhxhEPK1IdiSVxbEe/6P1JWYZ83/dzN1g4Y+h/UdxIjFeLhattfSuKowxucLfA=="
     },
     "@eslint-community/eslint-utils": {
       "version": "4.4.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/dashpay/platform-tutorials#readme",
   "dependencies": {
-    "@dashevo/evo-sdk": "3.1.0-dev.1",
+    "@dashevo/evo-sdk": "3.1.0-dev.6",
     "dotenv": "17.3.1"
   },
   "devDependencies": {

--- a/setupDashClient-core.d.mts
+++ b/setupDashClient-core.d.mts
@@ -11,6 +11,20 @@ interface ConnectedDocumentLike {
   [key: string]: unknown;
 }
 
+interface ConnectedDocumentTokenPaymentInfo {
+  paymentTokenContractId?: string;
+  tokenContractPosition: number;
+  minimumTokenCost?: bigint;
+  maximumTokenCost?: bigint;
+  gasFeesPaidBy?:
+    | "documentOwner"
+    | "contractOwner"
+    | "preferContractOwner"
+    | 0
+    | 1
+    | 2;
+}
+
 interface ConnectedDashClientLike {
   contracts: {
     fetch(contractId: string): Promise<{
@@ -46,6 +60,7 @@ interface ConnectedDashClientLike {
       document: unknown;
       identityKey: IdentityPublicKey | undefined;
       signer: IdentitySigner;
+      tokenPaymentInfo?: ConnectedDocumentTokenPaymentInfo;
     }): Promise<unknown>;
     transfer(args: {
       document: ConnectedDocumentLike | undefined;
@@ -80,6 +95,13 @@ interface ConnectedDashClientLike {
   identities: {
     nonce(identityId: string): Promise<bigint | null | undefined>;
     balance(identityId: string): Promise<bigint>;
+  };
+  tokens: {
+    calculateId(contractId: string, tokenPosition: number): Promise<string>;
+    identityBalances(
+      identityId: string,
+      tokenIds: string[],
+    ): Promise<Map<string, bigint>>;
   };
   dpns: {
     username(identityId: string): Promise<string | null | undefined>;

--- a/setupDashClient-core.mjs
+++ b/setupDashClient-core.mjs
@@ -102,6 +102,10 @@ export async function dip13KeyPath(network, identityIndex, keyIndex) {
 // SDK client helpers
 // ---------------------------------------------------------------------------
 
+// Workaround: pin platform protocol version for @dashevo/evo-sdk dev.6.
+// Remove once a fixed SDK release lands.
+export const PLATFORM_VERSION_OVERRIDE = 11;
+
 /**
  * Create and connect an EvoSDK client for the selected network.
  *
@@ -110,9 +114,11 @@ export async function dip13KeyPath(network, identityIndex, keyIndex) {
  */
 export async function createClient(network = 'testnet') {
   const factories = /** @type {Record<string, () => EvoSDK>} */ ({
-    testnet: () => EvoSDK.testnetTrusted(),
-    mainnet: () => EvoSDK.mainnetTrusted(),
-    local: () => EvoSDK.localTrusted(),
+    testnet: () =>
+      EvoSDK.testnetTrusted({ version: PLATFORM_VERSION_OVERRIDE }),
+    mainnet: () =>
+      EvoSDK.mainnetTrusted({ version: PLATFORM_VERSION_OVERRIDE }),
+    local: () => EvoSDK.localTrusted({ version: PLATFORM_VERSION_OVERRIDE }),
   });
 
   const factory = factories[network];


### PR DESCRIPTION
## Summary

- Mint flow now burns one fixed-supply **DashMint** token per card, so capacity is constrained by token supply rather than being open-ended. Identities without tokens see minting disabled.
- Bumps `@dashevo/evo-sdk` to `3.1.0-dev.6` and pins platform protocol version to 11. Extends the contract registration to declare the DashMint token and attach `tokenCost.create` to the `card` document type.
- New SDK surface in the shared core: `sdk.tokens.calculateId` / `sdk.tokens.identityBalances`, plus `documents.create({ tokenPaymentInfo })`. Type declarations in `setupDashClient-core.d.mts` and `src/dash/types.ts` updated to match.
- Session now tracks `dashMintTokenBalance` alongside credits; MintForm surfaces a token-balance warning and an `OutOfTokens` empty state. Collection sub-tabs cache cards to remove visible flicker on switch.
- E2E and Vitest suites updated: new `tokenPayment.test.ts`, MintForm balance/empty-state coverage, SessionContext token-balance assertions, and refreshed e2e overlay copy.

## Breaking changes

- **SDK bump:** `@dashevo/evo-sdk` `3.1.0-dev.1` → `3.1.0-dev.6`. Requires pinning platform protocol version to 11 ([`PLATFORM_VERSION_OVERRIDE`](setupDashClient-core.mjs#L106)) as a temporary workaround.
- **DashMint card contract reshaped:** `creationRestrictionMode` flipped from owner-only to open, and a new `tokenCost.create` rule burns 1 DashMint token per mint. Callers of `mintCard` must now pass `tokenPaymentInfo`. The contract declares a fixed-supply token at position 0.
- **Default contract ID changed:** browse-only mode now points at a token-enabled contract. Users with the old ID cached in `localStorage` will fail to mint until they clear it or pick a new contract.
- **`DashSdk` / `ConnectedDashClientLike` typings widened:** `sdk.documents.create` accepts optional `tokenPaymentInfo`; a new required `sdk.tokens` member (`calculateId`, `identityBalances`) is declared. Existing mocks/stubs implementing this interface need to add `tokens`.


## Test plan

- [x] `npm run lint` (root + `example-apps/dashmint-lab`)
- [x] `npm run build` in `example-apps/dashmint-lab`
- [x] `npm test` in `example-apps/dashmint-lab` (Vitest)
- [x] `npm run test:e2e` against testnet with a funded `PLATFORM_MNEMONIC`
- [x] Manually mint a card with token balance > 0 and confirm one token is burned
- [ ] Confirm Mint tab disables / shows OutOfTokens when token balance is 0
- [x] Verify collection sub-tabs don't flicker when switching between owned / marketplace
- [x] All tutorial level tests still pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Token-based minting: creating cards now burns a fixed-supply DashMint token.
  * Shows DashMint token balance and gates mint/starter-pack actions by balance.
  * Collection UI: per-tab caching and a refresh spinner so tabs stay visible during reloads.

* **Bug Fixes**
  * Prevented layout shifts when scrollbars appear.

* **Documentation**
  * Updated app docs and README to explain token-mint flow and UI behavior.

* **Tests**
  * Added/updated tests for token-paid minting and session/token behavior.

* **Chores**
  * SDK bump, test coverage script, and demo contract ID updated.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dashpay/platform-tutorials/pull/86?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->