### PR TITLE
docs: update Node version references to 22.22 toolchain

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Dash Platform Tutorials",
-  "image": "mcr.microsoft.com/devcontainers/javascript-node:20",
+  "image": "mcr.microsoft.com/devcontainers/javascript-node:22",
   "remoteUser": "node",
 
   "onCreateCommand": "cp -n .env.example .env",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,7 @@ Run `node view-wallet.mjs` to confirm the identity is found before proceeding.
 ## Commands
 
 ```bash
+nvm use                 # Use the repo's tested Node 22.22.x toolchain
 npm test                # Read-only tests (~2min, safe to run anytime)
 npm run test:read-write # Write tests (destructive, consumes testnet credits, ~5min)
 npm run test:all        # Both suites sequentially
@@ -26,6 +27,17 @@ npm run test:setup      # Mocha tests for setupDashClient configuration
 npm run lint            # TypeScript type-check all JS files (tsc)
 npm run fmt             # Format with Prettier
 ```
+
+## Node / npm Toolchain
+
+Use the repo-root `.nvmrc` before installing dependencies or updating lockfiles:
+
+```bash
+nvm use
+npm ci
+```
+
+The root package and each standalone example app declare `engines.node` for the tested Node minor version. The example apps have their own `package-lock.json` files, and npm's optional native/WASM dependency resolution can differ across Node/npm versions. For contributor work, prefer `npm ci` under `nvm use`; do not commit lockfile rewrites from another Node/npm version.
 
 **Running a single tutorial directly:**
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ your `.env` file to begin the tutorials.
 
 ## Install
 
-Note: [NodeJS](https://nodejs.org/en/download/) (v20+) must be installed to run the tutorial code.
+Note: [NodeJS](https://nodejs.org/en/download/) (v22.22+) must be installed to run the tutorial code.
 
 ### Clone this repository
 

--- a/example-apps/dashnote/README.md
+++ b/example-apps/dashnote/README.md
@@ -6,7 +6,7 @@ The app stays close to the tutorial `note` contract shape, but extends it with a
 
 ## Prerequisites
 
-- Node >= 20
+- Node 22.22+
 - A funded Dash Platform testnet identity for write operations. Login accepts either a BIP-39 mnemonic (with an optional identity index for DIP-13 derivation) or a WIF private key for an existing HIGH/CRITICAL authentication key on that identity.
 - Read-only mode works without any identity — visitors can read notes for any identity ID against the bundled contract. A previously-logged-in identity can also be re-browsed without re-auth via the remembered-identity flow.
 


### PR DESCRIPTION
Point the dev container image, install prerequisites, and CLAUDE.md toolchain guidance at the repo-pinned Node 22.22.x instead of the prior Node 20 references.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Node.js minimum requirement from v20 to v22.22+ across all setup guides and prerequisites
  * Enhanced contributor documentation with Node/npm toolchain best practices and guidance

* **Chores**
  * Updated development container base image to Node.js v22

<!-- end of auto-generated comment: release notes by coderabbit.ai -->