### PR TITLE
feat(dashmint-lab): add Tokens tab for DashMint token transfers

### DIFF
--- a/example-apps/dashmint-lab/eslint.config.js
+++ b/example-apps/dashmint-lab/eslint.config.js
@@ -6,7 +6,7 @@ import tseslint from "typescript-eslint";
 import { defineConfig, globalIgnores } from "eslint/config";
 
 export default defineConfig([
-  globalIgnores(["dist"]),
+  globalIgnores(["coverage", "dist"]),
   {
     files: ["**/*.{ts,tsx}"],
     extends: [

--- a/example-apps/dashmint-lab/src/App.tsx
+++ b/example-apps/dashmint-lab/src/App.tsx
@@ -22,6 +22,7 @@ import { MintForm } from "./components/MintForm";
 import { PurchaseModal } from "./components/PurchaseModal";
 import { SetPriceModal } from "./components/SetPriceModal";
 import { SubTabs, type CollectionSubTab, type TopTab } from "./components/Tabs";
+import { TokenTransferScreen } from "./components/TokenTransferScreen";
 import { TransferModal } from "./components/TransferModal";
 import { HowItWorks } from "./components/HowItWorks";
 import { errorMessage } from "./dash/logger";
@@ -89,12 +90,14 @@ function App() {
     else if (status === "browsing") setSubTab("all");
   }, [status]);
 
-  // Re-fetch token balance whenever the Mint tab becomes active. The balance
+  // Re-fetch token balance whenever token-related tabs become active. The balance
   // effect in SessionContext only runs on login/logout/contract change, so
   // without this prompt the value could be stale (read-after-write lag from
   // a recent mint elsewhere, or simply a value from many minutes ago).
   useEffect(() => {
-    if (tab === "mint" && status === "authenticated") refreshBalance();
+    if ((tab === "mint" || tab === "tokens") && status === "authenticated") {
+      refreshBalance();
+    }
   }, [tab, status, refreshBalance]);
 
   // Load cards for the current sub-tab whenever dependencies change.
@@ -172,6 +175,10 @@ function App() {
       title: "Mint",
       subtitle:
         "Create collectible cards on Dash Platform using DashMint tokens.",
+    },
+    tokens: {
+      title: "Tokens",
+      subtitle: "Send DashMint tokens to another identity on Dash Platform.",
     },
     "how-it-works": {
       title: "How it works",
@@ -299,6 +306,33 @@ function App() {
                   onMinted={refresh}
                 />
               </div>
+            )}
+          </section>
+        )}
+
+        {/* ── Tokens ────────────────────────────────────────────────── */}
+        {tab === "tokens" && (
+          <section className="relative">
+            {status !== "authenticated" && (
+              <div className="absolute inset-0 z-10 flex flex-col items-center justify-center gap-3 rounded-lg bg-bg/55 backdrop-blur-sm">
+                <p className="text-sm text-ink-2">
+                  Login to transfer DashMint tokens
+                </p>
+                <button
+                  type="button"
+                  onClick={() => setLoginOpen(true)}
+                  className="rounded-md bg-accent px-6 py-2.5 text-sm font-semibold text-bg transition hover:bg-accent-dim"
+                >
+                  Login
+                </button>
+              </div>
+            )}
+            {contractId && (
+              <TokenTransferScreen
+                contractId={contractId}
+                dashMintTokenBalance={dashMintTokenBalance}
+                onTransferred={refresh}
+              />
             )}
           </section>
         )}

--- a/example-apps/dashmint-lab/src/components/AppShell.tsx
+++ b/example-apps/dashmint-lab/src/components/AppShell.tsx
@@ -64,6 +64,15 @@ export function AppShell({
         }}
       />
       <NavButton
+        label="Tokens"
+        glyph="$"
+        active={tab === "tokens"}
+        onClick={() => {
+          onTabChange("tokens");
+          closeDrawer();
+        }}
+      />
+      <NavButton
         label="How it works"
         glyph="?"
         active={tab === "how-it-works"}

--- a/example-apps/dashmint-lab/src/components/Tabs.tsx
+++ b/example-apps/dashmint-lab/src/components/Tabs.tsx
@@ -4,7 +4,7 @@
  * Top-level navigation is handled by NavButton in the AppShell sidebar.
  */
 
-export type TopTab = "collection" | "mint" | "how-it-works";
+export type TopTab = "collection" | "mint" | "tokens" | "how-it-works";
 export type CollectionSubTab = "my" | "all" | "marketplace";
 
 export interface SubTabsProps {

--- a/example-apps/dashmint-lab/src/components/TokenTransferScreen.tsx
+++ b/example-apps/dashmint-lab/src/components/TokenTransferScreen.tsx
@@ -1,0 +1,314 @@
+import { useState, type FormEvent } from "react";
+import {
+  classifyRecipientInput,
+  type RecipientMode,
+} from "../dash/classifyRecipientInput";
+import {
+  DASHMINT_TOKEN_NAME,
+  DASHMINT_TOKEN_PLURAL,
+} from "../dash/dashMintToken";
+import { errorMessage } from "../dash/logger";
+import { normalizeDpnsName } from "../dash/resolveRecipient";
+import { transferDashMintTokens } from "../dash/transferDashMintTokens";
+import { useDpnsName } from "../hooks/useDpnsName";
+import { useResolvedRecipient } from "../hooks/useResolvedRecipient";
+import { truncateId } from "../lib/format";
+import { useSession } from "../session/useSession";
+import { IdentityLink } from "./IdentityLink";
+import {
+  OperationResultNotice,
+  type OperationResult,
+} from "./OperationResultNotice";
+
+export interface TokenTransferScreenProps {
+  contractId: string;
+  dashMintTokenBalance?: bigint | null;
+  onTransferred?: () => void;
+}
+
+export function TokenTransferScreen({
+  contractId,
+  dashMintTokenBalance = null,
+  onTransferred,
+}: TokenTransferScreenProps) {
+  const session = useSession();
+  const [recipient, setRecipient] = useState("");
+  const [amountInput, setAmountInput] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [result, setResult] = useState<OperationResult | null>(null);
+
+  const trimmedRecipient = recipient.trim();
+  const recipientMode: RecipientMode = trimmedRecipient
+    ? classifyRecipientInput(trimmedRecipient)
+    : "invalid";
+  const resolved = useResolvedRecipient(
+    session.sdk,
+    recipientMode === "name" || recipientMode === "ambiguous"
+      ? trimmedRecipient
+      : null,
+  );
+  const idForReverse =
+    recipientMode === "ambiguous" && resolved.status === "not-found"
+      ? trimmedRecipient
+      : null;
+  const reverseName = useDpnsName(session.sdk, idForReverse);
+
+  const amount = parseWholeTokenAmount(amountInput);
+  const amountError = amountInput.trim()
+    ? amount === null
+      ? "Enter a positive whole amount."
+      : dashMintTokenBalance !== null && amount > dashMintTokenBalance
+        ? `Insufficient ${DASHMINT_TOKEN_NAME} balance.`
+        : null
+    : null;
+  const resolvedId =
+    resolved.status === "resolved" ? resolved.identityId : null;
+  const nameBlocksSubmit =
+    recipientMode === "name" && resolved.status !== "resolved";
+  const ambiguousResolving =
+    recipientMode === "ambiguous" && resolved.status === "resolving";
+  const canSubmit =
+    !!session.sdk &&
+    !!session.keyManager &&
+    !!trimmedRecipient &&
+    recipientMode !== "invalid" &&
+    amount !== null &&
+    amountError === null &&
+    !nameBlocksSubmit &&
+    !ambiguousResolving;
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    if (!session.sdk || !session.keyManager || !canSubmit || amount === null) {
+      return;
+    }
+
+    const recipientId = resolvedId ?? trimmedRecipient;
+    setSubmitting(true);
+    setResult(null);
+    try {
+      await transferDashMintTokens({
+        sdk: session.sdk,
+        keyManager: session.keyManager,
+        contractId,
+        recipientId,
+        amount,
+        availableBalance: dashMintTokenBalance,
+        log: session.log,
+      });
+      setResult({
+        kind: "success",
+        message: `${DASHMINT_TOKEN_NAME} tokens transferred successfully.`,
+      });
+      setRecipient("");
+      setAmountInput("");
+      onTransferred?.();
+    } catch (err) {
+      setResult({ kind: "error", message: errorMessage(err) });
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="mx-auto grid max-w-[900px] gap-5 md:grid-cols-[minmax(0,360px)_minmax(0,1fr)]">
+      <div className="rounded-lg border border-line bg-surface p-5">
+        <div className="text-[10px] font-semibold uppercase tracking-[0.12em] text-ink-4">
+          Your {DASHMINT_TOKEN_NAME} balance
+        </div>
+        <div className="mt-2 font-mono text-[30px] font-semibold leading-none text-ink">
+          {dashMintTokenBalance === null
+            ? "Unavailable"
+            : dashMintTokenBalance.toString()}
+        </div>
+        <p className="mt-3 text-[12px] leading-[1.55] text-ink-3">
+          {DASHMINT_TOKEN_PLURAL} tokens are spent to mint cards and can be sent
+          to another identity on the active testnet contract.
+        </p>
+      </div>
+
+      <form
+        onSubmit={handleSubmit}
+        className="flex flex-col gap-4 rounded-lg border border-line bg-surface p-5"
+      >
+        <div>
+          <h2 className="text-[14px] font-semibold text-ink">
+            Transfer tokens
+          </h2>
+        </div>
+
+        <label className="flex flex-col gap-1">
+          <span className="text-[10px] font-semibold uppercase tracking-[0.12em] text-ink-4">
+            Amount
+          </span>
+          <input
+            type="text"
+            inputMode="numeric"
+            required
+            value={amountInput}
+            onChange={(e) => {
+              setAmountInput(e.target.value);
+              if (result) setResult(null);
+            }}
+            placeholder="1"
+            className="h-9 rounded-md border border-line bg-bg px-3 font-mono text-[13px] text-ink outline-none transition focus:border-accent-dim"
+          />
+          {amountError && (
+            <span className="text-[10px] text-rose-400">{amountError}</span>
+          )}
+        </label>
+
+        <label className="flex flex-col gap-1">
+          <span className="text-[10px] font-semibold uppercase tracking-[0.12em] text-ink-4">
+            Recipient identity or DPNS name
+          </span>
+          <input
+            type="text"
+            required
+            value={recipient}
+            onChange={(e) => {
+              setRecipient(e.target.value);
+              if (result) setResult(null);
+            }}
+            placeholder="alice.dash or identity ID"
+            className="h-9 rounded-md border border-line bg-bg px-3 font-mono text-[13px] text-ink outline-none transition focus:border-accent-dim"
+          />
+          <RecipientHint
+            mode={recipientMode}
+            resolved={resolved}
+            reverseName={reverseName}
+            trimmed={trimmedRecipient}
+          />
+        </label>
+
+        {trimmedRecipient && recipientMode !== "invalid" && amount !== null && (
+          <p className="text-[11px] text-ink-3">
+            Sending{" "}
+            <span className="font-mono text-ink">{amount.toString()}</span>{" "}
+            {DASHMINT_TOKEN_PLURAL} to{" "}
+            <TransferTarget
+              mode={recipientMode}
+              resolved={resolved}
+              reverseName={reverseName}
+              trimmed={trimmedRecipient}
+            />
+          </p>
+        )}
+
+        {result && <OperationResultNotice result={result} />}
+
+        <div className="mt-1 flex gap-2">
+          <button
+            type="submit"
+            disabled={submitting || result?.kind === "success" || !canSubmit}
+            className="flex-1 rounded-md bg-accent px-4 py-2 text-[13px] font-semibold text-bg transition hover:bg-accent-dim disabled:cursor-not-allowed disabled:bg-surface-2 disabled:text-ink-4"
+          >
+            {submitting ? "Transferring..." : "Transfer"}
+          </button>
+          <button
+            type="button"
+            disabled={submitting}
+            onClick={() => {
+              setRecipient("");
+              setAmountInput("");
+              setResult(null);
+            }}
+            className="flex-1 rounded-md border border-line bg-transparent px-4 py-2 text-[13px] font-medium text-ink-3 transition hover:border-line-2 hover:text-ink-2 disabled:cursor-not-allowed disabled:text-ink-4"
+          >
+            Clear
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}
+
+function parseWholeTokenAmount(input: string): bigint | null {
+  const trimmed = input.trim();
+  if (!/^[0-9]+$/.test(trimmed)) return null;
+  const amount = BigInt(trimmed);
+  return amount > 0n ? amount : null;
+}
+
+interface HintProps {
+  mode: RecipientMode;
+  resolved: ReturnType<typeof useResolvedRecipient>;
+  reverseName: string | null;
+  trimmed: string;
+}
+
+function RecipientHint({ mode, resolved, reverseName, trimmed }: HintProps) {
+  if (!trimmed) return null;
+
+  if (mode === "invalid") {
+    return (
+      <span className="text-[10px] text-rose-400">
+        Enter an identity ID or DPNS name.
+      </span>
+    );
+  }
+
+  if (resolved.status === "resolving") {
+    return <span className="text-[10px] text-ink-4">Resolving...</span>;
+  }
+
+  if (resolved.status === "resolved") {
+    return (
+      <span className="text-[10px] text-ink-4">
+        Resolved <IdentityLink identityId={resolved.identityId} />
+      </span>
+    );
+  }
+
+  if (mode === "name") {
+    return (
+      <span className="text-[10px] text-rose-400">
+        No identity found for &ldquo;{normalizeDpnsName(trimmed)}&rdquo;.
+      </span>
+    );
+  }
+
+  if (reverseName) {
+    return (
+      <span className="text-[10px] text-ink-4">
+        Resolved {reverseName}.dash
+      </span>
+    );
+  }
+
+  return null;
+}
+
+function TransferTarget({ mode, resolved, reverseName, trimmed }: HintProps) {
+  if (resolved.status === "resolved") {
+    return (
+      <span className="text-accent">
+        {normalizeDpnsName(trimmed)}{" "}
+        <span className="text-ink-4">
+          (<IdentityLink identityId={resolved.identityId} />)
+        </span>
+      </span>
+    );
+  }
+
+  if (mode === "ambiguous" && reverseName) {
+    return (
+      <span className="text-accent">
+        {reverseName}.dash{" "}
+        <span className="text-ink-4">
+          (<IdentityLink identityId={trimmed} />)
+        </span>
+      </span>
+    );
+  }
+
+  if (mode === "ambiguous") {
+    return (
+      <span className="text-accent">
+        <IdentityLink identityId={trimmed} />
+      </span>
+    );
+  }
+
+  return <span className="text-accent">{truncateId(trimmed)}</span>;
+}

--- a/example-apps/dashmint-lab/src/components/TokenTransferScreen.tsx
+++ b/example-apps/dashmint-lab/src/components/TokenTransferScreen.tsx
@@ -1,4 +1,4 @@
-import { useState, type FormEvent } from "react";
+import { useEffect, useState, type FormEvent } from "react";
 import {
   classifyRecipientInput,
   type RecipientMode,
@@ -36,6 +36,13 @@ export function TokenTransferScreen({
   const [amountInput, setAmountInput] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [result, setResult] = useState<OperationResult | null>(null);
+
+  useEffect(() => {
+    setRecipient("");
+    setAmountInput("");
+    setResult(null);
+    setSubmitting(false);
+  }, [contractId, session.identityId, session.status]);
 
   const trimmedRecipient = recipient.trim();
   const recipientMode: RecipientMode = trimmedRecipient
@@ -93,7 +100,6 @@ export function TokenTransferScreen({
         contractId,
         recipientId,
         amount,
-        availableBalance: dashMintTokenBalance,
         log: session.log,
       });
       setResult({

--- a/example-apps/dashmint-lab/src/dash/transferDashMintTokens.ts
+++ b/example-apps/dashmint-lab/src/dash/transferDashMintTokens.ts
@@ -2,7 +2,8 @@
  * Transfer DashMint tokens from the signed-in identity to another identity.
  *
  * DashMint lives at token position 0 on the active app contract. Token
- * transfers use the identity transfer key, unlike card document operations.
+ * single-transfer transitions can be signed by a critical auth or transfer
+ * purpose key; this app keeps explicit token sends on the transfer key.
  *
  * SDK method: sdk.tokens.transfer({ dataContractId, tokenPosition, amount, senderId, recipientId, identityKey, signer })
  */
@@ -16,7 +17,6 @@ export interface TransferDashMintTokensInput {
   contractId: string;
   recipientId: string;
   amount: bigint;
-  availableBalance?: bigint | null;
   log?: Logger;
 }
 
@@ -26,7 +26,6 @@ export async function transferDashMintTokens({
   contractId,
   recipientId,
   amount,
-  availableBalance,
   log,
 }: TransferDashMintTokensInput): Promise<void> {
   const trimmedRecipientId = recipientId.trim();
@@ -36,10 +35,10 @@ export async function transferDashMintTokens({
   if (amount <= 0n) {
     throw new Error("Amount must be greater than 0.");
   }
-  if (availableBalance !== null && availableBalance !== undefined) {
-    if (amount > availableBalance) {
-      throw new Error(`Not enough ${DASHMINT_TOKEN_NAME} tokens.`);
-    }
+
+  const knownSenderId = keyManager.identityId?.toString();
+  if (knownSenderId && trimmedRecipientId === knownSenderId) {
+    throw new Error("Cannot transfer tokens to yourself.");
   }
 
   const { identity, identityKey, signer } = await keyManager.getTransfer();

--- a/example-apps/dashmint-lab/src/dash/transferDashMintTokens.ts
+++ b/example-apps/dashmint-lab/src/dash/transferDashMintTokens.ts
@@ -1,0 +1,68 @@
+/**
+ * Transfer DashMint tokens from the signed-in identity to another identity.
+ *
+ * DashMint lives at token position 0 on the active app contract. Token
+ * transfers use the identity transfer key, unlike card document operations.
+ *
+ * SDK method: sdk.tokens.transfer({ dataContractId, tokenPosition, amount, senderId, recipientId, identityKey, signer })
+ */
+import { DASHMINT_TOKEN_NAME, DASHMINT_TOKEN_POSITION } from "./dashMintToken";
+import type { Logger } from "./logger";
+import type { DashKeyManager, DashSdk } from "./types";
+
+export interface TransferDashMintTokensInput {
+  sdk: DashSdk;
+  keyManager: DashKeyManager;
+  contractId: string;
+  recipientId: string;
+  amount: bigint;
+  availableBalance?: bigint | null;
+  log?: Logger;
+}
+
+export async function transferDashMintTokens({
+  sdk,
+  keyManager,
+  contractId,
+  recipientId,
+  amount,
+  availableBalance,
+  log,
+}: TransferDashMintTokensInput): Promise<void> {
+  const trimmedRecipientId = recipientId.trim();
+  if (!trimmedRecipientId) {
+    throw new Error("Recipient identity ID is required.");
+  }
+  if (amount <= 0n) {
+    throw new Error("Amount must be greater than 0.");
+  }
+  if (availableBalance !== null && availableBalance !== undefined) {
+    if (amount > availableBalance) {
+      throw new Error(`Not enough ${DASHMINT_TOKEN_NAME} tokens.`);
+    }
+  }
+
+  const { identity, identityKey, signer } = await keyManager.getTransfer();
+  const senderId = identity.id.toString();
+  if (trimmedRecipientId === senderId) {
+    throw new Error("Cannot transfer tokens to yourself.");
+  }
+
+  log?.(
+    `Transferring ${amount.toString()} ${DASHMINT_TOKEN_NAME} token${
+      amount === 1n ? "" : "s"
+    }...`,
+  );
+
+  await sdk.tokens.transfer({
+    dataContractId: contractId,
+    tokenPosition: DASHMINT_TOKEN_POSITION,
+    amount,
+    senderId,
+    recipientId: trimmedRecipientId,
+    identityKey,
+    signer,
+  });
+
+  log?.(`${DASHMINT_TOKEN_NAME} tokens transferred.`, "success");
+}

--- a/example-apps/dashmint-lab/src/dash/types.ts
+++ b/example-apps/dashmint-lab/src/dash/types.ts
@@ -13,6 +13,7 @@ export interface DashAuth {
 export interface DashKeyManager {
   readonly identityId: string | null | undefined;
   getAuth(): Promise<DashAuth>;
+  getTransfer(): Promise<DashAuth>;
 }
 
 export interface DashDocumentLike {
@@ -111,6 +112,15 @@ export interface DashSdk {
     totalSupply(
       tokenId: string,
     ): Promise<{ totalSupply: bigint; tokenId: string } | undefined>;
+    transfer(args: {
+      dataContractId: string;
+      tokenPosition: number;
+      amount: bigint;
+      senderId: string;
+      recipientId: string;
+      identityKey: IdentityPublicKey | undefined;
+      signer: IdentitySigner;
+    }): Promise<unknown>;
   };
   dpns: {
     username(identityId: string): Promise<string | null | undefined>;

--- a/example-apps/dashmint-lab/test/App.test.tsx
+++ b/example-apps/dashmint-lab/test/App.test.tsx
@@ -16,6 +16,7 @@ import type { TransferModalProps } from "../src/components/TransferModal";
 import type { SetPriceModalProps } from "../src/components/SetPriceModal";
 import type { PurchaseModalProps } from "../src/components/PurchaseModal";
 import type { BurnModalProps } from "../src/components/BurnModal";
+import type { TokenTransferScreenProps } from "../src/components/TokenTransferScreen";
 
 const {
   mockUseSession,
@@ -51,7 +52,9 @@ vi.mock("../src/components/AppShell", () => ({
   }: {
     children: React.ReactNode;
     onLoginOpen: () => void;
-    onTabChange: (tab: "collection" | "mint" | "how-it-works") => void;
+    onTabChange: (
+      tab: "collection" | "mint" | "tokens" | "how-it-works",
+    ) => void;
   }) => (
     <div>
       <button type="button" onClick={onLoginOpen}>
@@ -62,6 +65,9 @@ vi.mock("../src/components/AppShell", () => ({
       </button>
       <button type="button" onClick={() => onTabChange("mint")}>
         Mint Tab
+      </button>
+      <button type="button" onClick={() => onTabChange("tokens")}>
+        Tokens Tab
       </button>
       <button type="button" onClick={() => onTabChange("how-it-works")}>
         How Tab
@@ -209,6 +215,20 @@ vi.mock("../src/components/MintForm", () => ({
   }: {
     dashMintTokenBalance?: bigint | null;
   }) => <div>Mint Form tokens:{String(dashMintTokenBalance)}</div>,
+}));
+
+vi.mock("../src/components/TokenTransferScreen", () => ({
+  TokenTransferScreen: ({
+    dashMintTokenBalance,
+    onTransferred,
+  }: TokenTransferScreenProps) => (
+    <div>
+      Token Transfer Screen tokens:{String(dashMintTokenBalance)}
+      <button type="button" onClick={() => onTransferred?.()}>
+        Trigger Token Transfer Refresh
+      </button>
+    </div>
+  ),
 }));
 
 vi.mock("../src/components/HowItWorks", () => ({
@@ -558,6 +578,43 @@ describe("App", () => {
     expect(
       screen.queryByText(/Only the contract owner can mint new cards/),
     ).toBeNull();
+  });
+
+  it("shows the login gate on the tokens screen when not authenticated", async () => {
+    const session = makeSession({ status: "browsing" as const });
+    mockUseSession.mockReturnValue(session);
+    mockListAllCards.mockResolvedValue(cards);
+
+    render(<App />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Tokens Tab" }));
+
+    expect(screen.getByText("Login to transfer DashMint tokens")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Login" }));
+    expect(screen.getByTestId("login-modal").textContent).toContain(
+      "open:true",
+    );
+    expect(screen.getByText("Token Transfer Screen tokens:null")).toBeTruthy();
+  });
+
+  it("renders the token transfer screen and refreshes after token transfers", async () => {
+    const session = makeSession({
+      status: "authenticated" as const,
+      identityId: "identity-1",
+      dashMintTokenBalance: 7n,
+    });
+    mockUseSession.mockReturnValue(session);
+    mockListMyCards.mockResolvedValue([cards[1]]);
+
+    render(<App />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Tokens Tab" }));
+
+    expect(screen.getByText("Token Transfer Screen tokens:7")).toBeTruthy();
+    fireEvent.click(
+      screen.getByRole("button", { name: "Trigger Token Transfer Refresh" }),
+    );
+    expect(session.refreshBalance).toHaveBeenCalled();
   });
 
   it("does not show a gate on the mint screen for the contract owner", async () => {

--- a/example-apps/dashmint-lab/test/AppTokenTransferNavigation.test.tsx
+++ b/example-apps/dashmint-lab/test/AppTokenTransferNavigation.test.tsx
@@ -191,7 +191,6 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup();
-  vi.clearAllMocks();
 });
 
 describe("App token transfer navigation", () => {

--- a/example-apps/dashmint-lab/test/AppTokenTransferNavigation.test.tsx
+++ b/example-apps/dashmint-lab/test/AppTokenTransferNavigation.test.tsx
@@ -1,0 +1,229 @@
+// @vitest-environment jsdom
+
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import App from "../src/App";
+import type { Card } from "../src/dash/queries";
+import type { DashKeyManager, DashSdk } from "../src/dash/types";
+import type { ResolvedRecipient } from "../src/hooks/useResolvedRecipient";
+
+const {
+  mockUseSession,
+  mockListAllCards,
+  mockListMyCards,
+  mockListMarketplaceCards,
+  mockTransferDashMintTokens,
+  mockUseDpnsName,
+  mockUseResolvedRecipient,
+} = vi.hoisted(() => ({
+  mockUseSession: vi.fn(),
+  mockListAllCards: vi.fn(),
+  mockListMyCards: vi.fn(),
+  mockListMarketplaceCards: vi.fn(),
+  mockTransferDashMintTokens: vi.fn(),
+  mockUseDpnsName: vi.fn(),
+  mockUseResolvedRecipient: vi.fn(),
+}));
+
+vi.mock("../src/session/useSession", () => ({
+  useSession: mockUseSession,
+}));
+
+vi.mock("../src/dash/queries", () => ({
+  listAllCards: mockListAllCards,
+  listMyCards: mockListMyCards,
+  listMarketplaceCards: mockListMarketplaceCards,
+}));
+
+vi.mock("../src/dash/transferDashMintTokens", () => ({
+  transferDashMintTokens: mockTransferDashMintTokens,
+}));
+
+vi.mock("../src/hooks/useDpnsName", () => ({
+  useDpnsName: mockUseDpnsName,
+}));
+
+vi.mock("../src/hooks/useResolvedRecipient", () => ({
+  useResolvedRecipient: mockUseResolvedRecipient,
+}));
+
+vi.mock("sonner", () => ({
+  Toaster: () => <div data-testid="toaster" />,
+}));
+
+vi.mock("../src/components/AppShell", () => ({
+  AppShell: ({
+    children,
+    onLoginOpen,
+    onTabChange,
+  }: {
+    children: React.ReactNode;
+    onLoginOpen: () => void;
+    onTabChange: (
+      tab: "collection" | "mint" | "tokens" | "how-it-works",
+    ) => void;
+  }) => (
+    <div>
+      <button type="button" onClick={onLoginOpen}>
+        Open Login
+      </button>
+      <button type="button" onClick={() => onTabChange("collection")}>
+        Collection Tab
+      </button>
+      <button type="button" onClick={() => onTabChange("tokens")}>
+        Tokens Tab
+      </button>
+      {children}
+    </div>
+  ),
+}));
+
+vi.mock("../src/components/Tabs", () => ({
+  SubTabs: ({
+    onChange,
+    showMy,
+  }: {
+    onChange: (tab: "my" | "all" | "marketplace") => void;
+    showMy: boolean;
+  }) => (
+    <div>
+      {showMy && (
+        <button type="button" onClick={() => onChange("my")}>
+          Yours
+        </button>
+      )}
+      <button type="button" onClick={() => onChange("all")}>
+        All
+      </button>
+      <button type="button" onClick={() => onChange("marketplace")}>
+        Marketplace
+      </button>
+    </div>
+  ),
+}));
+
+vi.mock("../src/components/CollectionToolbar", () => ({
+  CollectionToolbar: () => <button type="button">Sort</button>,
+  RefreshSpinner: () => <span>Refreshing</span>,
+}));
+
+vi.mock("../src/components/CardGrid", () => ({
+  CardGrid: ({ cards }: { cards: Card[] }) => (
+    <div data-testid="cards">
+      {cards.map((card) => card.data.name).join("|")}
+    </div>
+  ),
+}));
+
+vi.mock("../src/components/LoginModal", () => ({
+  LoginModal: ({ open }: { open: boolean }) => (
+    <div data-testid="login-modal">open:{String(open)}</div>
+  ),
+}));
+
+vi.mock("../src/components/TransferModal", () => ({
+  TransferModal: () => <div data-testid="transfer-modal" />,
+}));
+
+vi.mock("../src/components/SetPriceModal", () => ({
+  SetPriceModal: () => <div data-testid="set-price-modal" />,
+}));
+
+vi.mock("../src/components/PurchaseModal", () => ({
+  PurchaseModal: () => <div data-testid="purchase-modal" />,
+}));
+
+vi.mock("../src/components/BurnModal", () => ({
+  BurnModal: () => <div data-testid="burn-modal" />,
+}));
+
+vi.mock("../src/components/MintForm", () => ({
+  MintForm: () => <div>Mint Form</div>,
+}));
+
+vi.mock("../src/components/HowItWorks", () => ({
+  HowItWorks: () => <div>How It Works</div>,
+}));
+
+const sessionValue = {
+  status: "authenticated" as const,
+  sdk: {} as DashSdk,
+  keyManager: {} as DashKeyManager,
+  identityId: "sender-1",
+  contractId: "contract-1",
+  contractOwnerId: null as string | null,
+  balance: null as bigint | null,
+  dashMintTokenBalance: 10n,
+  refreshBalance: vi.fn(),
+  log: vi.fn(),
+  browseOnly: vi.fn().mockResolvedValue(undefined),
+};
+
+const cards: Card[] = [
+  {
+    id: "card-1",
+    ownerId: "sender-1",
+    data: { name: "Fire Dragon", attack: 9, defense: 8 },
+  },
+];
+
+const SAMPLE_ID = "5LmvdJbGAtnk2Z3y5bwa2YcX9hk5GhVePtkT21a2mxAn";
+function resolved(identityId: string): ResolvedRecipient {
+  return { status: "resolved", identityId };
+}
+
+beforeEach(() => {
+  mockUseSession.mockReset();
+  mockListAllCards.mockReset();
+  mockListMyCards.mockReset();
+  mockListMarketplaceCards.mockReset();
+  mockTransferDashMintTokens.mockReset();
+  mockUseDpnsName.mockReset();
+  mockUseResolvedRecipient.mockReset();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("App token transfer navigation", () => {
+  it("does not retain a token transfer success after leaving and returning to Tokens", async () => {
+    mockUseSession.mockReturnValue(sessionValue);
+    mockListMyCards.mockResolvedValue(cards);
+    mockUseDpnsName.mockReturnValue(null);
+    mockUseResolvedRecipient.mockReturnValue(resolved(SAMPLE_ID));
+    mockTransferDashMintTokens.mockResolvedValue(undefined);
+
+    render(<App />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Tokens Tab" }));
+    fireEvent.change(screen.getByLabelText("Amount"), {
+      target: { value: "2" },
+    });
+    fireEvent.change(screen.getByLabelText("Recipient identity or DPNS name"), {
+      target: { value: "alice.dash" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Transfer" }));
+
+    await screen.findByRole("status");
+    expect(screen.getByRole("status").textContent).toContain(
+      "DashMint tokens transferred successfully.",
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Collection Tab" }));
+    await waitFor(() => {
+      expect(screen.queryByRole("status")).toBeNull();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Tokens Tab" }));
+    expect(screen.queryByRole("status")).toBeNull();
+  });
+});

--- a/example-apps/dashmint-lab/test/AppTokenTransferNavigation.test.tsx
+++ b/example-apps/dashmint-lab/test/AppTokenTransferNavigation.test.tsx
@@ -216,6 +216,13 @@ describe("App token transfer navigation", () => {
     expect(screen.getByRole("status").textContent).toContain(
       "DashMint tokens transferred successfully.",
     );
+    expect(mockTransferDashMintTokens).toHaveBeenCalledWith(
+      expect.objectContaining({
+        contractId: "contract-1",
+        recipientId: SAMPLE_ID,
+        amount: 2n,
+      }),
+    );
 
     fireEvent.click(screen.getByRole("button", { name: "Collection Tab" }));
     await waitFor(() => {

--- a/example-apps/dashmint-lab/test/TokenTransferScreen.test.tsx
+++ b/example-apps/dashmint-lab/test/TokenTransferScreen.test.tsx
@@ -42,8 +42,10 @@ vi.mock("../src/hooks/useResolvedRecipient", () => ({
 }));
 
 const sessionValue = {
+  status: "authenticated",
   sdk: {} as DashSdk,
   keyManager: {} as DashKeyManager,
+  identityId: "sender-1",
   log: vi.fn(),
 };
 
@@ -132,7 +134,6 @@ describe("TokenTransferScreen", () => {
         contractId: "contract-1",
         recipientId: SAMPLE_ID,
         amount: 2n,
-        availableBalance: 10n,
         log: sessionValue.log,
       });
     });
@@ -140,7 +141,7 @@ describe("TokenTransferScreen", () => {
 
   it("submits trimmed raw identity input through ambiguous fallback", async () => {
     mockUseSession.mockReturnValue(sessionValue);
-    mockUseDpnsName.mockReturnValue("alice");
+    mockUseDpnsName.mockReturnValue(null);
     mockUseResolvedRecipient.mockReturnValue({ status: "not-found" });
     mockTransferDashMintTokens.mockResolvedValueOnce(undefined);
 
@@ -154,7 +155,7 @@ describe("TokenTransferScreen", () => {
     fireEvent.change(screen.getByLabelText("Amount"), {
       target: { value: "3" },
     });
-    fireEvent.change(screen.getByLabelText("Recipient identity or DPNS name"), {
+    fireEvent.change(screen.getByPlaceholderText("alice.dash or identity ID"), {
       target: { value: `  ${SAMPLE_ID}  ` },
     });
     fireEvent.click(screen.getByRole("button", { name: "Transfer" }));
@@ -167,6 +168,122 @@ describe("TokenTransferScreen", () => {
         }),
       );
     });
+  });
+
+  it("trims whole-token amount input before submitting", async () => {
+    mockUseSession.mockReturnValue(sessionValue);
+    mockUseDpnsName.mockReturnValue(null);
+    mockUseResolvedRecipient.mockReturnValue(resolved(SAMPLE_ID));
+    mockTransferDashMintTokens.mockResolvedValueOnce(undefined);
+
+    render(
+      <TokenTransferScreen
+        contractId="contract-1"
+        dashMintTokenBalance={10n}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Amount"), {
+      target: { value: "  7  " },
+    });
+    fireEvent.change(screen.getByLabelText("Recipient identity or DPNS name"), {
+      target: { value: "alice.dash" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Transfer" }));
+
+    await waitFor(() => {
+      expect(mockTransferDashMintTokens).toHaveBeenCalledWith(
+        expect.objectContaining({ amount: 7n }),
+      );
+    });
+  });
+
+  it("rejects non-whole amount formats", () => {
+    const invalidAmounts = ["1e3", "-1", "0x10", "1.5", "0"];
+
+    for (const invalidAmount of invalidAmounts) {
+      cleanup();
+      vi.clearAllMocks();
+      mockUseSession.mockReturnValue(sessionValue);
+      mockUseDpnsName.mockReturnValue(null);
+      mockUseResolvedRecipient.mockReturnValue(resolved(SAMPLE_ID));
+
+      render(
+        <TokenTransferScreen
+          contractId="contract-1"
+          dashMintTokenBalance={10n}
+        />,
+      );
+
+      fireEvent.change(screen.getByLabelText("Amount"), {
+        target: { value: invalidAmount },
+      });
+      fireEvent.change(
+        screen.getByLabelText("Recipient identity or DPNS name"),
+        {
+          target: { value: "alice.dash" },
+        },
+      );
+
+      expect(screen.getByText("Enter a positive whole amount.")).toBeTruthy();
+      expect(
+        (screen.getByRole("button", { name: "Transfer" }) as HTMLButtonElement)
+          .disabled,
+      ).toBe(true);
+      expect(mockTransferDashMintTokens).not.toHaveBeenCalled();
+    }
+  });
+
+  it("passes trimmed name and ambiguous inputs to the resolver hook", () => {
+    mockUseSession.mockReturnValue(sessionValue);
+    mockUseDpnsName.mockReturnValue(null);
+    mockUseResolvedRecipient.mockReturnValue(idle);
+
+    render(
+      <TokenTransferScreen
+        contractId="contract-1"
+        dashMintTokenBalance={10n}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Recipient identity or DPNS name"), {
+      target: { value: "  Alice.dash  " },
+    });
+    expect(mockUseResolvedRecipient).toHaveBeenLastCalledWith(
+      sessionValue.sdk,
+      "Alice.dash",
+    );
+
+    fireEvent.change(screen.getByPlaceholderText("alice.dash or identity ID"), {
+      target: { value: `  ${SAMPLE_ID}  ` },
+    });
+    expect(mockUseResolvedRecipient).toHaveBeenLastCalledWith(
+      sessionValue.sdk,
+      SAMPLE_ID,
+    );
+  });
+
+  it("does not resolve invalid recipient input", () => {
+    mockUseSession.mockReturnValue(sessionValue);
+    mockUseDpnsName.mockReturnValue(null);
+    mockUseResolvedRecipient.mockReturnValue(idle);
+
+    render(
+      <TokenTransferScreen
+        contractId="contract-1"
+        dashMintTokenBalance={10n}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Recipient identity or DPNS name"), {
+      target: { value: "alice@dash" },
+    });
+
+    expect(mockUseResolvedRecipient).toHaveBeenLastCalledWith(
+      sessionValue.sdk,
+      null,
+    );
+    expect(mockUseDpnsName).toHaveBeenLastCalledWith(sessionValue.sdk, null);
   });
 
   it("shows success, clears fields, and notifies the parent", async () => {
@@ -200,6 +317,56 @@ describe("TokenTransferScreen", () => {
     expect(amount.value).toBe("");
     expect(recipient.value).toBe("");
     expect(onTransferred).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears a success notice across logout and login", async () => {
+    mockUseSession.mockReturnValue(sessionValue);
+    mockUseDpnsName.mockReturnValue(null);
+    mockUseResolvedRecipient.mockReturnValue(resolved(SAMPLE_ID));
+    mockTransferDashMintTokens.mockResolvedValueOnce(undefined);
+
+    const view = render(
+      <TokenTransferScreen
+        contractId="contract-1"
+        dashMintTokenBalance={10n}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Amount"), {
+      target: { value: "4" },
+    });
+    fireEvent.change(screen.getByLabelText("Recipient identity or DPNS name"), {
+      target: { value: "alice.dash" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Transfer" }));
+
+    await screen.findByRole("status");
+    expect(screen.getByRole("status").textContent).toContain(
+      "DashMint tokens transferred successfully.",
+    );
+
+    mockUseSession.mockReturnValue({
+      ...sessionValue,
+      status: "browsing",
+      identityId: null,
+      keyManager: null,
+    });
+    view.rerender(
+      <TokenTransferScreen
+        contractId="contract-1"
+        dashMintTokenBalance={null}
+      />,
+    );
+    expect(screen.queryByRole("status")).toBeNull();
+
+    mockUseSession.mockReturnValue({
+      ...sessionValue,
+      identityId: "sender-2",
+    });
+    view.rerender(
+      <TokenTransferScreen contractId="contract-1" dashMintTokenBalance={8n} />,
+    );
+    expect(screen.queryByRole("status")).toBeNull();
   });
 
   it("shows inline errors and preserves form values", async () => {

--- a/example-apps/dashmint-lab/test/TokenTransferScreen.test.tsx
+++ b/example-apps/dashmint-lab/test/TokenTransferScreen.test.tsx
@@ -79,10 +79,10 @@ describe("TokenTransferScreen", () => {
     ).toBe(true);
   });
 
-  it("keeps submit disabled for invalid amount and unresolved DPNS name", () => {
+  it("keeps submit disabled for an invalid amount", () => {
     mockUseSession.mockReturnValue(sessionValue);
     mockUseDpnsName.mockReturnValue(null);
-    mockUseResolvedRecipient.mockReturnValue({ status: "not-found" });
+    mockUseResolvedRecipient.mockReturnValue(resolved(SAMPLE_ID));
 
     render(
       <TokenTransferScreen
@@ -99,6 +99,31 @@ describe("TokenTransferScreen", () => {
     });
 
     expect(screen.getByText("Enter a positive whole amount.")).toBeTruthy();
+    expect(
+      (screen.getByRole("button", { name: "Transfer" }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(true);
+  });
+
+  it("keeps submit disabled for an unresolved DPNS name", () => {
+    mockUseSession.mockReturnValue(sessionValue);
+    mockUseDpnsName.mockReturnValue(null);
+    mockUseResolvedRecipient.mockReturnValue({ status: "not-found" });
+
+    render(
+      <TokenTransferScreen
+        contractId="contract-1"
+        dashMintTokenBalance={10n}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Amount"), {
+      target: { value: "2" },
+    });
+    fireEvent.change(screen.getByLabelText("Recipient identity or DPNS name"), {
+      target: { value: "alice.dash" },
+    });
+
     expect(screen.getByText(/No identity found/)).toBeTruthy();
     expect(
       (screen.getByRole("button", { name: "Transfer" }) as HTMLButtonElement)
@@ -106,7 +131,60 @@ describe("TokenTransferScreen", () => {
     ).toBe(true);
   });
 
-  it("submits a resolved DPNS identity ID", async () => {
+  it("keeps submit disabled for an amount above the local balance", () => {
+    mockUseSession.mockReturnValue(sessionValue);
+    mockUseDpnsName.mockReturnValue(null);
+    mockUseResolvedRecipient.mockReturnValue(resolved(SAMPLE_ID));
+
+    render(
+      <TokenTransferScreen contractId="contract-1" dashMintTokenBalance={2n} />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Amount"), {
+      target: { value: "5" },
+    });
+    fireEvent.change(screen.getByLabelText("Recipient identity or DPNS name"), {
+      target: { value: "alice.dash" },
+    });
+
+    expect(screen.getByText("Insufficient DashMint balance.")).toBeTruthy();
+    expect(
+      (screen.getByRole("button", { name: "Transfer" }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(true);
+    expect(mockTransferDashMintTokens).not.toHaveBeenCalled();
+  });
+
+  it("keeps submit disabled without a key manager", () => {
+    mockUseSession.mockReturnValue({
+      ...sessionValue,
+      keyManager: null,
+    });
+    mockUseDpnsName.mockReturnValue(null);
+    mockUseResolvedRecipient.mockReturnValue(resolved(SAMPLE_ID));
+
+    render(
+      <TokenTransferScreen
+        contractId="contract-1"
+        dashMintTokenBalance={10n}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Amount"), {
+      target: { value: "2" },
+    });
+    fireEvent.change(screen.getByLabelText("Recipient identity or DPNS name"), {
+      target: { value: "alice.dash" },
+    });
+
+    expect(
+      (screen.getByRole("button", { name: "Transfer" }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(true);
+    expect(mockTransferDashMintTokens).not.toHaveBeenCalled();
+  });
+
+  it("submits the resolved recipient identity ID", async () => {
     mockUseSession.mockReturnValue(sessionValue);
     mockUseDpnsName.mockReturnValue(null);
     mockUseResolvedRecipient.mockReturnValue(resolved(SAMPLE_ID));
@@ -139,7 +217,7 @@ describe("TokenTransferScreen", () => {
     });
   });
 
-  it("submits trimmed raw identity input through ambiguous fallback", async () => {
+  it("submits trimmed raw identity input when DPNS resolution does not match", async () => {
     mockUseSession.mockReturnValue(sessionValue);
     mockUseDpnsName.mockReturnValue(null);
     mockUseResolvedRecipient.mockReturnValue({ status: "not-found" });
@@ -198,12 +276,9 @@ describe("TokenTransferScreen", () => {
     });
   });
 
-  it("rejects non-whole amount formats", () => {
-    const invalidAmounts = ["1e3", "-1", "0x10", "1.5", "0"];
-
-    for (const invalidAmount of invalidAmounts) {
-      cleanup();
-      vi.clearAllMocks();
+  it.each(["1e3", "-1", "0x10", "1.5", "0"])(
+    "rejects non-whole amount format %s",
+    (invalidAmount) => {
       mockUseSession.mockReturnValue(sessionValue);
       mockUseDpnsName.mockReturnValue(null);
       mockUseResolvedRecipient.mockReturnValue(resolved(SAMPLE_ID));
@@ -231,8 +306,8 @@ describe("TokenTransferScreen", () => {
           .disabled,
       ).toBe(true);
       expect(mockTransferDashMintTokens).not.toHaveBeenCalled();
-    }
-  });
+    },
+  );
 
   it("passes trimmed name and ambiguous inputs to the resolver hook", () => {
     mockUseSession.mockReturnValue(sessionValue);
@@ -319,11 +394,13 @@ describe("TokenTransferScreen", () => {
     expect(onTransferred).toHaveBeenCalledTimes(1);
   });
 
-  it("clears a success notice across logout and login", async () => {
+  it("resets form values and notice when the session changes", async () => {
     mockUseSession.mockReturnValue(sessionValue);
     mockUseDpnsName.mockReturnValue(null);
     mockUseResolvedRecipient.mockReturnValue(resolved(SAMPLE_ID));
-    mockTransferDashMintTokens.mockResolvedValueOnce(undefined);
+    mockTransferDashMintTokens.mockRejectedValueOnce(
+      new Error("Transfer failed"),
+    );
 
     const view = render(
       <TokenTransferScreen
@@ -340,10 +417,18 @@ describe("TokenTransferScreen", () => {
     });
     fireEvent.click(screen.getByRole("button", { name: "Transfer" }));
 
-    await screen.findByRole("status");
-    expect(screen.getByRole("status").textContent).toContain(
-      "DashMint tokens transferred successfully.",
+    await screen.findByRole("alert");
+    expect(screen.getByRole("alert").textContent).toContain("Transfer failed");
+    expect((screen.getByLabelText("Amount") as HTMLInputElement).value).toBe(
+      "4",
     );
+    expect(
+      (
+        screen.getByPlaceholderText(
+          "alice.dash or identity ID",
+        ) as HTMLInputElement
+      ).value,
+    ).toBe("alice.dash");
 
     mockUseSession.mockReturnValue({
       ...sessionValue,
@@ -357,7 +442,17 @@ describe("TokenTransferScreen", () => {
         dashMintTokenBalance={null}
       />,
     );
-    expect(screen.queryByRole("status")).toBeNull();
+    expect(screen.queryByRole("alert")).toBeNull();
+    expect((screen.getByLabelText("Amount") as HTMLInputElement).value).toBe(
+      "",
+    );
+    expect(
+      (
+        screen.getByPlaceholderText(
+          "alice.dash or identity ID",
+        ) as HTMLInputElement
+      ).value,
+    ).toBe("");
 
     mockUseSession.mockReturnValue({
       ...sessionValue,
@@ -366,7 +461,7 @@ describe("TokenTransferScreen", () => {
     view.rerender(
       <TokenTransferScreen contractId="contract-1" dashMintTokenBalance={8n} />,
     );
-    expect(screen.queryByRole("status")).toBeNull();
+    expect(screen.queryByRole("alert")).toBeNull();
   });
 
   it("shows inline errors and preserves form values", async () => {
@@ -396,5 +491,67 @@ describe("TokenTransferScreen", () => {
     expect(alert.textContent).toContain("Transfer failed");
     expect(amount.value).toBe("5");
     expect(recipient.value).toBe("alice.dash");
+  });
+
+  it("clears an existing notice when editing the form", async () => {
+    mockUseSession.mockReturnValue(sessionValue);
+    mockUseDpnsName.mockReturnValue(null);
+    mockUseResolvedRecipient.mockReturnValue(resolved(SAMPLE_ID));
+    mockTransferDashMintTokens.mockRejectedValueOnce(
+      new Error("Transfer failed"),
+    );
+
+    render(
+      <TokenTransferScreen
+        contractId="contract-1"
+        dashMintTokenBalance={10n}
+      />,
+    );
+
+    const amount = screen.getByLabelText("Amount") as HTMLInputElement;
+    const recipient = screen.getByLabelText(
+      "Recipient identity or DPNS name",
+    ) as HTMLInputElement;
+    fireEvent.change(amount, { target: { value: "5" } });
+    fireEvent.change(recipient, { target: { value: "alice.dash" } });
+    fireEvent.click(screen.getByRole("button", { name: "Transfer" }));
+
+    await screen.findByRole("alert");
+    fireEvent.change(amount, { target: { value: "6" } });
+
+    expect(screen.queryByRole("alert")).toBeNull();
+    expect(amount.value).toBe("6");
+    expect(recipient.value).toBe("alice.dash");
+  });
+
+  it("clears form values and notice when Clear is clicked", async () => {
+    mockUseSession.mockReturnValue(sessionValue);
+    mockUseDpnsName.mockReturnValue(null);
+    mockUseResolvedRecipient.mockReturnValue(resolved(SAMPLE_ID));
+    mockTransferDashMintTokens.mockRejectedValueOnce(
+      new Error("Transfer failed"),
+    );
+
+    render(
+      <TokenTransferScreen
+        contractId="contract-1"
+        dashMintTokenBalance={10n}
+      />,
+    );
+
+    const amount = screen.getByLabelText("Amount") as HTMLInputElement;
+    const recipient = screen.getByLabelText(
+      "Recipient identity or DPNS name",
+    ) as HTMLInputElement;
+    fireEvent.change(amount, { target: { value: "5" } });
+    fireEvent.change(recipient, { target: { value: "alice.dash" } });
+    fireEvent.click(screen.getByRole("button", { name: "Transfer" }));
+
+    await screen.findByRole("alert");
+    fireEvent.click(screen.getByRole("button", { name: "Clear" }));
+
+    expect(screen.queryByRole("alert")).toBeNull();
+    expect(amount.value).toBe("");
+    expect(recipient.value).toBe("");
   });
 });

--- a/example-apps/dashmint-lab/test/TokenTransferScreen.test.tsx
+++ b/example-apps/dashmint-lab/test/TokenTransferScreen.test.tsx
@@ -1,0 +1,233 @@
+// @vitest-environment jsdom
+
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { TokenTransferScreen } from "../src/components/TokenTransferScreen";
+import type { DashKeyManager, DashSdk } from "../src/dash/types";
+import type { ResolvedRecipient } from "../src/hooks/useResolvedRecipient";
+
+const {
+  mockUseSession,
+  mockTransferDashMintTokens,
+  mockUseDpnsName,
+  mockUseResolvedRecipient,
+} = vi.hoisted(() => ({
+  mockUseSession: vi.fn(),
+  mockTransferDashMintTokens: vi.fn(),
+  mockUseDpnsName: vi.fn(),
+  mockUseResolvedRecipient: vi.fn(),
+}));
+
+vi.mock("../src/session/useSession", () => ({
+  useSession: mockUseSession,
+}));
+
+vi.mock("../src/dash/transferDashMintTokens", () => ({
+  transferDashMintTokens: mockTransferDashMintTokens,
+}));
+
+vi.mock("../src/hooks/useDpnsName", () => ({
+  useDpnsName: mockUseDpnsName,
+}));
+
+vi.mock("../src/hooks/useResolvedRecipient", () => ({
+  useResolvedRecipient: mockUseResolvedRecipient,
+}));
+
+const sessionValue = {
+  sdk: {} as DashSdk,
+  keyManager: {} as DashKeyManager,
+  log: vi.fn(),
+};
+
+const SAMPLE_ID = "5LmvdJbGAtnk2Z3y5bwa2YcX9hk5GhVePtkT21a2mxAn";
+const idle: ResolvedRecipient = { status: "idle" };
+function resolved(identityId: string): ResolvedRecipient {
+  return { status: "resolved", identityId };
+}
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("TokenTransferScreen", () => {
+  it("keeps submit disabled with empty fields", () => {
+    mockUseSession.mockReturnValue(sessionValue);
+    mockUseDpnsName.mockReturnValue(null);
+    mockUseResolvedRecipient.mockReturnValue(idle);
+
+    render(
+      <TokenTransferScreen
+        contractId="contract-1"
+        dashMintTokenBalance={10n}
+      />,
+    );
+
+    expect(
+      (screen.getByRole("button", { name: "Transfer" }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(true);
+  });
+
+  it("keeps submit disabled for invalid amount and unresolved DPNS name", () => {
+    mockUseSession.mockReturnValue(sessionValue);
+    mockUseDpnsName.mockReturnValue(null);
+    mockUseResolvedRecipient.mockReturnValue({ status: "not-found" });
+
+    render(
+      <TokenTransferScreen
+        contractId="contract-1"
+        dashMintTokenBalance={10n}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Amount"), {
+      target: { value: "1.5" },
+    });
+    fireEvent.change(screen.getByLabelText("Recipient identity or DPNS name"), {
+      target: { value: "alice.dash" },
+    });
+
+    expect(screen.getByText("Enter a positive whole amount.")).toBeTruthy();
+    expect(screen.getByText(/No identity found/)).toBeTruthy();
+    expect(
+      (screen.getByRole("button", { name: "Transfer" }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(true);
+  });
+
+  it("submits a resolved DPNS identity ID", async () => {
+    mockUseSession.mockReturnValue(sessionValue);
+    mockUseDpnsName.mockReturnValue(null);
+    mockUseResolvedRecipient.mockReturnValue(resolved(SAMPLE_ID));
+    mockTransferDashMintTokens.mockResolvedValueOnce(undefined);
+
+    render(
+      <TokenTransferScreen
+        contractId="contract-1"
+        dashMintTokenBalance={10n}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Amount"), {
+      target: { value: "2" },
+    });
+    fireEvent.change(screen.getByLabelText("Recipient identity or DPNS name"), {
+      target: { value: "Alice.dash" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Transfer" }));
+
+    await waitFor(() => {
+      expect(mockTransferDashMintTokens).toHaveBeenCalledWith({
+        sdk: sessionValue.sdk,
+        keyManager: sessionValue.keyManager,
+        contractId: "contract-1",
+        recipientId: SAMPLE_ID,
+        amount: 2n,
+        availableBalance: 10n,
+        log: sessionValue.log,
+      });
+    });
+  });
+
+  it("submits trimmed raw identity input through ambiguous fallback", async () => {
+    mockUseSession.mockReturnValue(sessionValue);
+    mockUseDpnsName.mockReturnValue("alice");
+    mockUseResolvedRecipient.mockReturnValue({ status: "not-found" });
+    mockTransferDashMintTokens.mockResolvedValueOnce(undefined);
+
+    render(
+      <TokenTransferScreen
+        contractId="contract-1"
+        dashMintTokenBalance={10n}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Amount"), {
+      target: { value: "3" },
+    });
+    fireEvent.change(screen.getByLabelText("Recipient identity or DPNS name"), {
+      target: { value: `  ${SAMPLE_ID}  ` },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Transfer" }));
+
+    await waitFor(() => {
+      expect(mockTransferDashMintTokens).toHaveBeenCalledWith(
+        expect.objectContaining({
+          recipientId: SAMPLE_ID,
+          amount: 3n,
+        }),
+      );
+    });
+  });
+
+  it("shows success, clears fields, and notifies the parent", async () => {
+    const onTransferred = vi.fn();
+    mockUseSession.mockReturnValue(sessionValue);
+    mockUseDpnsName.mockReturnValue(null);
+    mockUseResolvedRecipient.mockReturnValue(resolved(SAMPLE_ID));
+    mockTransferDashMintTokens.mockResolvedValueOnce(undefined);
+
+    render(
+      <TokenTransferScreen
+        contractId="contract-1"
+        dashMintTokenBalance={10n}
+        onTransferred={onTransferred}
+      />,
+    );
+
+    const amount = screen.getByLabelText("Amount") as HTMLInputElement;
+    const recipient = screen.getByLabelText(
+      "Recipient identity or DPNS name",
+    ) as HTMLInputElement;
+    fireEvent.change(amount, { target: { value: "4" } });
+    fireEvent.change(recipient, { target: { value: "alice.dash" } });
+    fireEvent.click(screen.getByRole("button", { name: "Transfer" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("status").textContent).toContain(
+        "DashMint tokens transferred successfully.",
+      );
+    });
+    expect(amount.value).toBe("");
+    expect(recipient.value).toBe("");
+    expect(onTransferred).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows inline errors and preserves form values", async () => {
+    mockUseSession.mockReturnValue(sessionValue);
+    mockUseDpnsName.mockReturnValue(null);
+    mockUseResolvedRecipient.mockReturnValue(resolved(SAMPLE_ID));
+    mockTransferDashMintTokens.mockRejectedValueOnce(
+      new Error("Transfer failed"),
+    );
+
+    render(
+      <TokenTransferScreen
+        contractId="contract-1"
+        dashMintTokenBalance={10n}
+      />,
+    );
+
+    const amount = screen.getByLabelText("Amount") as HTMLInputElement;
+    const recipient = screen.getByLabelText(
+      "Recipient identity or DPNS name",
+    ) as HTMLInputElement;
+    fireEvent.change(amount, { target: { value: "5" } });
+    fireEvent.change(recipient, { target: { value: "alice.dash" } });
+    fireEvent.click(screen.getByRole("button", { name: "Transfer" }));
+
+    const alert = await screen.findByRole("alert");
+    expect(alert.textContent).toContain("Transfer failed");
+    expect(amount.value).toBe("5");
+    expect(recipient.value).toBe("alice.dash");
+  });
+});

--- a/example-apps/dashmint-lab/test/dash.test.ts
+++ b/example-apps/dashmint-lab/test/dash.test.ts
@@ -102,6 +102,9 @@ describe("dashmint helpers", () => {
           signer: { id: "signer-1" },
         };
       },
+      async getTransfer() {
+        throw new Error("getTransfer should not be used here");
+      },
     };
     const sdk = {
       documents: {
@@ -145,6 +148,9 @@ describe("dashmint helpers", () => {
           signer: { id: "signer-1" },
         };
       },
+      async getTransfer() {
+        throw new Error("getTransfer should not be used here");
+      },
     };
     const sdk = {
       documents: {
@@ -179,6 +185,9 @@ describe("dashmint helpers", () => {
           signer: { id: "signer-1" },
         };
       },
+      async getTransfer() {
+        throw new Error("getTransfer should not be used here");
+      },
     };
     const sdk = {
       documents: {
@@ -212,6 +221,9 @@ describe("dashmint helpers", () => {
           identityKey: { id: "key-1" },
           signer: { id: "signer-1" },
         };
+      },
+      async getTransfer() {
+        throw new Error("getTransfer should not be used here");
       },
     };
     const sdk = {

--- a/example-apps/dashmint-lab/test/transferDashMintTokens.test.ts
+++ b/example-apps/dashmint-lab/test/transferDashMintTokens.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { transferDashMintTokens } from "../src/dash/transferDashMintTokens";
+import type { DashKeyManager, DashSdk } from "../src/dash/types";
+
+function makeKeyManager(senderId = "sender-1") {
+  return {
+    async getAuth() {
+      throw new Error("getAuth should not be used for token transfers");
+    },
+    async getTransfer() {
+      return {
+        identity: { id: { toString: () => senderId } },
+        identityKey: { id: "transfer-key" },
+        signer: { id: "transfer-signer" },
+      };
+    },
+  } as unknown as DashKeyManager;
+}
+
+function makeSdk() {
+  return {
+    tokens: {
+      transfer: vi.fn().mockResolvedValue(undefined),
+    },
+  } as unknown as DashSdk;
+}
+
+describe("transferDashMintTokens", () => {
+  it("uses the transfer key and submits the DashMint token transfer", async () => {
+    const sdk = makeSdk();
+    const keyManager = makeKeyManager("sender-1");
+    const log = vi.fn();
+
+    await transferDashMintTokens({
+      sdk,
+      keyManager,
+      contractId: "contract-1",
+      recipientId: "recipient-1",
+      amount: 3n,
+      availableBalance: 5n,
+      log,
+    });
+
+    expect(sdk.tokens.transfer).toHaveBeenCalledWith({
+      dataContractId: "contract-1",
+      tokenPosition: 0,
+      amount: 3n,
+      senderId: "sender-1",
+      recipientId: "recipient-1",
+      identityKey: { id: "transfer-key" },
+      signer: { id: "transfer-signer" },
+    });
+    expect(log).toHaveBeenCalledWith("DashMint tokens transferred.", "success");
+  });
+
+  it("rejects empty recipients before signing", async () => {
+    const sdk = makeSdk();
+    const keyManager = makeKeyManager();
+
+    await expect(
+      transferDashMintTokens({
+        sdk,
+        keyManager,
+        contractId: "contract-1",
+        recipientId: "  ",
+        amount: 1n,
+      }),
+    ).rejects.toThrow("Recipient identity ID is required.");
+    expect(sdk.tokens.transfer).not.toHaveBeenCalled();
+  });
+
+  it("rejects non-positive amounts before signing", async () => {
+    const sdk = makeSdk();
+    const keyManager = makeKeyManager();
+
+    await expect(
+      transferDashMintTokens({
+        sdk,
+        keyManager,
+        contractId: "contract-1",
+        recipientId: "recipient-1",
+        amount: 0n,
+      }),
+    ).rejects.toThrow("Amount must be greater than 0.");
+    expect(sdk.tokens.transfer).not.toHaveBeenCalled();
+  });
+
+  it("rejects amounts above the known local balance", async () => {
+    const sdk = makeSdk();
+    const keyManager = makeKeyManager();
+
+    await expect(
+      transferDashMintTokens({
+        sdk,
+        keyManager,
+        contractId: "contract-1",
+        recipientId: "recipient-1",
+        amount: 6n,
+        availableBalance: 5n,
+      }),
+    ).rejects.toThrow("Not enough DashMint tokens.");
+    expect(sdk.tokens.transfer).not.toHaveBeenCalled();
+  });
+
+  it("rejects self-transfers after resolving the sender identity", async () => {
+    const sdk = makeSdk();
+    const keyManager = makeKeyManager("sender-1");
+
+    await expect(
+      transferDashMintTokens({
+        sdk,
+        keyManager,
+        contractId: "contract-1",
+        recipientId: "sender-1",
+        amount: 1n,
+      }),
+    ).rejects.toThrow("Cannot transfer tokens to yourself.");
+    expect(sdk.tokens.transfer).not.toHaveBeenCalled();
+  });
+});

--- a/example-apps/dashmint-lab/test/transferDashMintTokens.test.ts
+++ b/example-apps/dashmint-lab/test/transferDashMintTokens.test.ts
@@ -4,17 +4,21 @@ import { transferDashMintTokens } from "../src/dash/transferDashMintTokens";
 import type { DashKeyManager, DashSdk } from "../src/dash/types";
 
 function makeKeyManager(senderId = "sender-1") {
+  const getTransfer = vi.fn(async () => ({
+    identity: { id: { toString: () => senderId } },
+    identityKey: { id: "transfer-key" },
+    signer: { id: "transfer-signer" },
+  }));
   return {
+    identityId: senderId,
     async getAuth() {
-      throw new Error("getAuth should not be used for token transfers");
-    },
-    async getTransfer() {
       return {
         identity: { id: { toString: () => senderId } },
-        identityKey: { id: "transfer-key" },
-        signer: { id: "transfer-signer" },
+        identityKey: { id: "auth-key" },
+        signer: { id: "auth-signer" },
       };
     },
+    getTransfer,
   } as unknown as DashKeyManager;
 }
 
@@ -27,7 +31,7 @@ function makeSdk() {
 }
 
 describe("transferDashMintTokens", () => {
-  it("uses the transfer key and submits the DashMint token transfer", async () => {
+  it("uses the app's transfer signer and submits the DashMint token transfer", async () => {
     const sdk = makeSdk();
     const keyManager = makeKeyManager("sender-1");
     const log = vi.fn();
@@ -38,7 +42,6 @@ describe("transferDashMintTokens", () => {
       contractId: "contract-1",
       recipientId: "recipient-1",
       amount: 3n,
-      availableBalance: 5n,
       log,
     });
 
@@ -86,24 +89,7 @@ describe("transferDashMintTokens", () => {
     expect(sdk.tokens.transfer).not.toHaveBeenCalled();
   });
 
-  it("rejects amounts above the known local balance", async () => {
-    const sdk = makeSdk();
-    const keyManager = makeKeyManager();
-
-    await expect(
-      transferDashMintTokens({
-        sdk,
-        keyManager,
-        contractId: "contract-1",
-        recipientId: "recipient-1",
-        amount: 6n,
-        availableBalance: 5n,
-      }),
-    ).rejects.toThrow("Not enough DashMint tokens.");
-    expect(sdk.tokens.transfer).not.toHaveBeenCalled();
-  });
-
-  it("rejects self-transfers after resolving the sender identity", async () => {
+  it("rejects known self-transfers before resolving the signer", async () => {
     const sdk = makeSdk();
     const keyManager = makeKeyManager("sender-1");
 
@@ -116,6 +102,27 @@ describe("transferDashMintTokens", () => {
         amount: 1n,
       }),
     ).rejects.toThrow("Cannot transfer tokens to yourself.");
+    expect(keyManager.getTransfer).not.toHaveBeenCalled();
+    expect(sdk.tokens.transfer).not.toHaveBeenCalled();
+  });
+
+  it("still rejects self-transfers after resolving the sender identity", async () => {
+    const sdk = makeSdk();
+    const keyManager = {
+      ...makeKeyManager("sender-1"),
+      identityId: null,
+    } as unknown as DashKeyManager;
+
+    await expect(
+      transferDashMintTokens({
+        sdk,
+        keyManager,
+        contractId: "contract-1",
+        recipientId: "sender-1",
+        amount: 1n,
+      }),
+    ).rejects.toThrow("Cannot transfer tokens to yourself.");
+    expect(keyManager.getTransfer).toHaveBeenCalledTimes(1);
     expect(sdk.tokens.transfer).not.toHaveBeenCalled();
   });
 });

--- a/setupDashClient-core.d.mts
+++ b/setupDashClient-core.d.mts
@@ -105,6 +105,15 @@ interface ConnectedDashClientLike {
     totalSupply(
       tokenId: string,
     ): Promise<{ totalSupply: bigint; tokenId: string } | undefined>;
+    transfer(args: {
+      dataContractId: string;
+      tokenPosition: number;
+      amount: bigint;
+      senderId: string;
+      recipientId: string;
+      identityKey: IdentityPublicKey | undefined;
+      signer: IdentitySigner;
+    }): Promise<unknown>;
   };
   dpns: {
     username(identityId: string): Promise<string | null | undefined>;
@@ -122,6 +131,11 @@ export declare class IdentityKeyManager {
   }): Promise<IdentityKeyManager>;
   readonly identityId: string | null | undefined;
   getAuth(): Promise<{
+    identity: Identity;
+    identityKey: IdentityPublicKey | undefined;
+    signer: IdentitySigner;
+  }>;
+  getTransfer(): Promise<{
     identity: Identity;
     identityKey: IdentityPublicKey | undefined;
     signer: IdentitySigner;


### PR DESCRIPTION
## Summary

- Adds a Tokens tab to DashMint Lab for transferring DashMint tokens between identities on testnet
- New `transferDashMintTokens` helper wraps `sdk.tokens.transfer` and uses the identity's TRANSFER-purpose key (key 3); fast-paths a self-transfer check via cached `keyManager.identityId` before the on-chain identity fetch, with a post-fetch fallback when the cached ID is null
- New `TokenTransferScreen` reuses the DPNS classifier/resolver hooks from card transfers, validates whole-token amounts, and resets form + result state across session changes; gate overlay matches the existing Mint tab pattern for unauthenticated browse mode
- Adds a `transfer` method to `setupDashClient-core.d.mts` and a `getTransfer()` accessor to the app-local `DashKeyManager` type

## Test plan

- [x] `npm run test` — 21 new tests across `TokenTransferScreen.test.tsx`, `transferDashMintTokens.test.ts`, `AppTokenTransferNavigation.test.tsx`, plus updates to `App.test.tsx` and `dash.test.ts`; coverage on `transferDashMintTokens.ts` is 100% stmt / 91% branch and `TokenTransferScreen.tsx` 86% / 90%
- [x] `npm run lint` and `npm run build`
- [x] Manual testnet round-trip: send DashMint tokens to another identity, confirm balance updates on both sides, verify Tokens tab gate appears when not signed in
- [x] DPNS recipient: type a `.dash` name, verify resolution + submission to the resolved ID
- [x] Self-transfer guard: type your own identity ID, confirm rejection before the network call
- [x] Insufficient balance: type an amount above your DashMint balance, confirm submit stays disabled with the inline hint

Notes:
- Token transfers use the TRANSFER-purpose key, not AUTHENTICATION — distinct from card document operations (which require AUTH per the SDK's document state-transition rules). The doc comment on `transferDashMintTokens.ts` notes that token single-transfer transitions accept either critical auth or TRANSFER purpose; this app standardizes on TRANSFER.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new Tokens tab for users to transfer tokens to recipients
  * Transfer form includes validation and balance checks to prevent invalid transactions

* **Tests**
  * Expanded test coverage for token transfer functionality

* **Chores**
  * Updated ESLint configuration to exclude the coverage directory

<!-- end of auto-generated comment: release notes by coderabbit.ai -->