### PR TITLE
chore(dashmint-lab): card pricing fixes, buy-screen credit check, and test coverage

### DIFF
--- a/example-apps/dashmint-lab/src/App.tsx
+++ b/example-apps/dashmint-lab/src/App.tsx
@@ -38,6 +38,12 @@ const SORT_LABELS: Record<SortKey, string> = {
 };
 const SORT_ORDER: SortKey[] = ["rarity", "name", "owner", "price"];
 
+function cardPriceValue(card: Card): bigint | null {
+  const price = card.$price;
+  if (price === undefined || price === 0 || price === 0n) return null;
+  return typeof price === "bigint" ? price : BigInt(Math.trunc(price));
+}
+
 function App() {
   const session = useSession();
   const {
@@ -154,9 +160,12 @@ function App() {
       );
     } else if (sortKey === "price") {
       return [...cards].sort((a, b) => {
-        const pa = a.$price ? Number(a.$price) : -1;
-        const pb = b.$price ? Number(b.$price) : -1;
-        return pb - pa;
+        const pa = cardPriceValue(a);
+        const pb = cardPriceValue(b);
+        if (pa === pb) return 0;
+        if (pa === null) return 1;
+        if (pb === null) return -1;
+        return pa > pb ? -1 : 1;
       });
     }
     return cards;

--- a/example-apps/dashmint-lab/src/components/CardTile.tsx
+++ b/example-apps/dashmint-lab/src/components/CardTile.tsx
@@ -91,8 +91,8 @@ export function CardTile({
         style={{ background: RARITY_RAIL_COLORS[rarity] }}
       />
 
-      {/* Header: rarity tag + price */}
-      <div className="flex items-center justify-between">
+      {/* Header: reserves chip height so listed and unlisted cards align */}
+      <div className="flex min-h-[22px] items-center justify-between">
         <RarityTag rarity={rarity} />
         {hasPrice && (
           <span

--- a/example-apps/dashmint-lab/src/components/PurchaseModal.tsx
+++ b/example-apps/dashmint-lab/src/components/PurchaseModal.tsx
@@ -28,6 +28,10 @@ export function PurchaseModal({
   const [submitting, setSubmitting] = useState(false);
   const [result, setResult] = useState<OperationResult | null>(null);
 
+  const price = card?.$price ?? null;
+  const insufficientCredits =
+    session.balance !== null && price !== null && session.balance < price;
+
   useEffect(() => {
     if (card) {
       setResult(null);
@@ -42,7 +46,8 @@ export function PurchaseModal({
       !session.keyManager ||
       !session.contractId ||
       card.$price === undefined ||
-      card.$price === null
+      card.$price === null ||
+      insufficientCredits
     )
       return;
     setSubmitting(true);
@@ -82,16 +87,41 @@ export function PurchaseModal({
               </span>
             </div>
 
+            <div className="flex items-center justify-between">
+              <span className="text-[10px] font-semibold uppercase tracking-[0.12em] text-ink-4">
+                Your balance
+              </span>
+              <span className="text-[13px] font-bold text-ink-2">
+                {session.balance === null
+                  ? "—"
+                  : `${formatCredits(session.balance)} credits`}
+              </span>
+            </div>
+
+            {insufficientCredits && (
+              <p className="rounded-md border border-[oklch(30%_0.08_25)] bg-[oklch(22%_0.04_25)] px-3 py-2 text-[12px] font-medium leading-[1.45] text-danger">
+                Not enough credits to buy this card.
+              </p>
+            )}
+
             {result && <OperationResultNotice result={result} />}
 
             <div className="mt-3 flex gap-2">
               <button
                 type="button"
                 onClick={handleBuy}
-                disabled={submitting || result?.kind === "success"}
+                disabled={
+                  submitting ||
+                  insufficientCredits ||
+                  result?.kind === "success"
+                }
                 className="flex-1 rounded-md bg-accent px-4 py-2 text-[13px] font-semibold text-bg transition hover:bg-accent-dim disabled:cursor-not-allowed disabled:bg-surface-2 disabled:text-ink-4"
               >
-                {submitting ? "Purchasing…" : "Buy"}
+                {submitting
+                  ? "Purchasing…"
+                  : insufficientCredits
+                    ? "Insufficient credits"
+                    : "Buy"}
               </button>
               <button
                 type="button"

--- a/example-apps/dashmint-lab/src/components/SetPriceModal.tsx
+++ b/example-apps/dashmint-lab/src/components/SetPriceModal.tsx
@@ -21,6 +21,7 @@ const SUCCESS_CLOSE_DELAY_MS = 700;
 // TODO(dashpay/platform#3786): Remove this app-level cap after the SDK can
 // safely serialize document prices above Number.MAX_SAFE_INTEGER.
 export const MAX_PRICE_CREDITS = 1_000_000_000_000_000;
+const MAX_PRICE_CREDITS_BIGINT = BigInt(MAX_PRICE_CREDITS);
 const MAX_PRICE_ERROR = `Price must be between 1 and ${formatCredits(MAX_PRICE_CREDITS)} credits.`;
 
 export function SetPriceModal({ card, onClose, onPriced }: SetPriceModalProps) {
@@ -71,13 +72,15 @@ export function SetPriceModal({ card, onClose, onPriced }: SetPriceModalProps) {
   async function handleSubmit(e: FormEvent) {
     e.preventDefault();
     const value = amount.trim();
-    const n = Number(value);
-    if (!/^\d+$/.test(value) || !Number.isFinite(n) || n < 1) return;
-    if (n > MAX_PRICE_CREDITS) {
+    if (!/^\d+$/.test(value)) return;
+
+    const price = BigInt(value);
+    if (price < 1n) return;
+    if (price > MAX_PRICE_CREDITS_BIGINT) {
       setResult({ kind: "error", message: MAX_PRICE_ERROR });
       return;
     }
-    await submitPrice(n);
+    await submitPrice(price);
   }
 
   const hasCurrentPrice = !!card && !!card.$price;

--- a/example-apps/dashmint-lab/src/components/SetPriceModal.tsx
+++ b/example-apps/dashmint-lab/src/components/SetPriceModal.tsx
@@ -18,6 +18,10 @@ export interface SetPriceModalProps {
 }
 
 const SUCCESS_CLOSE_DELAY_MS = 700;
+// TODO(dashpay/platform#3786): Remove this app-level cap after the SDK can
+// safely serialize document prices above Number.MAX_SAFE_INTEGER.
+export const MAX_PRICE_CREDITS = 1_000_000_000_000_000;
+const MAX_PRICE_ERROR = `Price must be between 1 and ${formatCredits(MAX_PRICE_CREDITS)} credits.`;
 
 export function SetPriceModal({ card, onClose, onPriced }: SetPriceModalProps) {
   const session = useSession();
@@ -66,8 +70,13 @@ export function SetPriceModal({ card, onClose, onPriced }: SetPriceModalProps) {
 
   async function handleSubmit(e: FormEvent) {
     e.preventDefault();
-    const n = parseInt(amount, 10);
-    if (!Number.isFinite(n) || n < 1) return;
+    const value = amount.trim();
+    const n = Number(value);
+    if (!/^\d+$/.test(value) || !Number.isFinite(n) || n < 1) return;
+    if (n > MAX_PRICE_CREDITS) {
+      setResult({ kind: "error", message: MAX_PRICE_ERROR });
+      return;
+    }
     await submitPrice(n);
   }
 
@@ -80,7 +89,11 @@ export function SetPriceModal({ card, onClose, onPriced }: SetPriceModalProps) {
       onClose={onClose}
     >
       {card && (
-        <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+        <form
+          onSubmit={handleSubmit}
+          noValidate
+          className="flex flex-col gap-4"
+        >
           <CardSummary card={card}>
             {hasCurrentPrice && (
               <div className="mb-3 text-[12px] text-accent">
@@ -95,6 +108,7 @@ export function SetPriceModal({ card, onClose, onPriced }: SetPriceModalProps) {
               <input
                 type="number"
                 min={1}
+                max={MAX_PRICE_CREDITS}
                 value={amount}
                 onChange={(e) => {
                   setAmount(e.target.value);

--- a/example-apps/dashmint-lab/src/dash/queries.ts
+++ b/example-apps/dashmint-lab/src/dash/queries.ts
@@ -34,6 +34,10 @@ export interface Card {
   $price?: number | bigint;
 }
 
+function hasSalePrice(card: Card): boolean {
+  return card.$price != null && card.$price !== 0 && card.$price !== 0n;
+}
+
 function toCard(id: string | null, raw: DashCardQueryDocument): Card {
   const j: Record<string, unknown> =
     typeof raw?.toJSON === "function" ? raw.toJSON() : raw;
@@ -112,7 +116,7 @@ export async function listMarketplaceCards({
     documentTypeName: "card",
     limit,
   });
-  const cards = normalizeCards(results).filter((c) => c.$price);
+  const cards = normalizeCards(results).filter(hasSalePrice);
   log?.(`Found ${cards.length} card(s) for sale.`);
   return cards;
 }

--- a/example-apps/dashmint-lab/test/App.test.tsx
+++ b/example-apps/dashmint-lab/test/App.test.tsx
@@ -433,6 +433,42 @@ describe("App", () => {
     );
   });
 
+  it("sorts prices by exact bigint value above Number.MAX_SAFE_INTEGER", async () => {
+    const session = makeSession();
+    const largePriceCards: Card[] = [
+      {
+        id: "lower",
+        ownerId: "owner-1",
+        data: { name: "Lower Price", attack: 1, defense: 1 },
+        $price: 9_007_199_254_740_992n,
+      },
+      {
+        id: "higher",
+        ownerId: "owner-2",
+        data: { name: "Higher Price", attack: 1, defense: 1 },
+        $price: 9_007_199_254_740_993n,
+      },
+    ];
+    mockUseSession.mockReturnValue(session);
+    mockListAllCards.mockResolvedValue(largePriceCards);
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("cards").textContent).toBe(
+        "Lower Price|Higher Price",
+      );
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Sort: Rarity" }));
+    fireEvent.click(screen.getByRole("button", { name: "Sort: Name" }));
+    fireEvent.click(screen.getByRole("button", { name: "Sort: Owner" }));
+
+    expect(screen.getByTestId("cards").textContent).toBe(
+      "Higher Price|Lower Price",
+    );
+  });
+
   it("wires modal state into child props for login and card actions", async () => {
     const session = makeSession();
     mockUseSession.mockReturnValue(session);

--- a/example-apps/dashmint-lab/test/DashCardOperations.test.ts
+++ b/example-apps/dashmint-lab/test/DashCardOperations.test.ts
@@ -1,0 +1,189 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { burnCard } from "../src/dash/burnCard";
+import { purchaseCard } from "../src/dash/purchaseCard";
+import { setPrice } from "../src/dash/setPrice";
+import { transferCard } from "../src/dash/transferCard";
+import type { DashKeyManager, DashSdk } from "../src/dash/types";
+
+const { mockWithAuthedCard } = vi.hoisted(() => ({
+  mockWithAuthedCard: vi.fn(),
+}));
+
+vi.mock("../src/dash/withAuthedCard", () => ({
+  withAuthedCard: mockWithAuthedCard,
+}));
+
+const identity = { id: "buyer-identity" };
+const identityKey = { id: "auth-key" };
+const signer = { id: "signer" };
+const doc = { id: "card-1", revision: 2n };
+
+const baseParams = {
+  sdk: {
+    documents: {
+      transfer: vi.fn(),
+      setPrice: vi.fn(),
+      purchase: vi.fn(),
+      delete: vi.fn(),
+    },
+  } as unknown as DashSdk,
+  keyManager: { getAuth: vi.fn() } as unknown as DashKeyManager,
+  contractId: "contract-1",
+  cardId: "card-1",
+  log: vi.fn(),
+};
+
+function arrangeAuthedCard() {
+  mockWithAuthedCard.mockImplementation(
+    async (
+      _opts: unknown,
+      fn: (ctx: {
+        doc?: typeof doc;
+        identity: typeof identity;
+        identityKey: typeof identityKey;
+        signer: typeof signer;
+      }) => Promise<void>,
+    ) => {
+      await fn({ doc, identity, identityKey, signer });
+    },
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  arrangeAuthedCard();
+});
+
+describe("card operation wrappers", () => {
+  it("transferCard validates the recipient before starting a mutation", async () => {
+    await expect(
+      transferCard({ ...baseParams, recipientId: "" }),
+    ).rejects.toThrow("Recipient identity ID is required.");
+
+    expect(mockWithAuthedCard).not.toHaveBeenCalled();
+    expect(baseParams.sdk.documents.transfer).not.toHaveBeenCalled();
+  });
+
+  it("transferCard passes the fetched document, recipient, auth key, and signer", async () => {
+    await transferCard({ ...baseParams, recipientId: "recipient-1" });
+
+    expect(mockWithAuthedCard).toHaveBeenCalledWith(
+      {
+        sdk: baseParams.sdk,
+        keyManager: baseParams.keyManager,
+        contractId: "contract-1",
+        cardId: "card-1",
+        errorLabel: "Transfer error",
+        log: baseParams.log,
+      },
+      expect.any(Function),
+    );
+    expect(baseParams.sdk.documents.transfer).toHaveBeenCalledWith({
+      document: doc,
+      recipientId: "recipient-1",
+      identityKey,
+      signer,
+    });
+    expect(baseParams.log).toHaveBeenCalledWith(
+      "Transferring card card-1 to recipient-1…",
+    );
+    expect(baseParams.log).toHaveBeenCalledWith("Card transferred!", "success");
+  });
+
+  it("setPrice converts numeric prices to bigint and calls documents.setPrice", async () => {
+    await setPrice({ ...baseParams, price: 12345 });
+
+    expect(mockWithAuthedCard).toHaveBeenCalledWith(
+      expect.objectContaining({
+        errorLabel: "Set price error",
+        cardId: "card-1",
+      }),
+      expect.any(Function),
+    );
+    expect(baseParams.sdk.documents.setPrice).toHaveBeenCalledWith({
+      document: doc,
+      price: 12345n,
+      identityKey,
+      signer,
+    });
+    expect(baseParams.log).toHaveBeenCalledWith(
+      "Setting price 12345 credits on card card-1…",
+    );
+    expect(baseParams.log).toHaveBeenCalledWith("Price set!", "success");
+  });
+
+  it("setPrice treats a zero price as removing the sale price", async () => {
+    await setPrice({ ...baseParams, price: 0n });
+
+    expect(mockWithAuthedCard).toHaveBeenCalledWith(
+      expect.objectContaining({ errorLabel: "Remove price error" }),
+      expect.any(Function),
+    );
+    expect(baseParams.sdk.documents.setPrice).toHaveBeenCalledWith({
+      document: doc,
+      price: 0n,
+      identityKey,
+      signer,
+    });
+    expect(baseParams.log).toHaveBeenCalledWith(
+      "Removing price from card card-1…",
+    );
+    expect(baseParams.log).toHaveBeenCalledWith(
+      "Card removed from sale.",
+      "success",
+    );
+  });
+
+  it("purchaseCard submits the current identity as buyerId and preserves bigint prices", async () => {
+    await purchaseCard({ ...baseParams, price: 99n });
+
+    expect(mockWithAuthedCard).toHaveBeenCalledWith(
+      expect.objectContaining({
+        errorLabel: "Purchase error",
+        cardId: "card-1",
+      }),
+      expect.any(Function),
+    );
+    expect(baseParams.sdk.documents.purchase).toHaveBeenCalledWith({
+      document: doc,
+      buyerId: "buyer-identity",
+      price: 99n,
+      identityKey,
+      signer,
+    });
+    expect(baseParams.log).toHaveBeenCalledWith(
+      "Purchasing card card-1 for 99 credits…",
+    );
+    expect(baseParams.log).toHaveBeenCalledWith("Card purchased!", "success");
+  });
+
+  it("burnCard skips document prefetch and sends the minimal delete document", async () => {
+    await burnCard(baseParams);
+
+    expect(mockWithAuthedCard).toHaveBeenCalledWith(
+      {
+        sdk: baseParams.sdk,
+        keyManager: baseParams.keyManager,
+        contractId: "contract-1",
+        cardId: "card-1",
+        preFetch: false,
+        errorLabel: "Burn error",
+        log: baseParams.log,
+      },
+      expect.any(Function),
+    );
+    expect(baseParams.sdk.documents.delete).toHaveBeenCalledWith({
+      document: {
+        id: "card-1",
+        ownerId: "buyer-identity",
+        dataContractId: "contract-1",
+        documentTypeName: "card",
+      },
+      identityKey,
+      signer,
+    });
+    expect(baseParams.log).toHaveBeenCalledWith("Burning card card-1…");
+    expect(baseParams.log).toHaveBeenCalledWith("Card burned.", "success");
+  });
+});

--- a/example-apps/dashmint-lab/test/PurchaseModal.test.tsx
+++ b/example-apps/dashmint-lab/test/PurchaseModal.test.tsx
@@ -41,6 +41,7 @@ const sessionValue = {
   sdk: {} as DashSdk,
   keyManager: {} as DashKeyManager,
   contractId: "contract-1",
+  balance: null as bigint | null,
   log: vi.fn(),
 };
 
@@ -108,5 +109,45 @@ describe("PurchaseModal", () => {
 
     expect(onPurchased).toHaveBeenCalledTimes(1);
     expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables Buy and warns when balance is below the price", () => {
+    mockUseSession.mockReturnValue({ ...sessionValue, balance: 10n });
+
+    render(<PurchaseModal card={card} onClose={vi.fn()} />);
+
+    const buyButton = screen.getByRole("button", {
+      name: "Insufficient credits",
+    });
+    expect(buyButton.hasAttribute("disabled")).toBe(true);
+    expect(
+      screen.getByText("Not enough credits to buy this card."),
+    ).toBeTruthy();
+
+    fireEvent.click(buyButton);
+    expect(mockPurchaseCard).not.toHaveBeenCalled();
+  });
+
+  it("enables Buy with no warning when balance covers the price", () => {
+    mockUseSession.mockReturnValue({ ...sessionValue, balance: 25n });
+
+    render(<PurchaseModal card={card} onClose={vi.fn()} />);
+
+    const buyButton = screen.getByRole("button", { name: "Buy" });
+    expect(buyButton.hasAttribute("disabled")).toBe(false);
+    expect(
+      screen.queryByText("Not enough credits to buy this card."),
+    ).toBeNull();
+  });
+
+  it("does not warn while the balance is still loading (null)", () => {
+    mockUseSession.mockReturnValue({ ...sessionValue, balance: null });
+
+    render(<PurchaseModal card={card} onClose={vi.fn()} />);
+
+    expect(screen.getByRole("button", { name: "Buy" })).toBeTruthy();
+    expect(
+      screen.queryByText("Not enough credits to buy this card."),
+    ).toBeNull();
   });
 });

--- a/example-apps/dashmint-lab/test/SetPriceModal.test.tsx
+++ b/example-apps/dashmint-lab/test/SetPriceModal.test.tsx
@@ -9,7 +9,10 @@ import {
 } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { SetPriceModal } from "../src/components/SetPriceModal";
+import {
+  MAX_PRICE_CREDITS,
+  SetPriceModal,
+} from "../src/components/SetPriceModal";
 import type { Card } from "../src/dash/queries";
 import type { DashKeyManager, DashSdk } from "../src/dash/types";
 
@@ -126,6 +129,25 @@ describe("SetPriceModal", () => {
 
     expect(onPriced).toHaveBeenCalledTimes(1);
     expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("sets a maximum price and blocks larger values", async () => {
+    mockUseSession.mockReturnValue(sessionValue);
+
+    render(<SetPriceModal card={unlistedCard} onClose={vi.fn()} />);
+
+    const priceInput = screen.getByLabelText("Price");
+    expect(priceInput.getAttribute("max")).toBe(String(MAX_PRICE_CREDITS));
+
+    fireEvent.change(priceInput, {
+      target: { value: String(MAX_PRICE_CREDITS + 1) },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "List for sale" }));
+
+    expect(mockSetPrice).not.toHaveBeenCalled();
+    expect(screen.getByRole("alert").textContent).toContain(
+      "Price must be between 1 and 1,000,000,000,000,000 credits.",
+    );
   });
 
   it("treats $price === 0n as unlisted (zero is not a valid price)", () => {

--- a/example-apps/dashmint-lab/test/SetPriceModal.test.tsx
+++ b/example-apps/dashmint-lab/test/SetPriceModal.test.tsx
@@ -114,7 +114,7 @@ describe("SetPriceModal", () => {
       keyManager: sessionValue.keyManager,
       contractId: "contract-1",
       cardId: "card-1",
-      price: 42,
+      price: 42n,
       log: sessionValue.log,
     });
 
@@ -147,6 +147,24 @@ describe("SetPriceModal", () => {
     expect(mockSetPrice).not.toHaveBeenCalled();
     expect(screen.getByRole("alert").textContent).toContain(
       "Price must be between 1 and 1,000,000,000,000,000 credits.",
+    );
+  });
+
+  it("submits the maximum accepted price as an exact bigint", async () => {
+    mockUseSession.mockReturnValue(sessionValue);
+    mockSetPrice.mockResolvedValueOnce(undefined);
+
+    render(<SetPriceModal card={unlistedCard} onClose={vi.fn()} />);
+
+    fireEvent.change(screen.getByLabelText("Price"), {
+      target: { value: String(MAX_PRICE_CREDITS) },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "List for sale" }));
+
+    expect(mockSetPrice).toHaveBeenCalledWith(
+      expect.objectContaining({
+        price: BigInt(MAX_PRICE_CREDITS),
+      }),
     );
   });
 

--- a/example-apps/dashmint-lab/test/UiPrimitives.test.tsx
+++ b/example-apps/dashmint-lab/test/UiPrimitives.test.tsx
@@ -1,0 +1,207 @@
+// @vitest-environment jsdom
+
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  within,
+} from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { AppShell } from "../src/components/AppShell";
+import { CardGrid } from "../src/components/CardGrid";
+import { HowItWorks } from "../src/components/HowItWorks";
+import { SubTabs } from "../src/components/Tabs";
+import type { Card } from "../src/dash/queries";
+
+const { mockUseDpnsName } = vi.hoisted(() => ({
+  mockUseDpnsName: vi.fn(),
+}));
+
+vi.mock("../src/hooks/useDpnsName", () => ({
+  useDpnsName: mockUseDpnsName,
+}));
+
+vi.mock("../src/components/CardTile", () => ({
+  CardTile: ({
+    card,
+    onTransfer,
+  }: {
+    card: Card;
+    onTransfer?: (card: Card) => void;
+  }) => (
+    <article>
+      <h3>{card.data.name}</h3>
+      <button type="button" onClick={() => onTransfer?.(card)}>
+        Transfer {card.id}
+      </button>
+    </article>
+  ),
+}));
+
+const cards: Card[] = [
+  {
+    id: "card-1",
+    ownerId: "owner-1",
+    data: { name: "Fire Dragon", attack: 9, defense: 8 },
+  },
+  {
+    id: "card-2",
+    ownerId: "owner-2",
+    data: { name: "Aqua Spirit", attack: 3, defense: 4 },
+  },
+];
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("AppShell", () => {
+  it("shows sidebar login navigation when the session is not authenticated", () => {
+    const onLoginOpen = vi.fn();
+
+    render(
+      <AppShell
+        tab="collection"
+        onTabChange={vi.fn()}
+        status="browsing"
+        identityId={null}
+        sdk={null}
+        onLoginOpen={onLoginOpen}
+      >
+        <div>Collection content</div>
+      </AppShell>,
+    );
+
+    const sidebar = screen.getByRole("complementary", {
+      name: "Main navigation",
+    });
+    fireEvent.click(within(sidebar).getByRole("button", { name: /Login/ }));
+
+    expect(onLoginOpen).toHaveBeenCalledTimes(1);
+    expect(screen.getByText("Collection content")).toBeTruthy();
+  });
+
+  it("closes the mobile drawer after selecting a navigation item", () => {
+    const onTabChange = vi.fn();
+
+    render(
+      <AppShell
+        tab="collection"
+        onTabChange={onTabChange}
+        status="browsing"
+        identityId={null}
+        sdk={null}
+        onLoginOpen={vi.fn()}
+      >
+        <div>Collection content</div>
+      </AppShell>,
+    );
+
+    const menuButton = screen.getByRole("button", { name: "Open menu" });
+    fireEvent.click(menuButton);
+    expect(menuButton.getAttribute("aria-expanded")).toBe("true");
+
+    const sidebar = screen.getByRole("complementary", {
+      name: "Main navigation",
+    });
+    fireEvent.click(within(sidebar).getByRole("button", { name: /Mint/ }));
+
+    expect(onTabChange).toHaveBeenCalledWith("mint");
+    expect(menuButton.getAttribute("aria-expanded")).toBe("false");
+  });
+
+  it("hides login navigation and shows identity details when authenticated", () => {
+    mockUseDpnsName.mockReturnValue("alice");
+
+    render(
+      <AppShell
+        tab="collection"
+        onTabChange={vi.fn()}
+        status="authenticated"
+        identityId="identity-1234567890"
+        sdk={{} as never}
+        onLoginOpen={vi.fn()}
+      >
+        <div>Collection content</div>
+      </AppShell>,
+    );
+
+    const sidebar = screen.getByRole("complementary", {
+      name: "Main navigation",
+    });
+    expect(within(sidebar).queryByRole("button", { name: /Login/ })).toBeNull();
+    expect(screen.getByText("Signed in")).toBeTruthy();
+    expect(screen.getByText("@alice")).toBeTruthy();
+  });
+});
+
+describe("SubTabs", () => {
+  it("hides the Yours tab for browse-only users", () => {
+    render(<SubTabs value="all" onChange={vi.fn()} showMy={false} />);
+
+    expect(screen.queryByRole("button", { name: "Yours" })).toBeNull();
+    expect(screen.getByRole("button", { name: "All" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Marketplace" })).toBeTruthy();
+  });
+
+  it("emits tab changes for visible collection tabs", () => {
+    const onChange = vi.fn();
+    render(<SubTabs value="my" onChange={onChange} showMy />);
+
+    fireEvent.click(screen.getByRole("button", { name: "All" }));
+    fireEvent.click(screen.getByRole("button", { name: "Marketplace" }));
+    fireEvent.click(screen.getByRole("button", { name: "Yours" }));
+
+    expect(onChange).toHaveBeenNthCalledWith(1, "all");
+    expect(onChange).toHaveBeenNthCalledWith(2, "marketplace");
+    expect(onChange).toHaveBeenNthCalledWith(3, "my");
+  });
+});
+
+describe("CardGrid", () => {
+  it("renders the configured empty message when there are no cards", () => {
+    render(
+      <CardGrid
+        cards={[]}
+        currentIdentityId={null}
+        emptyMessage="Nothing minted yet."
+      />,
+    );
+
+    expect(screen.getByText("Nothing minted yet.")).toBeTruthy();
+  });
+
+  it("renders one CardTile per card and forwards callbacks", () => {
+    const onTransfer = vi.fn();
+
+    render(
+      <CardGrid
+        cards={cards}
+        currentIdentityId="owner-1"
+        onTransfer={onTransfer}
+      />,
+    );
+
+    expect(screen.getByText("Fire Dragon")).toBeTruthy();
+    expect(screen.getByText("Aqua Spirit")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Transfer card-2" }));
+
+    expect(onTransfer).toHaveBeenCalledWith(cards[1]);
+  });
+});
+
+describe("HowItWorks", () => {
+  it("maps the mint operation to the token-paid document create call", () => {
+    render(<HowItWorks />);
+
+    expect(screen.getByText("Platform operations at a glance")).toBeTruthy();
+    expect(screen.getByText("Mint card")).toBeTruthy();
+    expect(
+      screen.getByText("sdk.documents.create + tokenPaymentInfo"),
+    ).toBeTruthy();
+  });
+});

--- a/example-apps/dashmint-lab/test/logger.test.ts
+++ b/example-apps/dashmint-lab/test/logger.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import { errorMessage } from "../src/dash/logger";
+
+describe("errorMessage", () => {
+  it("reads .message from Error instances", () => {
+    expect(errorMessage(new Error("boom"))).toBe("boom");
+  });
+
+  it("returns string values as-is", () => {
+    expect(errorMessage("already a string")).toBe("already a string");
+  });
+
+  it("reads .message from plain objects (Evo SDK throws these)", () => {
+    expect(errorMessage({ message: "wasm failed", code: 7 })).toBe(
+      "wasm failed",
+    );
+  });
+
+  it("JSON-stringifies objects without a string message", () => {
+    expect(errorMessage({ code: 7, detail: "nope" })).toBe(
+      '{"code":7,"detail":"nope"}',
+    );
+  });
+
+  it("falls back to String() when JSON.stringify throws (circular refs)", () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    expect(errorMessage(circular)).toBe("[object Object]");
+  });
+
+  it("handles primitives that are neither Error nor string", () => {
+    expect(errorMessage(42)).toBe("42");
+    expect(errorMessage(null)).toBe("null");
+  });
+});

--- a/example-apps/dashmint-lab/test/queries.test.ts
+++ b/example-apps/dashmint-lab/test/queries.test.ts
@@ -1,0 +1,148 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  listAllCards,
+  listMarketplaceCards,
+  listMyCards,
+  normalizeCards,
+} from "../src/dash/queries";
+import type { DashSdk } from "../src/dash/types";
+
+const rawCards = {
+  "doc-1": {
+    $ownerId: "owner-1",
+    name: "Fire Dragon",
+    description: "Hot",
+    attack: 9,
+    defense: 8,
+    $price: 50n,
+  },
+  "doc-2": {
+    $ownerId: "owner-2",
+    name: "Aqua Spirit",
+    attack: 3,
+    defense: 4,
+  },
+  "doc-3": {
+    $ownerId: "owner-3",
+    name: "Unlisted Golem",
+    attack: 4,
+    defense: 9,
+    $price: 0n,
+  },
+};
+
+function makeSdk(results: unknown): DashSdk {
+  return {
+    documents: {
+      query: vi.fn().mockResolvedValue(results),
+    },
+  } as unknown as DashSdk;
+}
+
+let log: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  log = vi.fn();
+});
+
+describe("card queries", () => {
+  it("normalizes plain object query results keyed by document id", () => {
+    expect(normalizeCards(rawCards)).toEqual([
+      {
+        id: "doc-1",
+        ownerId: "owner-1",
+        data: {
+          name: "Fire Dragon",
+          description: "Hot",
+          attack: 9,
+          defense: 8,
+        },
+        $price: 50n,
+      },
+      {
+        id: "doc-2",
+        ownerId: "owner-2",
+        data: {
+          name: "Aqua Spirit",
+          description: undefined,
+          attack: 3,
+          defense: 4,
+        },
+        $price: undefined,
+      },
+      {
+        id: "doc-3",
+        ownerId: "owner-3",
+        data: {
+          name: "Unlisted Golem",
+          description: undefined,
+          attack: 4,
+          defense: 9,
+        },
+        $price: 0n,
+      },
+    ]);
+  });
+
+  it("listMyCards queries the owner-scoped collection", async () => {
+    const sdk = makeSdk(rawCards);
+
+    const cards = await listMyCards({
+      sdk,
+      contractId: "contract-1",
+      identityId: "owner-1",
+      log,
+    });
+
+    expect(sdk.documents.query).toHaveBeenCalledWith({
+      dataContractId: "contract-1",
+      documentTypeName: "card",
+      where: [["$ownerId", "==", "owner-1"]],
+      limit: 100,
+    });
+    expect(cards).toHaveLength(3);
+    expect(log).toHaveBeenCalledWith("Loading your cards…");
+    expect(log).toHaveBeenCalledWith("Found 3 card(s).");
+  });
+
+  it("listAllCards uses the caller-provided limit", async () => {
+    const sdk = makeSdk([]);
+
+    await expect(
+      listAllCards({
+        sdk,
+        contractId: "contract-1",
+        limit: 25,
+        log,
+      }),
+    ).resolves.toEqual([]);
+
+    expect(sdk.documents.query).toHaveBeenCalledWith({
+      dataContractId: "contract-1",
+      documentTypeName: "card",
+      limit: 25,
+    });
+    expect(log).toHaveBeenCalledWith("Loading all cards (any owner)…");
+    expect(log).toHaveBeenCalledWith("Found 0 card(s) total.");
+  });
+
+  it("listMarketplaceCards returns only cards with a non-zero sale price", async () => {
+    const sdk = makeSdk(rawCards);
+
+    const cards = await listMarketplaceCards({
+      sdk,
+      contractId: "contract-1",
+      log,
+    });
+
+    expect(sdk.documents.query).toHaveBeenCalledWith({
+      dataContractId: "contract-1",
+      documentTypeName: "card",
+      limit: 100,
+    });
+    expect(cards.map((card) => card.id)).toEqual(["doc-1"]);
+    expect(log).toHaveBeenCalledWith("Loading marketplace…");
+    expect(log).toHaveBeenCalledWith("Found 1 card(s) for sale.");
+  });
+});

--- a/example-apps/dashmint-lab/test/useDpnsName.test.tsx
+++ b/example-apps/dashmint-lab/test/useDpnsName.test.tsx
@@ -1,0 +1,125 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { useDpnsName } from "../src/hooks/useDpnsName";
+import type { DashSdk } from "../src/dash/types";
+
+function makeSdk(username: ReturnType<typeof vi.fn>): DashSdk {
+  return {
+    dpns: {
+      username,
+      resolveName: vi.fn(),
+    },
+  } as unknown as DashSdk;
+}
+
+function Probe({
+  sdk,
+  identityId,
+}: {
+  sdk?: DashSdk | null;
+  identityId?: string | null;
+}) {
+  const name = useDpnsName(sdk, identityId);
+  return <div data-testid="name">{name ?? ""}</div>;
+}
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("useDpnsName", () => {
+  it("does not resolve until both sdk and identity id are available", () => {
+    const username = vi.fn();
+    const sdk = makeSdk(username);
+
+    render(<Probe sdk={sdk} identityId={null} />);
+
+    expect(screen.getByTestId("name").textContent).toBe("");
+    expect(username).not.toHaveBeenCalled();
+  });
+
+  it("resolves an identity id and strips the display-only .dash suffix", async () => {
+    const username = vi.fn().mockResolvedValue("alice.dash");
+    const sdk = makeSdk(username);
+
+    render(<Probe sdk={sdk} identityId="identity-use-dpns-name-1" />);
+
+    expect(screen.getByTestId("name").textContent).toBe("");
+    await waitFor(() => {
+      expect(screen.getByTestId("name").textContent).toBe("alice");
+    });
+    expect(username).toHaveBeenCalledWith("identity-use-dpns-name-1");
+  });
+
+  it("keeps names that do not end in the display-only .dash suffix", async () => {
+    const username = vi.fn().mockResolvedValue("alice");
+    const sdk = makeSdk(username);
+
+    render(<Probe sdk={sdk} identityId="identity-use-dpns-name-2" />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("name").textContent).toBe("alice");
+    });
+  });
+
+  it.each([
+    ["missing", undefined],
+    ["numeric", 123],
+    ["object", { label: "alice.dash" }],
+  ])("treats %s DPNS responses as no display name", async (_case, value) => {
+    const username = vi.fn().mockResolvedValue(value);
+    const sdk = makeSdk(username);
+
+    render(<Probe sdk={sdk} identityId={`identity-use-dpns-name-${_case}`} />);
+
+    await waitFor(() => {
+      expect(username).toHaveBeenCalledTimes(1);
+    });
+    expect(screen.getByTestId("name").textContent).toBe("");
+  });
+
+  it("reuses the module-level cache across hook mounts", async () => {
+    const username = vi.fn().mockResolvedValue("cached-name.dash");
+    const sdk = makeSdk(username);
+
+    const first = render(
+      <Probe sdk={sdk} identityId="identity-use-dpns-name-cache" />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("name").textContent).toBe("cached-name");
+    });
+    first.unmount();
+
+    render(<Probe sdk={sdk} identityId="identity-use-dpns-name-cache" />);
+
+    expect(screen.getByTestId("name").textContent).toBe("cached-name");
+    expect(username).toHaveBeenCalledTimes(1);
+  });
+
+  it("shares an in-flight lookup across sibling hook instances", async () => {
+    const username = vi.fn().mockResolvedValue("shared-name.dash");
+    const sdk = makeSdk(username);
+
+    function Pair() {
+      return (
+        <>
+          <Probe sdk={sdk} identityId="identity-use-dpns-name-shared" />
+          <Probe sdk={sdk} identityId="identity-use-dpns-name-shared" />
+        </>
+      );
+    }
+
+    render(<Pair />);
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId("name").map((el) => el.textContent)).toEqual(
+        ["shared-name", "shared-name"],
+      );
+    });
+    expect(username).toHaveBeenCalledTimes(1);
+  });
+});

--- a/example-apps/dashmint-lab/test/useResolvedRecipient.test.tsx
+++ b/example-apps/dashmint-lab/test/useResolvedRecipient.test.tsx
@@ -1,0 +1,224 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { DashSdk } from "../src/dash/types";
+import { useResolvedRecipient } from "../src/hooks/useResolvedRecipient";
+
+const { mockResolveDpnsName } = vi.hoisted(() => ({
+  mockResolveDpnsName: vi.fn(),
+}));
+
+vi.mock("../src/dash/resolveRecipient", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../src/dash/resolveRecipient")>();
+  return {
+    ...actual,
+    resolveDpnsName: mockResolveDpnsName,
+  };
+});
+
+const sdk = {
+  dpns: {
+    resolveName: vi.fn(),
+    username: vi.fn(),
+  },
+} as unknown as DashSdk;
+
+function Probe({
+  currentSdk = sdk,
+  input,
+}: {
+  currentSdk?: DashSdk | null;
+  input?: string | null;
+}) {
+  const state = useResolvedRecipient(currentSdk, input);
+  return <div data-testid="state">{JSON.stringify(state)}</div>;
+}
+
+function state() {
+  return JSON.parse(screen.getByTestId("state").textContent ?? "{}");
+}
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("useResolvedRecipient", () => {
+  it("stays idle when there is no sdk or resolvable input", () => {
+    render(<Probe currentSdk={null} input="alice.dash" />);
+    expect(state()).toEqual({ status: "idle" });
+    expect(mockResolveDpnsName).not.toHaveBeenCalled();
+
+    cleanup();
+
+    render(<Probe input="   " />);
+    expect(state()).toEqual({ status: "idle" });
+    expect(mockResolveDpnsName).not.toHaveBeenCalled();
+  });
+
+  it("normalizes a DPNS name, resolves it, and reports the identity id", async () => {
+    mockResolveDpnsName.mockResolvedValueOnce("identity-recipient-1");
+
+    render(<Probe input=" Alice.DASH " />);
+
+    expect(state()).toEqual({ status: "resolving" });
+    await waitFor(() => {
+      expect(state()).toEqual({
+        status: "resolved",
+        identityId: "identity-recipient-1",
+      });
+    });
+    expect(mockResolveDpnsName).toHaveBeenCalledWith(sdk, "alice.dash");
+  });
+
+  it("reports not-found when DPNS resolution completes without an identity", async () => {
+    mockResolveDpnsName.mockResolvedValueOnce(null);
+
+    render(<Probe input="missing-recipient-name" />);
+
+    await waitFor(() => {
+      expect(state()).toEqual({ status: "not-found" });
+    });
+    expect(mockResolveDpnsName).toHaveBeenCalledWith(
+      sdk,
+      "missing-recipient-name.dash",
+    );
+  });
+
+  it("reuses cached not-found results across hook mounts", async () => {
+    mockResolveDpnsName.mockResolvedValueOnce(null);
+
+    const first = render(<Probe input="cached-missing-recipient" />);
+    await waitFor(() => {
+      expect(state()).toEqual({ status: "not-found" });
+    });
+    first.unmount();
+
+    render(<Probe input="cached-missing-recipient" />);
+
+    expect(state()).toEqual({ status: "not-found" });
+    expect(mockResolveDpnsName).toHaveBeenCalledTimes(1);
+  });
+
+  it("reuses cached resolved names across hook mounts", async () => {
+    mockResolveDpnsName.mockResolvedValueOnce("identity-recipient-cache");
+
+    const first = render(<Probe input="cached-recipient-name" />);
+    await waitFor(() => {
+      expect(state()).toEqual({
+        status: "resolved",
+        identityId: "identity-recipient-cache",
+      });
+    });
+    first.unmount();
+
+    render(<Probe input="cached-recipient-name" />);
+
+    expect(state()).toEqual({
+      status: "resolved",
+      identityId: "identity-recipient-cache",
+    });
+    expect(mockResolveDpnsName).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not cache transient resolver errors across mounts", async () => {
+    mockResolveDpnsName
+      .mockRejectedValueOnce(new Error("temporary network failure"))
+      .mockResolvedValueOnce("identity-recipient-retry");
+
+    const first = render(<Probe input="retry-recipient-name" />);
+    await waitFor(() => {
+      expect(mockResolveDpnsName).toHaveBeenCalledTimes(1);
+    });
+    first.unmount();
+
+    render(<Probe input="retry-recipient-name" />);
+
+    await waitFor(() => {
+      expect(state()).toEqual({
+        status: "resolved",
+        identityId: "identity-recipient-retry",
+      });
+    });
+    expect(mockResolveDpnsName).toHaveBeenCalledTimes(2);
+  });
+
+  it("shares one in-flight lookup across sibling hook instances", async () => {
+    // Hold the lookup pending so the second sibling's effect runs while the
+    // cache entry is still a Promise, exercising the shared-promise branch.
+    let resolveLookup: (value: string) => void = () => {};
+    mockResolveDpnsName.mockReturnValueOnce(
+      new Promise<string>((resolve) => {
+        resolveLookup = resolve;
+      }),
+    );
+
+    function Pair() {
+      return (
+        <>
+          <Probe input="shared-recipient-name" />
+          <Probe input="shared-recipient-name" />
+        </>
+      );
+    }
+
+    render(<Pair />);
+
+    expect(mockResolveDpnsName).toHaveBeenCalledTimes(1);
+    expect(screen.getAllByTestId("state").map((el) => el.textContent)).toEqual([
+      JSON.stringify({ status: "resolving" }),
+      JSON.stringify({ status: "resolving" }),
+    ]);
+
+    resolveLookup("identity-recipient-shared");
+
+    await waitFor(() => {
+      expect(
+        screen
+          .getAllByTestId("state")
+          .map((el) => JSON.parse(el.textContent ?? "{}")),
+      ).toEqual([
+        { status: "resolved", identityId: "identity-recipient-shared" },
+        { status: "resolved", identityId: "identity-recipient-shared" },
+      ]);
+    });
+    expect(mockResolveDpnsName).toHaveBeenCalledTimes(1);
+  });
+
+  it("propagates a rejected shared lookup to sibling hooks", async () => {
+    let rejectLookup: (reason: Error) => void = () => {};
+    mockResolveDpnsName.mockReturnValueOnce(
+      new Promise<string>((_resolve, reject) => {
+        rejectLookup = reject;
+      }),
+    );
+
+    function Pair() {
+      return (
+        <>
+          <Probe input="failing-recipient-name" />
+          <Probe input="failing-recipient-name" />
+        </>
+      );
+    }
+
+    render(<Pair />);
+    expect(mockResolveDpnsName).toHaveBeenCalledTimes(1);
+
+    rejectLookup(new Error("shared lookup failed"));
+
+    // Both siblings re-render after the rejection; the dropped cache entry
+    // returns them to "resolving"; a later remount or key/sdk change can retry.
+    await waitFor(() => {
+      expect(
+        screen.getAllByTestId("state").map((el) => el.textContent),
+      ).toEqual([
+        JSON.stringify({ status: "resolving" }),
+        JSON.stringify({ status: "resolving" }),
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

A collection of related improvements to the DashMint Lab example app, centered on card pricing and test coverage.

- **Exact bigint prices** — card prices are read and submitted as exact `bigint` values instead of being coerced through `number`, avoiding precision loss on large prices.
- **Price cap below the SDK serialization limit** — listing a card caps the price below the value where SDK serialization fails, instead of letting the write be rejected on-chain.
- **Insufficient-credits indicator on the Buy screen** — `PurchaseModal` now shows the buyer's balance, warns when it's below the card price, and disables the Buy button (relabeled "Insufficient credits") up front, instead of failing only with a raw SDK error after the click.
- **Card row alignment** — the price chip reserves its height so card rows stay aligned whether or not a card is listed.

## Tests

- Adds unit coverage across dash ops, queries, logger, hooks (`useDpnsName`, `useResolvedRecipient`), and UI primitives.
- Adds `PurchaseModal` cases for the insufficient-credits states and extends `SetPriceModal` / `App` coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Purchase modal now displays your current credit balance and prevents purchases when insufficient credits are available.
  * Price setting enforces a maximum price cap.

* **Bug Fixes**
  * Improved price sorting accuracy for large values.
  * Fixed card header alignment for better visual consistency.
  * Corrected zero-price handling in marketplace listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->