### PR TITLE
fix: repair root typecheck and pin lint/format tooling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,9 @@
         "@types/node": "25.5.0",
         "chai": "6.2.2",
         "eslint": "8.45.0",
-        "mocha": "11.7.5"
+        "mocha": "11.7.5",
+        "prettier": "3.8.1",
+        "typescript": "4.9.5"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -330,6 +332,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
       "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
       "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -630,6 +633,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.45.0.tgz",
       "integrity": "sha512-pd8KSxiQpdYRfYa9Wufvdoct3ZPQQuVuU5O6scNgMuOMYuxvH0IGaYK0wUFjo4UYYQQCUndlXiMbnxopwvvTiw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.4.0",
@@ -1460,6 +1464,22 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prettier": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
+      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
@@ -1754,6 +1774,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
       }
     },
     "node_modules/undici-types": {
@@ -2123,7 +2157,8 @@
       "version": "8.10.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
       "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "acorn-jsx": {
       "version": "5.3.2",
@@ -2325,6 +2360,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.45.0.tgz",
       "integrity": "sha512-pd8KSxiQpdYRfYa9Wufvdoct3ZPQQuVuU5O6scNgMuOMYuxvH0IGaYK0wUFjo4UYYQQCUndlXiMbnxopwvvTiw==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.4.0",
@@ -2926,6 +2962,12 @@
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true
     },
+    "prettier": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
+      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+      "dev": true
+    },
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
@@ -3099,6 +3141,12 @@
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true
+    },
+    "typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true
     },
     "undici-types": {

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "Tutorial code for https://docs.dash.org/platform",
   "main": "connect.mjs",
   "scripts": {
-    "fmt": "npx prettier@3.8.1 --write '**/*.{js,mjs}'",
-    "lint": "npx -p typescript@4 tsc",
+    "fmt": "prettier --write '**/*.{js,mjs}'",
+    "lint": "tsc",
     "test": "node --test --test-timeout=120000 test/read-only.test.mjs",
     "test:read-only": "node --test --test-timeout=120000 test/read-only.test.mjs",
     "test:read-write": "node --test --test-timeout=300000 --test-concurrency=1 test/read-write.test.mjs",
@@ -31,6 +31,8 @@
     "@types/node": "25.5.0",
     "chai": "6.2.2",
     "eslint": "8.45.0",
-    "mocha": "11.7.5"
+    "mocha": "11.7.5",
+    "prettier": "3.8.1",
+    "typescript": "4.9.5"
   }
 }

--- a/setupDashClient-core.d.mts
+++ b/setupDashClient-core.d.mts
@@ -1,9 +1,20 @@
 import type {
   DataContract,
+  EvoSDK,
   Identity,
   IdentityPublicKey,
   IdentitySigner,
+  PlatformAddress,
+  PlatformAddressInfo,
+  PlatformAddressSigner,
 } from "@dashevo/evo-sdk";
+
+interface AddressEntry {
+  address: PlatformAddress;
+  bech32m: string;
+  privateKeyWif: string;
+  path: string;
+}
 
 interface ConnectedDocumentLike {
   revision?: bigint | number | string;
@@ -25,7 +36,7 @@ interface ConnectedDocumentTokenPaymentInfo {
     | 2;
 }
 
-interface ConnectedDashClientLike {
+export interface ConnectedDashClientLike {
   contracts: {
     fetch(contractId: string): Promise<{
       toJSON?: () => Record<string, unknown>;
@@ -148,6 +159,12 @@ export declare class IdentityKeyManager {
     network?: string;
     identityIndex?: number;
   }): Promise<IdentityKeyManager>;
+  static createForNewIdentity(opts: {
+    sdk: ConnectedDashClientLike;
+    mnemonic: string;
+    network?: string;
+    identityIndex?: number;
+  }): Promise<IdentityKeyManager>;
   readonly identityId: string | null | undefined;
   getAuth(): Promise<{
     identity: Identity;
@@ -161,6 +178,29 @@ export declare class IdentityKeyManager {
   }>;
 }
 
+export declare class AddressKeyManager {
+  static create(opts: {
+    sdk: ConnectedDashClientLike;
+    mnemonic: string;
+    network?: string;
+    count?: number;
+  }): Promise<AddressKeyManager>;
+  readonly addresses: AddressEntry[];
+  readonly primaryAddress: AddressEntry;
+  getSigner(): PlatformAddressSigner;
+  getFullSigner(): PlatformAddressSigner;
+  getInfo(): Promise<PlatformAddressInfo | undefined>;
+  getInfoAt(index: number): Promise<PlatformAddressInfo | undefined>;
+}
+
+export declare const KEY_SPECS: readonly unknown[];
+
+export declare function dip13KeyPath(
+  network: string,
+  identityIndex: number,
+  keyIndex: number,
+): Promise<string>;
+
 export declare function createClient(
   network?: string,
-): Promise<ConnectedDashClientLike>;
+): Promise<ConnectedDashClientLike & EvoSDK>;

--- a/view-wallet.mjs
+++ b/view-wallet.mjs
@@ -22,6 +22,7 @@ try {
   const { bech32m, path } = addressKeyManager.primaryAddress;
 
   let identityId = 'No identity found for this mnemonic';
+  let balance = null;
   try {
     const keyManager = await IdentityKeyManager.create({
       sdk,
@@ -29,6 +30,8 @@ try {
       network,
     });
     identityId = keyManager.identityId;
+    const identity = await sdk.identities.fetch(identityId);
+    balance = identity.balance;
   } catch (e) {
     if (!e.message?.includes('No identity found for the given mnemonic'))
       throw e;
@@ -43,6 +46,14 @@ try {
     `https://bridge.thepasta.org/?address=${bech32m}`,
   );
   console.log('Identity ID:     ', identityId);
+  if (balance !== null) {
+    // 1000 credits = 1 duff, 100_000_000 duffs = 1 Dash
+    const dash = Number(balance) / 1e11;
+    console.log(
+      'Identity balance:',
+      `${balance} credits (${dash.toFixed(8)} DASH)`,
+    );
+  }
 } catch (e) {
   console.error('Something went wrong:\n', e.message);
 }


### PR DESCRIPTION
## Summary

The root `npm run lint` was failing against `setupDashClient.mjs`. This branch fixes the typecheck, pins the tooling it depends on, and adds an identity balance readout to `view-wallet.mjs`.

## What changed

- **Fix root typecheck** — `setupDashClient-core.d.mts` was added as a narrow typed boundary for the example apps and only declared the subset they consume. Because the root `tsc` resolves this `.d.mts` instead of the JSDoc-typed `.mjs`, the wrapper failed to typecheck against members it relies on. Declared the missing exports and widened `createClient`'s return to the full SDK surface; the example apps' imports are unaffected.
- **Pin tooling** — moved `prettier` and `typescript` from `npx` to pinned `devDependencies` and pointed the `fmt`/`lint` scripts at the local binaries.
- **view-wallet balance** — `view-wallet.mjs` now fetches the identity and prints its balance in credits and DASH.

## Test plan

- [x] `npm run lint` passes (previously errored)
- [x] `node view-wallet.mjs` shows the identity balance line

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added address management capabilities with new key management functionality
  * Introduced new identity key manager factory method for streamlined setup
  * Wallet now displays balance information including credits and converted DASH value

<!-- end of auto-generated comment: release notes by coderabbit.ai -->