### PR TITLE
feat(dashproof-lab): prevent duplicate anchors with pre-flight check and clear rejection message

### DIFF
--- a/example-apps/dashproof-lab/src/App.tsx
+++ b/example-apps/dashproof-lab/src/App.tsx
@@ -112,6 +112,7 @@ function App() {
               contractId={session.contractId}
               onLoginPrompt={() => setLoginOpen(true)}
               onAnchored={() => setRefreshKey((value) => value + 1)}
+              onViewChainHistory={openHistoryForChain}
             />
           )}
           {tab === "verify" && (

--- a/example-apps/dashproof-lab/src/components/AnchorForm.tsx
+++ b/example-apps/dashproof-lab/src/components/AnchorForm.tsx
@@ -11,8 +11,14 @@ import {
 
 import { createAnchor } from "../dash/createAnchor";
 import { errorMessage } from "../dash/logger";
+import { findAnchorByHash, type AnchorRecord } from "../dash/queries";
 import { suggestChainId } from "../lib/chainId";
-import { formatBytes, formatHashBlocks, formatTimestamp } from "../lib/format";
+import {
+  formatBytes,
+  formatHashBlocks,
+  formatTimestamp,
+  truncateId,
+} from "../lib/format";
 import { bytesToHex, hashFile } from "../lib/hash";
 import { useSession } from "../session/useSession";
 import { OperationResultNotice } from "./OperationResultNotice";
@@ -21,12 +27,14 @@ interface AnchorFormProps {
   contractId: string | null;
   onAnchored: () => void;
   onLoginPrompt: () => void;
+  onViewChainHistory?: (chainId: string) => void;
 }
 
 export function AnchorForm({
   contractId,
   onAnchored,
   onLoginPrompt,
+  onViewChainHistory,
 }: AnchorFormProps) {
   const session = useSession();
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
@@ -43,6 +51,10 @@ export function AnchorForm({
   const [hashCopied, setHashCopied] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [hashing, setHashing] = useState(false);
+  const [checkingDuplicate, setCheckingDuplicate] = useState(false);
+  const [existingAnchor, setExistingAnchor] = useState<AnchorRecord | null>(
+    null,
+  );
   const [dragActive, setDragActive] = useState(false);
   const inputId = "anchor-file-input";
   const inputRef = useRef<HTMLInputElement | null>(null);
@@ -68,6 +80,8 @@ export function AnchorForm({
     setEntryHash(null);
     setHashHex("");
     setHashCopied(false);
+    setCheckingDuplicate(false);
+    setExistingAnchor(null);
     if (!file) {
       if (chainIdAutoManagedRef.current) setChainId("");
       return;
@@ -90,11 +104,39 @@ export function AnchorForm({
       }
       setStatusTone("info");
       setStatusText("SHA-256 computed locally in the browser.");
+      setHashing(false);
+
+      if (!session.sdk || !contractId) return;
+
+      setCheckingDuplicate(true);
+      try {
+        const match = await findAnchorByHash({
+          sdk: session.sdk,
+          contractId,
+          entryHash: digest,
+          log: session.log,
+        });
+        if (fileSelectionRef.current !== requestId) return;
+        setExistingAnchor(match);
+      } catch (err) {
+        // The unique hash index is the real duplicate guard; a failed
+        // pre-flight lookup must not block the local hash preview.
+        if (fileSelectionRef.current === requestId) {
+          session.log?.(errorMessage(err), "error");
+        }
+      } finally {
+        if (fileSelectionRef.current === requestId) {
+          setCheckingDuplicate(false);
+        }
+      }
     } catch (err) {
+      if (fileSelectionRef.current !== requestId) return;
       setStatusTone("error");
       setStatusText(errorMessage(err));
     } finally {
-      setHashing(false);
+      if (fileSelectionRef.current === requestId) {
+        setHashing(false);
+      }
     }
   }
 
@@ -140,32 +182,49 @@ export function AnchorForm({
     setHashCopied(true);
   }
 
-  async function handleSubmit(event: FormEvent) {
-    event.preventDefault();
+  function getSubmitPayload() {
     if (
+      session.status !== "authenticated" ||
       !session.sdk ||
       !session.keyManager ||
       !selectedFile ||
       !entryHash ||
-      !contractId
+      !contractId ||
+      chainId.trim().length === 0 ||
+      checkingDuplicate ||
+      existingAnchor
     ) {
-      return;
+      return null;
     }
+
+    return {
+      sdk: session.sdk,
+      keyManager: session.keyManager,
+      selectedFile,
+      entryHash,
+      contractId,
+    };
+  }
+
+  async function handleSubmit(event: FormEvent) {
+    event.preventDefault();
+    const submitPayload = getSubmitPayload();
+    if (!submitPayload) return;
 
     setSubmitting(true);
     setStatusText(null);
     try {
       await createAnchor({
-        sdk: session.sdk,
-        keyManager: session.keyManager,
-        contractId,
+        sdk: submitPayload.sdk,
+        keyManager: submitPayload.keyManager,
+        contractId: submitPayload.contractId,
         log: session.log,
         anchor: {
-          entryHash,
+          entryHash: submitPayload.entryHash,
           chainId,
-          filename: selectedFile.name,
-          mimeType: selectedFile.type,
-          size: selectedFile.size,
+          filename: submitPayload.selectedFile.name,
+          mimeType: submitPayload.selectedFile.type,
+          size: submitPayload.selectedFile.size,
           note,
         },
       });
@@ -182,14 +241,7 @@ export function AnchorForm({
     }
   }
 
-  const canSubmit =
-    session.status === "authenticated" &&
-    !!session.sdk &&
-    !!session.keyManager &&
-    !!selectedFile &&
-    !!entryHash &&
-    !!contractId &&
-    chainId.trim().length > 0;
+  const canSubmit = getSubmitPayload() !== null;
 
   return (
     <section className="mx-auto max-w-[1000px] rounded-lg border border-line bg-surface p-5">
@@ -314,6 +366,11 @@ export function AnchorForm({
               <span className="h-4 w-4 animate-spin rounded-full border-2 border-line border-t-accent" />
               <span>Computing hash…</span>
             </div>
+          ) : checkingDuplicate ? (
+            <div className="mt-3 flex items-center gap-3 text-[13px] text-ink">
+              <span className="h-4 w-4 animate-spin rounded-full border-2 border-line border-t-accent" />
+              <span>Checking for existing proof…</span>
+            </div>
           ) : (
             <>
               <div className="mt-3 whitespace-pre-wrap font-mono text-[11px] leading-6 text-ink">
@@ -338,13 +395,32 @@ export function AnchorForm({
           />
         </label>
 
+        {existingAnchor && (
+          <OperationResultNotice tone="error" title="Already anchored">
+            This file already has a proof on Dash Platform (chain{" "}
+            <button
+              type="button"
+              onClick={() => onViewChainHistory?.(existingAnchor.chainId)}
+              className="font-medium underline underline-offset-2 transition hover:opacity-80"
+            >
+              {existingAnchor.chainId}
+            </button>
+            , anchored {formatTimestamp(existingAnchor.createdAt)} by{" "}
+            <span className="font-mono">
+              {truncateId(existingAnchor.ownerId, 12)}
+            </span>
+            ). The hash index rejects duplicates, so a new proof can&rsquo;t be
+            created for it.
+          </OperationResultNotice>
+        )}
+
         {statusText && (
           <OperationResultNotice tone={statusTone} title="Proof status">
             {statusText}
           </OperationResultNotice>
         )}
 
-        {session.status !== "authenticated" ? (
+        {existingAnchor ? null : session.status !== "authenticated" ? (
           <div className="rounded-lg border border-dashed border-line px-4 py-4">
             <div className="text-[13px] font-semibold text-ink">
               Login required for submission

--- a/example-apps/dashproof-lab/src/components/AnchorForm.tsx
+++ b/example-apps/dashproof-lab/src/components/AnchorForm.tsx
@@ -55,6 +55,7 @@ export function AnchorForm({
   const [existingAnchor, setExistingAnchor] = useState<AnchorRecord | null>(
     null,
   );
+  const [anchoredCurrentFile, setAnchoredCurrentFile] = useState(false);
   const [dragActive, setDragActive] = useState(false);
   const inputId = "anchor-file-input";
   const inputRef = useRef<HTMLInputElement | null>(null);
@@ -82,6 +83,7 @@ export function AnchorForm({
     setHashCopied(false);
     setCheckingDuplicate(false);
     setExistingAnchor(null);
+    setAnchoredCurrentFile(false);
     if (!file) {
       if (chainIdAutoManagedRef.current) setChainId("");
       return;
@@ -192,7 +194,8 @@ export function AnchorForm({
       !contractId ||
       chainId.trim().length === 0 ||
       checkingDuplicate ||
-      existingAnchor
+      existingAnchor ||
+      anchoredCurrentFile
     ) {
       return null;
     }
@@ -232,6 +235,7 @@ export function AnchorForm({
       setStatusText(
         "Proof created and anchored on Dash Platform. Duplicate hashes are rejected by design.",
       );
+      setAnchoredCurrentFile(true);
       onAnchored();
     } catch (err) {
       setStatusTone("error");

--- a/example-apps/dashproof-lab/src/dash/createAnchor.ts
+++ b/example-apps/dashproof-lab/src/dash/createAnchor.ts
@@ -6,7 +6,7 @@
 import { Document } from "@dashevo/evo-sdk";
 
 import { bytesToBase64, bytesToDocumentArray } from "../lib/hash";
-import type { Logger } from "./logger";
+import { errorMessage, type Logger } from "./logger";
 import type { DashKeyManager, DashSdk } from "./types";
 
 export interface CreateAnchorInput {
@@ -25,6 +25,18 @@ export interface CreateAnchorParams {
   contractId: string;
   anchor: CreateAnchorInput;
   log?: Logger;
+}
+
+export const DUPLICATE_ANCHOR_MESSAGE =
+  "This file is already anchored. The proof contract rejects duplicate SHA-256 hashes.";
+
+function isDuplicateAnchorError(err: unknown): boolean {
+  const message = errorMessage(err).toLowerCase();
+  return (
+    message.includes("duplicate") ||
+    message.includes("unique") ||
+    message.includes("already exists")
+  );
 }
 
 export async function createAnchor({
@@ -73,6 +85,13 @@ export async function createAnchor({
     dataContractId: contractId,
     ownerId: identity.id,
   });
-  await sdk.documents.create({ document, identityKey, signer });
+  try {
+    await sdk.documents.create({ document, identityKey, signer });
+  } catch (err) {
+    if (isDuplicateAnchorError(err)) {
+      throw new Error(DUPLICATE_ANCHOR_MESSAGE);
+    }
+    throw err;
+  }
   log?.("Proof anchor submitted.", "success");
 }

--- a/example-apps/dashproof-lab/src/dash/createAnchor.ts
+++ b/example-apps/dashproof-lab/src/dash/createAnchor.ts
@@ -91,6 +91,7 @@ export async function createAnchor({
     if (isDuplicateAnchorError(err)) {
       throw new Error(DUPLICATE_ANCHOR_MESSAGE);
     }
+    log?.(`Anchor submission failed: ${errorMessage(err)}`, "error", { err });
     throw err;
   }
   log?.("Proof anchor submitted.", "success");

--- a/example-apps/dashproof-lab/src/dash/logger.ts
+++ b/example-apps/dashproof-lab/src/dash/logger.ts
@@ -3,7 +3,11 @@
  */
 export type LogLevel = "info" | "success" | "error";
 
-export type Logger = (message: string, level?: LogLevel) => void;
+export type Logger = (
+  message: string,
+  level?: LogLevel,
+  details?: Record<string, unknown>,
+) => void;
 
 export function errorMessage(err: unknown): string {
   if (err instanceof Error) return err.message;

--- a/example-apps/dashproof-lab/src/session/SessionContext.tsx
+++ b/example-apps/dashproof-lab/src/session/SessionContext.tsx
@@ -51,10 +51,14 @@ export function SessionProvider({ children }: { children: ReactNode }) {
     loadStoredContractId(),
   );
 
-  const log = useCallback<Logger>((message, level = "info") => {
+  const log = useCallback<Logger>((message, level = "info", details) => {
     const method =
       level === "error" ? "error" : level === "success" ? "info" : "log";
-    console[method](`[${level}] ${message}`);
+    if (details) {
+      console[method](`[${level}] ${message}`, details);
+    } else {
+      console[method](`[${level}] ${message}`);
+    }
     if (level === "success") toast.success(message);
     if (level === "error") toast.error(message);
   }, []);

--- a/example-apps/dashproof-lab/test/AnchorForm.test.tsx
+++ b/example-apps/dashproof-lab/test/AnchorForm.test.tsx
@@ -157,6 +157,20 @@ describe("AnchorForm", () => {
       );
     });
     expect(onAnchored).toHaveBeenCalled();
+
+    await waitFor(() => {
+      expect(
+        (
+          screen.getByRole("button", {
+            name: /create proof/i,
+          }) as HTMLButtonElement
+        ).disabled,
+      ).toBe(true);
+    });
+    const form = screen.getByLabelText(/chain id/i).closest("form");
+    expect(form).toBeTruthy();
+    fireEvent.submit(form as HTMLFormElement);
+    expect(mockCreateAnchor).toHaveBeenCalledTimes(1);
   });
 
   it("auto-fills from the filename, preserves manual edits, and resumes after clearing", async () => {

--- a/example-apps/dashproof-lab/test/AnchorForm.test.tsx
+++ b/example-apps/dashproof-lab/test/AnchorForm.test.tsx
@@ -13,11 +13,13 @@ import { AnchorForm } from "../src/components/AnchorForm";
 import { EXAMPLE_FILE_FIXTURES } from "../src/data/exampleFiles";
 import { formatHashBlocks } from "../src/lib/format";
 
-const { mockUseSession, mockHashFile, mockCreateAnchor } = vi.hoisted(() => ({
-  mockUseSession: vi.fn(),
-  mockHashFile: vi.fn(),
-  mockCreateAnchor: vi.fn(),
-}));
+const { mockUseSession, mockHashFile, mockCreateAnchor, mockFindAnchorByHash } =
+  vi.hoisted(() => ({
+    mockUseSession: vi.fn(),
+    mockHashFile: vi.fn(),
+    mockCreateAnchor: vi.fn(),
+    mockFindAnchorByHash: vi.fn(),
+  }));
 
 vi.mock("../src/session/useSession", () => ({
   useSession: mockUseSession,
@@ -35,6 +37,10 @@ vi.mock("../src/dash/createAnchor", () => ({
   createAnchor: mockCreateAnchor,
 }));
 
+vi.mock("../src/dash/queries", () => ({
+  findAnchorByHash: mockFindAnchorByHash,
+}));
+
 function makeSession(overrides: Record<string, unknown> = {}) {
   return {
     status: "readonly",
@@ -49,6 +55,8 @@ beforeEach(() => {
   mockHashFile.mockReset();
   mockCreateAnchor.mockReset();
   mockUseSession.mockReset();
+  mockFindAnchorByHash.mockReset();
+  mockFindAnchorByHash.mockResolvedValue(null);
 });
 
 afterEach(() => {
@@ -242,5 +250,98 @@ describe("AnchorForm", () => {
     await screen.findByText("SHA-256 computed locally in the browser.");
     expect(screen.getByText("drop-proof.txt")).toBeTruthy();
     expect(mockHashFile).toHaveBeenCalledWith(file);
+  });
+
+  it("warns and blocks submit when the file is already anchored", async () => {
+    mockUseSession.mockReturnValue(
+      makeSession({
+        status: "authenticated",
+        keyManager: { getAuth: vi.fn() },
+      }),
+    );
+    mockHashFile.mockResolvedValue(new Uint8Array(32).fill(1));
+    mockFindAnchorByHash.mockResolvedValue({
+      id: "anchor-1",
+      ownerId: "ownerabcdef0123456789",
+      createdAt: 1700000000000,
+      entryHash: new Uint8Array(32).fill(1),
+      entryHashHex: "01".repeat(32),
+      chainId: "existing-chain",
+    });
+    const onViewChainHistory = vi.fn();
+
+    render(
+      <AnchorForm
+        contractId="contract-1"
+        onAnchored={vi.fn()}
+        onLoginPrompt={vi.fn()}
+        onViewChainHistory={onViewChainHistory}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText(/select file/i), {
+      target: {
+        files: [new File(["proof"], "dupe.txt", { type: "text/plain" })],
+      },
+    });
+    fireEvent.change(screen.getByLabelText(/chain id/i), {
+      target: { value: "chain-1" },
+    });
+
+    await screen.findByText("Already anchored");
+    expect(mockFindAnchorByHash).toHaveBeenCalledWith(
+      expect.objectContaining({ contractId: "contract-1" }),
+    );
+    // The submit CTA is removed entirely while a duplicate is detected.
+    expect(screen.queryByRole("button", { name: /create proof/i })).toBeNull();
+    const form = screen.getByLabelText(/chain id/i).closest("form");
+    expect(form).toBeTruthy();
+    fireEvent.submit(form as HTMLFormElement);
+    expect(mockCreateAnchor).not.toHaveBeenCalled();
+
+    // The chain ID links into that chain's history.
+    fireEvent.click(screen.getByRole("button", { name: "existing-chain" }));
+    expect(onViewChainHistory).toHaveBeenCalledWith("existing-chain");
+  });
+
+  it("allows submit and shows no warning when the file is not yet anchored", async () => {
+    mockUseSession.mockReturnValue(
+      makeSession({
+        status: "authenticated",
+        keyManager: { getAuth: vi.fn() },
+      }),
+    );
+    mockHashFile.mockResolvedValue(new Uint8Array(32).fill(2));
+    mockFindAnchorByHash.mockResolvedValue(null);
+
+    render(
+      <AnchorForm
+        contractId="contract-1"
+        onAnchored={vi.fn()}
+        onLoginPrompt={vi.fn()}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText(/select file/i), {
+      target: {
+        files: [new File(["fresh"], "fresh.txt", { type: "text/plain" })],
+      },
+    });
+    fireEvent.change(screen.getByLabelText(/chain id/i), {
+      target: { value: "chain-1" },
+    });
+
+    await screen.findByText("SHA-256 computed locally in the browser.");
+
+    await waitFor(() => {
+      expect(
+        (
+          screen.getByRole("button", {
+            name: /create proof/i,
+          }) as HTMLButtonElement
+        ).disabled,
+      ).toBe(false);
+    });
+    expect(screen.queryByText("Already anchored")).toBeNull();
   });
 });

--- a/example-apps/dashproof-lab/test/dash.test.ts
+++ b/example-apps/dashproof-lab/test/dash.test.ts
@@ -17,7 +17,10 @@ vi.mock("@dashevo/evo-sdk", () => ({
   },
 }));
 
-import { createAnchor } from "../src/dash/createAnchor";
+import {
+  createAnchor,
+  DUPLICATE_ANCHOR_MESSAGE,
+} from "../src/dash/createAnchor";
 import {
   clearStoredContractId,
   loadStoredContractId,
@@ -295,6 +298,38 @@ describe("dashproof helpers", () => {
         },
       }),
     ).rejects.toThrow("entryHash must be a 32-byte SHA-256 digest.");
+  });
+
+  it("createAnchor explains duplicate hash rejections", async () => {
+    const mockDocumentsCreate = vi
+      .fn()
+      .mockRejectedValue(
+        new Error("Invalid transition: duplicate unique index violation"),
+      );
+
+    await expect(
+      createAnchor({
+        sdk: {
+          documents: {
+            create: mockDocumentsCreate,
+          },
+        },
+        keyManager: {
+          async getAuth() {
+            return {
+              identity: { id: "identity-1" },
+              identityKey: undefined,
+              signer: undefined,
+            };
+          },
+        },
+        contractId: "contract-1",
+        anchor: {
+          entryHash: new Uint8Array(32),
+          chainId: "chain-1",
+        },
+      }),
+    ).rejects.toThrow(DUPLICATE_ANCHOR_MESSAGE);
   });
 
   it("createAnchor rejects a previousId that is not 32 bytes", async () => {


### PR DESCRIPTION
## Summary

DashProof's data contract already rejects duplicate SHA-256 hashes via a unique index, but the app exposed that only as a raw SDK error after the user had filled out and submitted the form. This PR adds two layers of duplicate handling so the dead end is caught early and explained clearly.

## Changes

**Pre-flight duplicate detection** (`AnchorForm.tsx`)
- After hashing a selected file locally, the form looks up the hash via `findAnchorByHash`. If a proof already exists, it shows an "Already anchored" notice instead of the submit CTA.
- The notice surfaces the existing anchor's chain, timestamp, and owner, and links the chain ID into that chain's history (new `onViewChainHistory` prop, wired up in `App.tsx`).
- The lookup is best-effort: a failed pre-flight query is logged but never blocks the local hash preview — the unique index remains the real guard.
- Submit gating consolidated into a single `getSubmitPayload()` helper so `canSubmit`, the submit handler, and the new duplicate/`checkingDuplicate` states can't drift apart. Submission is blocked while the check is in flight, when a duplicate is found, or after the current file has been anchored.

**Hardened rejection path** (`createAnchor.ts`)
- `sdk.documents.create` errors that look like a duplicate/unique-index violation are translated into a clear `DUPLICATE_ANCHOR_MESSAGE` rather than a raw SDK error string. This covers the race where a duplicate slips past the pre-flight check.

## Tests

- `AnchorForm.test.tsx`: warns and blocks submit (CTA removed, `createAnchor` not called) when the file is already anchored, including the chain-history link; confirms submit stays enabled with no warning for a fresh file; verifies the form can't be re-submitted after a successful anchor.
- `dash.test.ts`: `createAnchor` surfaces `DUPLICATE_ANCHOR_MESSAGE` on a unique-index violation.

All changes are scoped to `example-apps/dashproof-lab/`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Duplicate anchor detection: the app checks if a file hash is already anchored before allowing submission.
  * View existing proof details (chain, timestamp, owner) and a link to open chain history when a duplicate is found.
* **Bug Fixes**
  * Prevents submitting already-anchored files and shows a clear duplicate-error message.
* **Tests**
  * Added coverage for duplicate-anchor scenarios and navigation-to-history behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->