### PR TITLE
chore: update @dashevo/evo-sdk to 4.0.0

### DIFF
--- a/example-apps/dashmint-lab/package-lock.json
+++ b/example-apps/dashmint-lab/package-lock.json
@@ -8,7 +8,7 @@
       "name": "dashmint-lab",
       "version": "0.0.0",
       "dependencies": {
-        "@dashevo/evo-sdk": "4.0.0-rc.2",
+        "@dashevo/evo-sdk": "4.0.0",
         "@tailwindcss/vite": "^4.2.2",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
@@ -437,20 +437,20 @@
       }
     },
     "node_modules/@dashevo/evo-sdk": {
-      "version": "4.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@dashevo/evo-sdk/-/evo-sdk-4.0.0-rc.2.tgz",
-      "integrity": "sha512-SR823jh4OE19dxNbRPMukGZXj7MTa01af0rXIW1MvO/khN5Mn9Wp4nzzPRRPGXzG74RA46bimyJAhFxqdUz0eQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@dashevo/evo-sdk/-/evo-sdk-4.0.0.tgz",
+      "integrity": "sha512-LH7hu/VAfeNxI6sPG06cNa3fkzfQCF2p0cup2t/EfP0aBmAeI6HwfIRzNvGPdn0iSA7O0n6wv+4lCI2QdYUCFA==",
       "dependencies": {
-        "@dashevo/wasm-sdk": "4.0.0-rc.2"
+        "@dashevo/wasm-sdk": "4.0.0"
       },
       "engines": {
         "node": ">=18.18"
       }
     },
     "node_modules/@dashevo/wasm-sdk": {
-      "version": "4.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@dashevo/wasm-sdk/-/wasm-sdk-4.0.0-rc.2.tgz",
-      "integrity": "sha512-nQH7qVcCz28ePj9TJD7NNfrqEs+YlxtSmUxnCcU8HYZ9A9i3dgW0kU9tCo4RO6mUbnEEausymfy/2rc6nXIhhQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@dashevo/wasm-sdk/-/wasm-sdk-4.0.0.tgz",
+      "integrity": "sha512-VHOE3Q6b/bNGARxZwjZIpOWHf/B1VPmW7Xu5RCN925/7ED7F3TtPl3TvY3UBQnUKN40WhMloc3opTV3BA/jm1w==",
       "engines": {
         "node": ">=18.18"
       }

--- a/example-apps/dashmint-lab/package.json
+++ b/example-apps/dashmint-lab/package.json
@@ -21,7 +21,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@dashevo/evo-sdk": "4.0.0-rc.2",
+    "@dashevo/evo-sdk": "4.0.0",
     "@tailwindcss/vite": "^4.2.2",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",

--- a/example-apps/dashmint-lab/public/dashmint-lite.html
+++ b/example-apps/dashmint-lab/public/dashmint-lite.html
@@ -119,7 +119,7 @@
     // package and serves it as a browser-native ES module. Pinned to the same
     // version the React app at ../package.json depends on so both UIs behave
     // identically against the same testnet contract.
-    import { EvoSDK } from 'https://esm.sh/@dashevo/evo-sdk@4.0.0-rc.2';
+    import { EvoSDK } from 'https://esm.sh/@dashevo/evo-sdk@4.0.0';
 
     // The token-enabled "card" data contract is already published on testnet by
     // the React app. Anyone querying with the same contract id hits the same

--- a/example-apps/dashnote-starter/package-lock.json
+++ b/example-apps/dashnote-starter/package-lock.json
@@ -8,7 +8,7 @@
       "name": "dashnote-starter",
       "version": "0.0.0",
       "dependencies": {
-        "@dashevo/evo-sdk": "4.0.0-rc.2",
+        "@dashevo/evo-sdk": "4.0.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4"
       },
@@ -272,20 +272,20 @@
       }
     },
     "node_modules/@dashevo/evo-sdk": {
-      "version": "4.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@dashevo/evo-sdk/-/evo-sdk-4.0.0-rc.2.tgz",
-      "integrity": "sha512-SR823jh4OE19dxNbRPMukGZXj7MTa01af0rXIW1MvO/khN5Mn9Wp4nzzPRRPGXzG74RA46bimyJAhFxqdUz0eQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@dashevo/evo-sdk/-/evo-sdk-4.0.0.tgz",
+      "integrity": "sha512-LH7hu/VAfeNxI6sPG06cNa3fkzfQCF2p0cup2t/EfP0aBmAeI6HwfIRzNvGPdn0iSA7O0n6wv+4lCI2QdYUCFA==",
       "dependencies": {
-        "@dashevo/wasm-sdk": "4.0.0-rc.2"
+        "@dashevo/wasm-sdk": "4.0.0"
       },
       "engines": {
         "node": ">=18.18"
       }
     },
     "node_modules/@dashevo/wasm-sdk": {
-      "version": "4.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@dashevo/wasm-sdk/-/wasm-sdk-4.0.0-rc.2.tgz",
-      "integrity": "sha512-nQH7qVcCz28ePj9TJD7NNfrqEs+YlxtSmUxnCcU8HYZ9A9i3dgW0kU9tCo4RO6mUbnEEausymfy/2rc6nXIhhQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@dashevo/wasm-sdk/-/wasm-sdk-4.0.0.tgz",
+      "integrity": "sha512-VHOE3Q6b/bNGARxZwjZIpOWHf/B1VPmW7Xu5RCN925/7ED7F3TtPl3TvY3UBQnUKN40WhMloc3opTV3BA/jm1w==",
       "engines": {
         "node": ">=18.18"
       }

--- a/example-apps/dashnote-starter/package.json
+++ b/example-apps/dashnote-starter/package.json
@@ -17,7 +17,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@dashevo/evo-sdk": "4.0.0-rc.2",
+    "@dashevo/evo-sdk": "4.0.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4"
   },

--- a/example-apps/dashnote/package-lock.json
+++ b/example-apps/dashnote/package-lock.json
@@ -8,7 +8,7 @@
       "name": "dashnote",
       "version": "0.0.0",
       "dependencies": {
-        "@dashevo/evo-sdk": "4.0.0-rc.2",
+        "@dashevo/evo-sdk": "4.0.0",
         "@tailwindcss/vite": "^4.2.2",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
@@ -437,20 +437,20 @@
       }
     },
     "node_modules/@dashevo/evo-sdk": {
-      "version": "4.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@dashevo/evo-sdk/-/evo-sdk-4.0.0-rc.2.tgz",
-      "integrity": "sha512-SR823jh4OE19dxNbRPMukGZXj7MTa01af0rXIW1MvO/khN5Mn9Wp4nzzPRRPGXzG74RA46bimyJAhFxqdUz0eQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@dashevo/evo-sdk/-/evo-sdk-4.0.0.tgz",
+      "integrity": "sha512-LH7hu/VAfeNxI6sPG06cNa3fkzfQCF2p0cup2t/EfP0aBmAeI6HwfIRzNvGPdn0iSA7O0n6wv+4lCI2QdYUCFA==",
       "dependencies": {
-        "@dashevo/wasm-sdk": "4.0.0-rc.2"
+        "@dashevo/wasm-sdk": "4.0.0"
       },
       "engines": {
         "node": ">=18.18"
       }
     },
     "node_modules/@dashevo/wasm-sdk": {
-      "version": "4.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@dashevo/wasm-sdk/-/wasm-sdk-4.0.0-rc.2.tgz",
-      "integrity": "sha512-nQH7qVcCz28ePj9TJD7NNfrqEs+YlxtSmUxnCcU8HYZ9A9i3dgW0kU9tCo4RO6mUbnEEausymfy/2rc6nXIhhQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@dashevo/wasm-sdk/-/wasm-sdk-4.0.0.tgz",
+      "integrity": "sha512-VHOE3Q6b/bNGARxZwjZIpOWHf/B1VPmW7Xu5RCN925/7ED7F3TtPl3TvY3UBQnUKN40WhMloc3opTV3BA/jm1w==",
       "engines": {
         "node": ">=18.18"
       }

--- a/example-apps/dashnote/package.json
+++ b/example-apps/dashnote/package.json
@@ -21,7 +21,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@dashevo/evo-sdk": "4.0.0-rc.2",
+    "@dashevo/evo-sdk": "4.0.0",
     "@tailwindcss/vite": "^4.2.2",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",

--- a/example-apps/dashnote/public/dashnote-lite.html
+++ b/example-apps/dashnote/public/dashnote-lite.html
@@ -129,7 +129,7 @@
     // package and serves it as a browser-native ES module. Pinned to the same
     // version the React app at ../package.json depends on so both UIs behave
     // identically against the same testnet contract.
-    import { EvoSDK } from 'https://esm.sh/@dashevo/evo-sdk@4.0.0-rc.2';
+    import { EvoSDK } from 'https://esm.sh/@dashevo/evo-sdk@4.0.0';
 
     // The "note" data contract is already published on testnet by the React app.
     // Anyone querying with the same contract id hits the same documents.

--- a/example-apps/dashproof-lab/package-lock.json
+++ b/example-apps/dashproof-lab/package-lock.json
@@ -8,7 +8,7 @@
       "name": "dashproof-lab",
       "version": "0.0.0",
       "dependencies": {
-        "@dashevo/evo-sdk": "4.0.0-rc.2",
+        "@dashevo/evo-sdk": "4.0.0",
         "@tailwindcss/vite": "^4.2.2",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
@@ -437,20 +437,20 @@
       }
     },
     "node_modules/@dashevo/evo-sdk": {
-      "version": "4.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@dashevo/evo-sdk/-/evo-sdk-4.0.0-rc.2.tgz",
-      "integrity": "sha512-SR823jh4OE19dxNbRPMukGZXj7MTa01af0rXIW1MvO/khN5Mn9Wp4nzzPRRPGXzG74RA46bimyJAhFxqdUz0eQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@dashevo/evo-sdk/-/evo-sdk-4.0.0.tgz",
+      "integrity": "sha512-LH7hu/VAfeNxI6sPG06cNa3fkzfQCF2p0cup2t/EfP0aBmAeI6HwfIRzNvGPdn0iSA7O0n6wv+4lCI2QdYUCFA==",
       "dependencies": {
-        "@dashevo/wasm-sdk": "4.0.0-rc.2"
+        "@dashevo/wasm-sdk": "4.0.0"
       },
       "engines": {
         "node": ">=18.18"
       }
     },
     "node_modules/@dashevo/wasm-sdk": {
-      "version": "4.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@dashevo/wasm-sdk/-/wasm-sdk-4.0.0-rc.2.tgz",
-      "integrity": "sha512-nQH7qVcCz28ePj9TJD7NNfrqEs+YlxtSmUxnCcU8HYZ9A9i3dgW0kU9tCo4RO6mUbnEEausymfy/2rc6nXIhhQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@dashevo/wasm-sdk/-/wasm-sdk-4.0.0.tgz",
+      "integrity": "sha512-VHOE3Q6b/bNGARxZwjZIpOWHf/B1VPmW7Xu5RCN925/7ED7F3TtPl3TvY3UBQnUKN40WhMloc3opTV3BA/jm1w==",
       "engines": {
         "node": ">=18.18"
       }

--- a/example-apps/dashproof-lab/package.json
+++ b/example-apps/dashproof-lab/package.json
@@ -22,7 +22,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@dashevo/evo-sdk": "4.0.0-rc.2",
+    "@dashevo/evo-sdk": "4.0.0",
     "@tailwindcss/vite": "^4.2.2",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",

--- a/example-apps/dashproof-lab/public/dashproof-lite.html
+++ b/example-apps/dashproof-lab/public/dashproof-lite.html
@@ -120,7 +120,7 @@
     // package and serves it as a browser-native ES module. Pinned to the same
     // version the React app at ../package.json depends on so both UIs behave
     // identically against the same testnet contract.
-    import { EvoSDK } from 'https://esm.sh/@dashevo/evo-sdk@4.0.0-rc.2';
+    import { EvoSDK } from 'https://esm.sh/@dashevo/evo-sdk@4.0.0';
 
     // The "anchor" data contract is already published on testnet by the React app.
     // Anyone querying with the same contract id hits the same documents.

--- a/example-apps/dashrate/package-lock.json
+++ b/example-apps/dashrate/package-lock.json
@@ -8,7 +8,7 @@
       "name": "dashrate",
       "version": "0.0.0",
       "dependencies": {
-        "@dashevo/evo-sdk": "4.0.0-rc.2",
+        "@dashevo/evo-sdk": "4.0.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4"
       },
@@ -433,20 +433,20 @@
       }
     },
     "node_modules/@dashevo/evo-sdk": {
-      "version": "4.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@dashevo/evo-sdk/-/evo-sdk-4.0.0-rc.2.tgz",
-      "integrity": "sha512-SR823jh4OE19dxNbRPMukGZXj7MTa01af0rXIW1MvO/khN5Mn9Wp4nzzPRRPGXzG74RA46bimyJAhFxqdUz0eQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@dashevo/evo-sdk/-/evo-sdk-4.0.0.tgz",
+      "integrity": "sha512-LH7hu/VAfeNxI6sPG06cNa3fkzfQCF2p0cup2t/EfP0aBmAeI6HwfIRzNvGPdn0iSA7O0n6wv+4lCI2QdYUCFA==",
       "dependencies": {
-        "@dashevo/wasm-sdk": "4.0.0-rc.2"
+        "@dashevo/wasm-sdk": "4.0.0"
       },
       "engines": {
         "node": ">=18.18"
       }
     },
     "node_modules/@dashevo/wasm-sdk": {
-      "version": "4.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@dashevo/wasm-sdk/-/wasm-sdk-4.0.0-rc.2.tgz",
-      "integrity": "sha512-nQH7qVcCz28ePj9TJD7NNfrqEs+YlxtSmUxnCcU8HYZ9A9i3dgW0kU9tCo4RO6mUbnEEausymfy/2rc6nXIhhQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@dashevo/wasm-sdk/-/wasm-sdk-4.0.0.tgz",
+      "integrity": "sha512-VHOE3Q6b/bNGARxZwjZIpOWHf/B1VPmW7Xu5RCN925/7ED7F3TtPl3TvY3UBQnUKN40WhMloc3opTV3BA/jm1w==",
       "engines": {
         "node": ">=18.18"
       }

--- a/example-apps/dashrate/package.json
+++ b/example-apps/dashrate/package.json
@@ -21,7 +21,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@dashevo/evo-sdk": "4.0.0-rc.2",
+    "@dashevo/evo-sdk": "4.0.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "platform-tutorials",
-  "version": "4.0-rc",
+  "version": "4.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "platform-tutorials",
-      "version": "4.0-rc",
+      "version": "4.0.0",
       "license": "MIT",
       "dependencies": {
-        "@dashevo/evo-sdk": "4.0.0-rc.2",
+        "@dashevo/evo-sdk": "4.0.0",
         "dotenv": "17.3.1"
       },
       "devDependencies": {
@@ -35,20 +35,20 @@
       }
     },
     "node_modules/@dashevo/evo-sdk": {
-      "version": "4.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@dashevo/evo-sdk/-/evo-sdk-4.0.0-rc.2.tgz",
-      "integrity": "sha512-SR823jh4OE19dxNbRPMukGZXj7MTa01af0rXIW1MvO/khN5Mn9Wp4nzzPRRPGXzG74RA46bimyJAhFxqdUz0eQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@dashevo/evo-sdk/-/evo-sdk-4.0.0.tgz",
+      "integrity": "sha512-LH7hu/VAfeNxI6sPG06cNa3fkzfQCF2p0cup2t/EfP0aBmAeI6HwfIRzNvGPdn0iSA7O0n6wv+4lCI2QdYUCFA==",
       "dependencies": {
-        "@dashevo/wasm-sdk": "4.0.0-rc.2"
+        "@dashevo/wasm-sdk": "4.0.0"
       },
       "engines": {
         "node": ">=18.18"
       }
     },
     "node_modules/@dashevo/wasm-sdk": {
-      "version": "4.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@dashevo/wasm-sdk/-/wasm-sdk-4.0.0-rc.2.tgz",
-      "integrity": "sha512-nQH7qVcCz28ePj9TJD7NNfrqEs+YlxtSmUxnCcU8HYZ9A9i3dgW0kU9tCo4RO6mUbnEEausymfy/2rc6nXIhhQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@dashevo/wasm-sdk/-/wasm-sdk-4.0.0.tgz",
+      "integrity": "sha512-VHOE3Q6b/bNGARxZwjZIpOWHf/B1VPmW7Xu5RCN925/7ED7F3TtPl3TvY3UBQnUKN40WhMloc3opTV3BA/jm1w==",
       "engines": {
         "node": ">=18.18"
       }
@@ -1948,17 +1948,17 @@
       "dev": true
     },
     "@dashevo/evo-sdk": {
-      "version": "4.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@dashevo/evo-sdk/-/evo-sdk-4.0.0-rc.2.tgz",
-      "integrity": "sha512-SR823jh4OE19dxNbRPMukGZXj7MTa01af0rXIW1MvO/khN5Mn9Wp4nzzPRRPGXzG74RA46bimyJAhFxqdUz0eQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@dashevo/evo-sdk/-/evo-sdk-4.0.0.tgz",
+      "integrity": "sha512-LH7hu/VAfeNxI6sPG06cNa3fkzfQCF2p0cup2t/EfP0aBmAeI6HwfIRzNvGPdn0iSA7O0n6wv+4lCI2QdYUCFA==",
       "requires": {
-        "@dashevo/wasm-sdk": "4.0.0-rc.2"
+        "@dashevo/wasm-sdk": "4.0.0"
       }
     },
     "@dashevo/wasm-sdk": {
-      "version": "4.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@dashevo/wasm-sdk/-/wasm-sdk-4.0.0-rc.2.tgz",
-      "integrity": "sha512-nQH7qVcCz28ePj9TJD7NNfrqEs+YlxtSmUxnCcU8HYZ9A9i3dgW0kU9tCo4RO6mUbnEEausymfy/2rc6nXIhhQ=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@dashevo/wasm-sdk/-/wasm-sdk-4.0.0.tgz",
+      "integrity": "sha512-VHOE3Q6b/bNGARxZwjZIpOWHf/B1VPmW7Xu5RCN925/7ED7F3TtPl3TvY3UBQnUKN40WhMloc3opTV3BA/jm1w=="
     },
     "@eslint-community/eslint-utils": {
       "version": "4.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "platform-tutorials",
-  "version": "4.0-rc",
+  "version": "4.0.0",
   "description": "Tutorial code for https://docs.dash.org/platform",
   "main": "connect.mjs",
   "scripts": {
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/dashpay/platform-tutorials#readme",
   "dependencies": {
-    "@dashevo/evo-sdk": "4.0.0-rc.2",
+    "@dashevo/evo-sdk": "4.0.0",
     "dotenv": "17.3.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Bump the dependency from the 4.0.0-rc.2 prerelease to the final 4.0.0 release across the root tutorial package and all five example apps, and sync the root package version to 4.0.0.

This is a pure version bump — no source-logic changes are required. Also bump the esm.sh CDN pins in the three lite HTML companions and regenerate all six lockfiles so evo-sdk and its transitive wasm-sdk resolve to 4.0.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project to version **4.0.0**.
  * Upgraded the Dash SDK used across the app and example pages to the stable **4.0.0** release.

* **Bug Fixes**
  * Standardized the runtime SDK version to reduce inconsistencies between the main app and demo pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->