### PR TITLE
test(dashnote): wait for note title to render before asserting

### DIFF
--- a/example-apps/dashnote/test/NotesWorkspace.test.tsx
+++ b/example-apps/dashnote/test/NotesWorkspace.test.tsx
@@ -650,11 +650,11 @@ describe("NotesWorkspace", () => {
       render(<NotesWorkspace onOpenLogin={vi.fn()} onOpenSettings={vi.fn()} />);
 
       await waitFor(() => {
-        expect(mockListMyNotes).toHaveBeenCalledTimes(1);
+        expect(screen.getByText(/phone note/i)).toBeTruthy();
       });
       // List rendered (note title visible) but editor body field not, since
       // no note has been selected yet on mobile.
-      expect(screen.getByText(/phone note/i)).toBeTruthy();
+      expect(mockListMyNotes).toHaveBeenCalledTimes(1);
       expect(mockGetNote).not.toHaveBeenCalled();
       expect(screen.queryByLabelText(/^body$/i)).toBeNull();
     });


### PR DESCRIPTION
The mobile auto-select test waited only for mockListMyNotes to be called, not for the resolved promise's state update to flush, so CI occasionally hit getByText while the loading spinner was still visible. Wait on the rendered title instead.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test timing assertions for improved test reliability.

**Note:** This is an internal test improvement with no end-user facing changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dashpay/platform-tutorials/pull/88?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->