### PR TITLE
feat(dashmint-lab): show mint supply, collapse form when sold out

### DIFF
--- a/example-apps/dashmint-lab/public/dashmint-lite.html
+++ b/example-apps/dashmint-lab/public/dashmint-lite.html
@@ -124,14 +124,19 @@
     // The token-enabled "card" data contract is already published on testnet by
     // the React app. Anyone querying with the same contract id hits the same
     // documents.
-    const CONTRACT_ID = 'GDBN1h52Zcs8hSSKBoz67WDyWmUwcRyCSJjXBgKPty94';
+    const CONTRACT_ID = '5hK6SMfN4m2vU1t9qhvngUUQjsXeMNwr8MZdFeGBH8Aa';
     const DOC_TYPE = 'card';
 
     // Connect to testnet. testnetTrusted() uses the SDK's bundled list of trusted
     // nodes — no node URL or config needed. connect() does the gRPC handshake
     // + initial sync. No identity or signing is required for read-only queries.
+    //
+    // Workaround: pin the platform protocol version for evo-sdk dev.6 so the
+    // SDK doesn't ask testnet for a newer protocol it can't decode. Mirrors
+    // PLATFORM_VERSION_OVERRIDE in setupDashClient-core.mjs. Remove once a
+    // fixed SDK release lands.
     async function connectSdk() {
-      const sdk = EvoSDK.testnetTrusted();
+      const sdk = EvoSDK.testnetTrusted({ version: 11 });
       await sdk.connect();
       return sdk;
     }

--- a/example-apps/dashmint-lab/src/App.tsx
+++ b/example-apps/dashmint-lab/src/App.tsx
@@ -89,6 +89,14 @@ function App() {
     else if (status === "browsing") setSubTab("all");
   }, [status]);
 
+  // Re-fetch token balance whenever the Mint tab becomes active. The balance
+  // effect in SessionContext only runs on login/logout/contract change, so
+  // without this prompt the value could be stale (read-after-write lag from
+  // a recent mint elsewhere, or simply a value from many minutes ago).
+  useEffect(() => {
+    if (tab === "mint" && status === "authenticated") refreshBalance();
+  }, [tab, status, refreshBalance]);
+
   // Load cards for the current sub-tab whenever dependencies change.
   // Keeps any previously-cached results visible while refetching so tab
   // switches don't tear down the grid — only the first load shows the

--- a/example-apps/dashmint-lab/src/components/MintForm.tsx
+++ b/example-apps/dashmint-lab/src/components/MintForm.tsx
@@ -14,6 +14,11 @@ import {
 import { useSession } from "../session/useSession";
 import { OddsTable } from "./OddsTable";
 
+// Module-level cache so the supply count survives tab unmounts. When the
+// user navigates back to Mint we render the last known value immediately
+// and silently refetch — no "—" placeholder flash.
+const mintedCountCache = new Map<string, bigint>();
+
 export interface MintFormProps {
   contractId: string;
   dashMintTokenBalance?: bigint | null;
@@ -30,7 +35,9 @@ export function MintForm({
   const [description, setDescription] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [mintingPack, setMintingPack] = useState(false);
-  const [mintedCount, setMintedCount] = useState<bigint | null>(null);
+  const [mintedCount, setMintedCount] = useState<bigint | null>(
+    () => mintedCountCache.get(contractId) ?? null,
+  );
   const starterPackTokenCost = BigInt(STARTER_PACK_SIZE);
 
   useEffect(() => {
@@ -38,10 +45,12 @@ export function MintForm({
     let cancelled = false;
     fetchCardsMintedCount({ sdk: session.sdk, contractId })
       .then((count) => {
+        mintedCountCache.set(contractId, count);
         if (!cancelled) setMintedCount(count);
       })
       .catch(() => {
-        if (!cancelled) setMintedCount(null);
+        // Keep the previous (possibly cached) value on failure so the UI
+        // doesn't regress to "—" just because a refetch hiccuped.
       });
     return () => {
       cancelled = true;

--- a/example-apps/dashmint-lab/src/components/MintForm.tsx
+++ b/example-apps/dashmint-lab/src/components/MintForm.tsx
@@ -272,7 +272,7 @@ export function MintForm({
             starterPackSoldOut ||
             hasInsufficientTokensForStarterPack
           }
-          className="self-start rounded-md border border-line-2 px-4 py-2 text-[13px] font-semibold text-ink transition hover:border-accent-dim hover:text-ink disabled:cursor-not-allowed disabled:border-line disabled:text-ink-4"
+          className="h-10 rounded-md border border-line-2 px-[18px] text-[13px] font-semibold text-ink transition hover:border-accent-dim hover:text-ink disabled:cursor-not-allowed disabled:border-line disabled:text-ink-4"
         >
           {mintingPack
             ? "Minting…"

--- a/example-apps/dashmint-lab/src/components/MintForm.tsx
+++ b/example-apps/dashmint-lab/src/components/MintForm.tsx
@@ -257,8 +257,8 @@ export function MintForm({
           Starter Pack
         </h2>
         <p className="text-[12px] leading-[1.55] text-ink-3">
-          Mint a random set of sample cards from the tutorial collection. Costs{" "}
-          {STARTER_PACK_SIZE} DashMint tokens.
+          Mint {STARTER_PACK_SIZE} random cards from the tutorial collection.
+          Costs {STARTER_PACK_SIZE} DashMint tokens (1 per card).
         </p>
         {starterPackSoldOut ? (
           <p className="rounded-md border border-[oklch(30%_0.08_25)] bg-[oklch(22%_0.04_25)] px-3 py-2 text-[12px] font-medium leading-[1.45] text-danger">

--- a/example-apps/dashmint-lab/src/components/MintForm.tsx
+++ b/example-apps/dashmint-lab/src/components/MintForm.tsx
@@ -2,11 +2,15 @@
  * Mint-a-card form. Calls src/dash/mintCard directly; session provides
  * sdk, keyManager, and the contract ID.
  */
-import { useState, type FormEvent } from "react";
+import { useEffect, useState, type FormEvent } from "react";
 import { drawStarterPack, STARTER_PACK_SIZE } from "../data/starterPack";
 import { errorMessage } from "../dash/logger";
 import { mintCard } from "../dash/mintCard";
-import { DASHMINT_TOKEN_COST } from "../dash/dashMintToken";
+import {
+  DASHMINT_TOKEN_COST,
+  DASHMINT_TOKEN_SUPPLY,
+  fetchCardsMintedCount,
+} from "../dash/dashMintToken";
 import { useSession } from "../session/useSession";
 import { OddsTable } from "./OddsTable";
 
@@ -26,17 +30,43 @@ export function MintForm({
   const [description, setDescription] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [mintingPack, setMintingPack] = useState(false);
+  const [mintedCount, setMintedCount] = useState<bigint | null>(null);
   const starterPackTokenCost = BigInt(STARTER_PACK_SIZE);
+
+  useEffect(() => {
+    if (!session.sdk) return;
+    let cancelled = false;
+    fetchCardsMintedCount({ sdk: session.sdk, contractId })
+      .then((count) => {
+        if (!cancelled) setMintedCount(count);
+      })
+      .catch(() => {
+        if (!cancelled) setMintedCount(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [session.sdk, contractId, submitting, mintingPack]);
+  const soldOut = mintedCount !== null && mintedCount >= DASHMINT_TOKEN_SUPPLY;
+  const starterPackSoldOut =
+    mintedCount !== null &&
+    DASHMINT_TOKEN_SUPPLY - mintedCount < starterPackTokenCost;
   const hasInsufficientTokensForCard =
     dashMintTokenBalance !== null && dashMintTokenBalance < DASHMINT_TOKEN_COST;
   const hasInsufficientTokensForStarterPack =
     dashMintTokenBalance !== null &&
     dashMintTokenBalance < starterPackTokenCost;
+  const mintedPercent =
+    mintedCount === null
+      ? 0
+      : Math.min(100, Number((mintedCount * 100n) / DASHMINT_TOKEN_SUPPLY));
 
   async function handleSubmit(e: FormEvent) {
     e.preventDefault();
     if (!session.sdk || !session.keyManager) return;
-    if (submitting || mintingPack || hasInsufficientTokensForCard) return;
+    if (submitting || mintingPack || soldOut || hasInsufficientTokensForCard) {
+      return;
+    }
     setSubmitting(true);
     try {
       await mintCard({
@@ -58,7 +88,12 @@ export function MintForm({
 
   async function handleStarterPack() {
     if (!session.sdk || !session.keyManager) return;
-    if (submitting || mintingPack || hasInsufficientTokensForStarterPack) {
+    if (
+      submitting ||
+      mintingPack ||
+      starterPackSoldOut ||
+      hasInsufficientTokensForStarterPack
+    ) {
       return;
     }
     setMintingPack(true);
@@ -83,6 +118,41 @@ export function MintForm({
     }
   }
 
+  const supplyBlock = (
+    <div className="rounded-md border border-line bg-bg px-3 py-2">
+      <div className="text-[10px] font-semibold uppercase tracking-[0.12em] text-ink-4">
+        Supply
+      </div>
+      <div className="mt-1 font-mono text-[14px] text-ink">
+        {mintedCount === null
+          ? "—"
+          : `${mintedCount.toString()} / ${DASHMINT_TOKEN_SUPPLY.toString()} minted`}
+      </div>
+      {mintedCount !== null && (
+        <div className="mt-2 h-1.5 overflow-hidden rounded-full bg-surface-2">
+          <div
+            className={`h-full ${soldOut ? "bg-danger" : "bg-accent"}`}
+            style={{ width: `${mintedPercent}%` }}
+          />
+        </div>
+      )}
+      {soldOut && (
+        <p className="mt-2 rounded-md border border-[oklch(30%_0.08_25)] bg-[oklch(22%_0.04_25)] px-3 py-2 text-[12px] font-medium leading-[1.45] text-danger">
+          All cards have been minted.
+        </p>
+      )}
+    </div>
+  );
+
+  if (soldOut) {
+    return (
+      <div className="flex flex-col gap-5 rounded-xl border border-line bg-surface p-5">
+        {supplyBlock}
+        <OddsTable />
+      </div>
+    );
+  }
+
   return (
     <div className="flex flex-col gap-5 rounded-xl border border-line bg-surface p-5">
       <form onSubmit={handleSubmit} className="flex flex-col gap-4">
@@ -93,9 +163,11 @@ export function MintForm({
           </p>
         </div>
 
+        {supplyBlock}
+
         <div className="rounded-md border border-line bg-bg px-3 py-2">
           <div className="text-[10px] font-semibold uppercase tracking-[0.12em] text-ink-4">
-            DashMint tokens
+            Your DashMint token balance
           </div>
           <div className="mt-1 font-mono text-[14px] text-ink">
             {dashMintTokenBalance === null
@@ -179,20 +251,34 @@ export function MintForm({
           Mint a random set of sample cards from the tutorial collection. Costs{" "}
           {STARTER_PACK_SIZE} DashMint tokens.
         </p>
-        {hasInsufficientTokensForStarterPack && (
+        {starterPackSoldOut ? (
           <p className="rounded-md border border-[oklch(30%_0.08_25)] bg-[oklch(22%_0.04_25)] px-3 py-2 text-[12px] font-medium leading-[1.45] text-danger">
-            You need {STARTER_PACK_SIZE} DashMint tokens to open a Starter Pack.
+            Not enough remaining supply for a Starter Pack.
           </p>
+        ) : (
+          hasInsufficientTokensForStarterPack && (
+            <p className="rounded-md border border-[oklch(30%_0.08_25)] bg-[oklch(22%_0.04_25)] px-3 py-2 text-[12px] font-medium leading-[1.45] text-danger">
+              You need {STARTER_PACK_SIZE} DashMint tokens to open a Starter
+              Pack.
+            </p>
+          )
         )}
         <button
           type="button"
           onClick={handleStarterPack}
           disabled={
-            submitting || mintingPack || hasInsufficientTokensForStarterPack
+            submitting ||
+            mintingPack ||
+            starterPackSoldOut ||
+            hasInsufficientTokensForStarterPack
           }
           className="self-start rounded-md border border-line-2 px-4 py-2 text-[13px] font-semibold text-ink transition hover:border-accent-dim hover:text-ink disabled:cursor-not-allowed disabled:border-line disabled:text-ink-4"
         >
-          {mintingPack ? "Minting…" : "Open Starter Pack"}
+          {mintingPack
+            ? "Minting…"
+            : starterPackSoldOut
+              ? "Sold out"
+              : "Open Starter Pack"}
         </button>
       </div>
     </div>

--- a/example-apps/dashmint-lab/src/dash/contractStorage.ts
+++ b/example-apps/dashmint-lab/src/dash/contractStorage.ts
@@ -16,7 +16,7 @@ const STORAGE_KEY = "dashmint-lab.contractId";
  * the Settings modal or register their own.
  */
 export const DEFAULT_CONTRACT_ID =
-  "GDBN1h52Zcs8hSSKBoz67WDyWmUwcRyCSJjXBgKPty94";
+  "5hK6SMfN4m2vU1t9qhvngUUQjsXeMNwr8MZdFeGBH8Aa";
 
 export function loadStoredContractId(): string | null {
   return localStorage.getItem(STORAGE_KEY) ?? DEFAULT_CONTRACT_ID;

--- a/example-apps/dashmint-lab/src/dash/dashMintToken.ts
+++ b/example-apps/dashmint-lab/src/dash/dashMintToken.ts
@@ -38,3 +38,21 @@ export async function fetchDashMintTokenBalance({
   const balances = await sdk.tokens.identityBalances(identityId, [tokenId]);
   return balances.get(tokenId) ?? 0n;
 }
+
+// Every mint burns exactly one DashMint token (manual burns/mints are locked
+// in the contract), so cards minted = SUPPLY - current circulating supply.
+export async function fetchCardsMintedCount({
+  sdk,
+  contractId,
+}: {
+  sdk: DashSdk;
+  contractId: string;
+}): Promise<bigint> {
+  const tokenId = await sdk.tokens.calculateId(
+    contractId,
+    DASHMINT_TOKEN_POSITION,
+  );
+  const supply = await sdk.tokens.totalSupply(tokenId);
+  const remaining = supply?.totalSupply ?? DASHMINT_TOKEN_SUPPLY;
+  return DASHMINT_TOKEN_SUPPLY - remaining;
+}

--- a/example-apps/dashmint-lab/src/dash/types.ts
+++ b/example-apps/dashmint-lab/src/dash/types.ts
@@ -108,6 +108,9 @@ export interface DashSdk {
       identityId: string,
       tokenIds: string[],
     ): Promise<Map<string, bigint>>;
+    totalSupply(
+      tokenId: string,
+    ): Promise<{ totalSupply: bigint; tokenId: string } | undefined>;
   };
   dpns: {
     username(identityId: string): Promise<string | null | undefined>;

--- a/example-apps/dashmint-lab/test/MintForm.test.tsx
+++ b/example-apps/dashmint-lab/test/MintForm.test.tsx
@@ -242,7 +242,7 @@ describe("MintForm", () => {
         /Mint a unique collectible card\. Costs 1 DashMint token\./,
       ),
     ).toBeTruthy();
-    expect(screen.getByText("DashMint tokens")).toBeTruthy();
+    expect(screen.getByText("Your DashMint token balance")).toBeTruthy();
     expect(screen.getByText("0")).toBeTruthy();
     expect(
       screen.getByText("You need at least 1 DashMint token to mint a card."),

--- a/example-apps/dashmint-lab/test/MintForm.test.tsx
+++ b/example-apps/dashmint-lab/test/MintForm.test.tsx
@@ -7,18 +7,22 @@ import {
   screen,
   waitFor,
 } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { MintForm } from "../src/components/MintForm";
 import type { DashKeyManager, DashSdk } from "../src/dash/types";
 
-const { mockUseSession, mockMintCard, mockDrawStarterPack } = vi.hoisted(
-  () => ({
-    mockUseSession: vi.fn(),
-    mockMintCard: vi.fn(),
-    mockDrawStarterPack: vi.fn(),
-  }),
-);
+const {
+  mockUseSession,
+  mockMintCard,
+  mockDrawStarterPack,
+  mockFetchCardsMintedCount,
+} = vi.hoisted(() => ({
+  mockUseSession: vi.fn(),
+  mockMintCard: vi.fn(),
+  mockDrawStarterPack: vi.fn(),
+  mockFetchCardsMintedCount: vi.fn(),
+}));
 
 vi.mock("../src/session/useSession", () => ({
   useSession: mockUseSession,
@@ -27,6 +31,16 @@ vi.mock("../src/session/useSession", () => ({
 vi.mock("../src/dash/mintCard", () => ({
   mintCard: mockMintCard,
 }));
+
+vi.mock("../src/dash/dashMintToken", async () => {
+  const actual = await vi.importActual<
+    typeof import("../src/dash/dashMintToken")
+  >("../src/dash/dashMintToken");
+  return {
+    ...actual,
+    fetchCardsMintedCount: mockFetchCardsMintedCount,
+  };
+});
 
 vi.mock("../src/data/starterPack", () => ({
   STARTER_PACK_SIZE: 3,
@@ -59,6 +73,14 @@ const starterPackCards = [
 afterEach(() => {
   cleanup();
   vi.clearAllMocks();
+});
+
+beforeEach(() => {
+  // Test stub: a never-resolving promise so `mintedCount` stays at its
+  // initial `null` (the "supply unknown" branch — full form visible, no
+  // sold-out gating). Tests that need a concrete count override this with
+  // `mockResolvedValueOnce(...)`.
+  mockFetchCardsMintedCount.mockReturnValue(new Promise(() => {}));
 });
 
 describe("MintForm", () => {
@@ -301,5 +323,86 @@ describe("MintForm", () => {
         `You need ${STARTER_PACK_SIZE} DashMint tokens to open a Starter Pack.`,
       ),
     ).toBeTruthy();
+  });
+
+  it("shows the supply count and progress once the minted count loads", async () => {
+    mockUseSession.mockReturnValue(sessionValue);
+    mockFetchCardsMintedCount.mockResolvedValueOnce(42n);
+
+    render(
+      <MintForm
+        contractId="contract-1"
+        dashMintTokenBalance={5n}
+        onMinted={vi.fn()}
+      />,
+    );
+
+    expect(await screen.findByText("42 / 100 minted")).toBeTruthy();
+    // Mint form still rendered while supply remains.
+    expect(screen.getByRole("button", { name: "Mint Card" })).toBeTruthy();
+  });
+
+  it("collapses to the supply notice and hides the form when sold out", async () => {
+    mockUseSession.mockReturnValue(sessionValue);
+    mockFetchCardsMintedCount.mockResolvedValueOnce(100n);
+
+    render(
+      <MintForm
+        contractId="contract-1"
+        dashMintTokenBalance={0n}
+        onMinted={vi.fn()}
+      />,
+    );
+
+    expect(await screen.findByText("100 / 100 minted")).toBeTruthy();
+    expect(screen.getByText("All cards have been minted.")).toBeTruthy();
+
+    // Form, token-balance block, and both mint buttons should be gone.
+    expect(screen.queryByRole("button", { name: "Mint Card" })).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: "Open Starter Pack" }),
+    ).toBeNull();
+    expect(screen.queryByPlaceholderText("e.g. Fire Dragon")).toBeNull();
+    expect(screen.queryByText("Your DashMint token balance")).toBeNull();
+    expect(
+      screen.queryByText("You need at least 1 DashMint token to mint a card."),
+    ).toBeNull();
+  });
+
+  it("disables the starter pack when fewer than pack-size mints remain", async () => {
+    mockUseSession.mockReturnValue(sessionValue);
+    // 2 mints left, pack size is 3.
+    mockFetchCardsMintedCount.mockResolvedValueOnce(98n);
+
+    render(
+      <MintForm
+        contractId="contract-1"
+        dashMintTokenBalance={10n}
+        onMinted={vi.fn()}
+      />,
+    );
+
+    expect(await screen.findByText("98 / 100 minted")).toBeTruthy();
+    expect(
+      screen.getByText("Not enough remaining supply for a Starter Pack."),
+    ).toBeTruthy();
+    expect(
+      (
+        screen.getByRole("button", {
+          name: "Sold out",
+        }) as HTMLButtonElement
+      ).disabled,
+    ).toBe(true);
+    // Single-card mint is still available once the name is filled in.
+    fireEvent.change(screen.getByPlaceholderText("e.g. Fire Dragon"), {
+      target: { value: "Sky Hunter" },
+    });
+    expect(
+      (
+        screen.getByRole("button", {
+          name: "Mint Card",
+        }) as HTMLButtonElement
+      ).disabled,
+    ).toBe(false);
   });
 });

--- a/example-apps/dashmint-lab/test/e2e/browse.spec.ts
+++ b/example-apps/dashmint-lab/test/e2e/browse.spec.ts
@@ -190,13 +190,23 @@ test("Price sort puts the highest-priced card first in the Marketplace", async (
 
   const inspect = Math.min(count, 8);
   const prices: number[] = [];
+  const SUFFIX_SCALE: Record<string, number> = {
+    K: 1e3,
+    M: 1e6,
+    B: 1e9,
+    T: 1e12,
+    Q: 1e15,
+  };
   for (let i = 0; i < inspect; i += 1) {
     const text = await cards.nth(i).innerText();
-    const match = text.match(/([\d,]+)\s*cr/);
+    // Matches both `1,234 cr` and compact forms like `999.9B cr`.
+    const match = text.match(/([\d,]+(?:\.\d+)?)\s*([KMBTQ])?\s*cr/);
     if (!match) {
       throw new Error(`Could not parse price chip for card ${i}: ${text}`);
     }
-    prices.push(Number(match[1].replace(/,/g, "")));
+    const base = Number(match[1].replace(/,/g, ""));
+    const scale = match[2] ? SUFFIX_SCALE[match[2]] : 1;
+    prices.push(base * scale);
   }
 
   for (let i = 1; i < prices.length; i += 1) {
@@ -246,8 +256,10 @@ rawTest.describe("Mobile viewport", () => {
     await hamburger.click();
     await expect(collectionNavBtn).toBeInViewport();
 
-    // Click outside the drawer to close.
-    await page.mouse.click(380, 10);
+    // Click the backdrop to close the drawer. The drawer is 208px wide and
+    // the mobile top bar covers roughly the first 52px vertically — aim well
+    // outside both so the click lands on the backdrop, not the hamburger.
+    await page.mouse.click(360, 400);
     await expect(collectionNavBtn).not.toBeInViewport();
   });
 

--- a/example-apps/dashnote-starter/src/components/SignIn.tsx
+++ b/example-apps/dashnote-starter/src/components/SignIn.tsx
@@ -20,18 +20,21 @@ interface SignInProps {
 // bundle before the user has signaled any intent to use it.
 const SAMPLE_NOTES = [
   {
-    title: "Shopping list",
-    message: "Coffee beans, oat milk, sourdough.",
+    title: "Identity-owned data follows you",
+    message:
+      "Notes belong to your identity, not your device. Sign in from another browser and they're still there.",
     meta: "Updated 2 hours ago",
   },
   {
-    title: "Reading queue",
-    message: "Finish chapter 4 of the Dash Platform overview.",
+    title: "One contract, many writers",
+    message:
+      "Every note is stored in a shared data contract, but each identity only sees its own notes.",
     meta: "Updated yesterday",
   },
   {
-    title: "(no title)",
-    message: "Remember: notes are owned by the identity, not the device.",
+    title: "Revisions prevent conflicts",
+    message:
+      "If two clients edit the same note, stale updates are rejected instead of overwriting newer data.",
     meta: "Updated 3 days ago",
   },
 ];
@@ -41,61 +44,69 @@ export function SignIn({ onSignIn, busy, status }: SignInProps) {
 
   return (
     <main className="signin">
-      <h1>Dashnote Starter</h1>
-      <p>
-        Paste a BIP-39 mnemonic for a funded testnet identity. The starter uses
-        a hardcoded note contract on testnet so you can create your first note
-        immediately.
+      <p className="eyebrow">Dash Platform tutorial</p>
+      <h1>Personal notes, stored on a public blockchain.</h1>
+      <p className="lede">
+        Sign in with a mnemonic to create, edit, and query notes stored against
+        your Dash Platform testnet identity.
       </p>
-      <p>
-        Don't have one yet?{" "}
-        <a
-          href="https://bridge.thepasta.org/"
-          target="_blank"
-          rel="noreferrer noopener"
+
+      <section className="signin-card" aria-label="Sign in">
+        <form
+          onSubmit={(event) => {
+            event.preventDefault();
+            const trimmed = mnemonic.trim();
+            if (!trimmed) return;
+            onSignIn(trimmed);
+          }}
         >
-          Use Dash Bridge
-        </a>{" "}
-        to generate a mnemonic and register a funded testnet identity in one
-        flow.
-      </p>
-      <form
-        onSubmit={(event) => {
-          event.preventDefault();
-          const trimmed = mnemonic.trim();
-          if (!trimmed) return;
-          onSignIn(trimmed);
-        }}
-      >
-        <label htmlFor="mnemonic">Mnemonic</label>
-        <textarea
-          id="mnemonic"
-          rows={3}
-          value={mnemonic}
-          onChange={(event) => setMnemonic(event.target.value)}
-          placeholder="word1 word2 word3 …"
-          autoComplete="off"
-          spellCheck={false}
-          disabled={busy}
-        />
-        <button type="submit" disabled={busy || !mnemonic.trim()}>
-          {busy ? "Signing in…" : "Sign in"}
-        </button>
-      </form>
-      {status && (
-        <p className="status" aria-live="polite">
-          {status}
-        </p>
-      )}
+          <label htmlFor="mnemonic">Mnemonic</label>
+          <textarea
+            id="mnemonic"
+            rows={3}
+            value={mnemonic}
+            onChange={(event) => setMnemonic(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === "Enter" && !event.shiftKey) {
+                event.preventDefault();
+                event.currentTarget.form?.requestSubmit();
+              }
+            }}
+            placeholder="word1 word2 word3 …"
+            autoComplete="off"
+            spellCheck={false}
+            disabled={busy}
+          />
+          <div className="signin-actions">
+            <button type="submit" disabled={busy || !mnemonic.trim()}>
+              {busy ? "Signing in…" : "Sign in"}
+            </button>
+            <a
+              className="button-secondary"
+              href="https://bridge.thepasta.org/"
+              target="_blank"
+              rel="noreferrer noopener"
+            >
+              Get a testnet identity
+            </a>
+          </div>
+        </form>
+        {status && (
+          <p className="status" aria-live="polite">
+            {status}
+          </p>
+        )}
+      </section>
 
       <section className="preview" aria-label="Sample notes">
-        <h2>Sample notes</h2>
-        <p className="hint">
-          A preview of what your notes will look like once you sign in.
-        </p>
+        <div className="row section-head">
+          <h2>Sample notes</h2>
+          <span className="badge">Preview</span>
+        </div>
+        <p className="hint">What your notes will look like once you sign in.</p>
         <ul className="note-list">
           {SAMPLE_NOTES.map((note) => (
-            <li key={note.title} className="note-item">
+            <li key={note.title} className="note-item sample">
               <div className="note-body">
                 <h3 className="note-title">{note.title}</h3>
                 <p className="note-message">{note.message}</p>
@@ -105,6 +116,20 @@ export function SignIn({ onSignIn, busy, status }: SignInProps) {
           ))}
         </ul>
       </section>
+
+      <details className="about">
+        <summary>About this starter app</summary>
+        <p>
+          The starter uses a hardcoded note contract on Dash Platform testnet,
+          so you can create your first note immediately after signing in. Notes
+          are owned by your identity — not the device — so they persist across
+          browsers as long as you hold the mnemonic.
+        </p>
+        <p>
+          Read the source to see how a small React app writes documents to a
+          data contract and queries them back.
+        </p>
+      </details>
 
       <footer>
         <p>

--- a/example-apps/dashnote-starter/src/styles.css
+++ b/example-apps/dashnote-starter/src/styles.css
@@ -125,6 +125,124 @@ button.linklike.danger {
   max-width: 480px;
 }
 
+.signin .eyebrow {
+  margin: 0 0 0.25rem;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: #2563eb;
+}
+
+.signin h1 {
+  font-size: 1.75rem;
+  line-height: 1.15;
+  margin-bottom: 0.75rem;
+}
+
+.signin .lede {
+  margin: 0 0 1.25rem;
+  color: #374151;
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+.signin-card {
+  padding: 1.25rem;
+  background: white;
+  border: 1px solid #d4d8de;
+  border-radius: 8px;
+  box-shadow: 0 1px 3px rgba(15, 23, 42, 0.08);
+}
+
+.signin-card form {
+  margin: 0;
+}
+
+.signin-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 0.75rem;
+}
+
+.signin-actions button {
+  margin-top: 0;
+}
+
+.button-secondary {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.5rem 1rem;
+  font: inherit;
+  font-size: 0.875rem;
+  color: #1f2937;
+  background: white;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+  text-decoration: none;
+}
+
+.button-secondary:hover {
+  background: #f3f4f6;
+}
+
+.badge {
+  padding: 0.125rem 0.5rem;
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #6b7280;
+  background: #f3f4f6;
+  border-radius: 999px;
+}
+
+.preview {
+  margin-top: 2rem;
+}
+
+.note-item.sample {
+  background: #fafafa;
+  border-style: dashed;
+  box-shadow: none;
+}
+
+.note-item.sample .note-title,
+.note-item.sample .note-message {
+  color: #6b7280;
+}
+
+.note-item.sample .note-meta {
+  color: #9ca3af;
+}
+
+.about {
+  margin-top: 2rem;
+  color: #4b5563;
+  font-size: 0.9rem;
+}
+
+.about > summary {
+  cursor: pointer;
+  color: #2563eb;
+  font-weight: 500;
+  list-style: revert;
+}
+
+.about > summary:hover {
+  text-decoration: underline;
+}
+
+.about p {
+  margin: 0.5rem 0;
+}
+
+.about[open] > summary {
+  margin-bottom: 0.25rem;
+}
+
 .identity {
   margin: 0.125rem 0;
   font-size: 0.75rem;

--- a/setupDashClient-core.d.mts
+++ b/setupDashClient-core.d.mts
@@ -102,6 +102,9 @@ interface ConnectedDashClientLike {
       identityId: string,
       tokenIds: string[],
     ): Promise<Map<string, bigint>>;
+    totalSupply(
+      tokenId: string,
+    ): Promise<{ totalSupply: bigint; tokenId: string } | undefined>;
   };
   dpns: {
     username(identityId: string): Promise<string | null | undefined>;


### PR DESCRIPTION
## Summary

- Adds a Supply block (`X / 100 minted` + progress bar) to the Mint page, sourced from `sdk.tokens.totalSupply` — every mint burns one fixed-supply DashMint token, so minted = SUPPLY − circulating.
- When supply is exhausted, the form collapses to just the Supply block and odds table; name/description fields, token-balance block, and both mint buttons are hidden so the page reads as intentionally finished. The starter pack also disables itself when fewer than pack-size mints remain.
- Refresh the DashMint token balance when the Mint tab becomes active so values don't lag a recent mint until the next reload. A module-level cache for the minted count keeps the value visible across tab switches (no "—" placeholder flash).
- Two small e2e fixes that surfaced alongside this work: the Marketplace price-sort regex now accepts the K/M/B/T/Q suffixes from `formatCreditsCompact`, and the mobile-drawer dismiss click moved out from under the sticky top bar.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added supply tracking with minted progress indicator to the minting interface
  * Added sold-out prevention logic and UI messaging
  * Enhanced sign-in page with new onboarding content and an "About this starter app" panel

* **UI/UX Improvements**
  * Redesigned sign-in form layout with improved interaction patterns
  * Added visual badge and styling for onboarding content
  * Improved mobile navigation drawer closing behavior
  * Updated marketplace price parsing to support compact number formats

* **Chores**
  * Updated contract data identifiers across the application
  * Enhanced SDK protocol version configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->