### PR TITLE
fix: unpin the platform protocol version so clients auto-detect

### DIFF
--- a/.github/workflows/test-tutorials.yml
+++ b/.github/workflows/test-tutorials.yml
@@ -41,11 +41,11 @@ jobs:
           node -v
           npm -v
       - run: npm ci
-      - name: Run read-only tutorial tests
+      - name: Run PR-safe tests
         env:
           NETWORK: testnet
           PLATFORM_MNEMONIC: ${{ secrets.PLATFORM_MNEMONIC }}
-        run: npm run test:read-only
+        run: npm test
 
   test-read-write:
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,9 +19,10 @@ Run `node view-wallet.mjs` to confirm the identity is found before proceeding.
 
 ```bash
 nvm use                 # Use the repo's tested Node 22.22.x toolchain
-npm test                # Read-only tests (~2min, safe to run anytime)
+npm test                # All PR-safe suites (~2min, safe to run anytime)
+npm run test:read-only  # Just the tutorial subprocess suite
 npm run test:read-write # Write tests (destructive, consumes testnet credits, ~5min)
-npm run test:all        # Both suites sequentially
+npm run test:all        # Every suite sequentially
 npm run test:setup      # Mocha tests for setupDashClient configuration
 
 npm run lint            # TypeScript type-check all JS files (tsc)
@@ -51,6 +52,8 @@ node 1-Identities-and-Names/identity-retrieve.mjs
 ```bash
 node --test --test-timeout=120000 test/read-only.test.mjs
 ```
+
+**Protocol version:** `createClient()` deliberately leaves the platform protocol version unset so the SDK negotiates it with the network — it starts at a conservative version and ratchets up to whatever the network reports, capped at the newest version the SDK understands. Passing the `version` option pins it and disables negotiation outright, so a hardcoded value silently goes stale at the next network upgrade. Use `sdk.version()` when you need the negotiated value.
 
 ## Architecture
 
@@ -89,7 +92,7 @@ The central helper (~500 lines) that all tutorials import. It handles:
 
 ### Test Framework
 
-Tests use Node.js built-in test runner. Each test runs a tutorial as a **subprocess** via `test/run-tutorial.mjs` and validates:
+Tests use Node.js built-in test runner. The tutorial suites (`read-only`, `read-write`) run each tutorial as a **subprocess** via `test/run-tutorial.mjs` and validate:
 
 - Exit code is 0
 - `stdout`/`stderr` match expected regex patterns
@@ -98,6 +101,14 @@ Tests use Node.js built-in test runner. Each test runs a tutorial as a **subproc
 `test/assertions.mjs` provides helpers like `extractId()` and `extractKeyId()` to capture values from output for use in subsequent dependent tests.
 
 **Read-write tests** maintain a shared state object to pass IDs (contract IDs, document IDs, etc.) between sequential dependent tests.
+
+The remaining suites are repo invariants rather than tutorial runs, which is why they live in their own files:
+
+| File | Checks | Network |
+| - | - | - |
+| `platform-version-config.test.mjs` | `createClient()` passes no `version` to the `*Trusted` factories, so the SDK negotiates the protocol version instead of using a pin | none (factories mocked) |
+| `platform-version.test.mjs` | A live client settles on `min(network active version, SDK ceiling)` after its first proof-bearing read | testnet + mainnet |
+| `lite-sdk-versions.test.mjs` | Each `*-lite.html` page imports exactly the `@dashevo/evo-sdk` version its companion app declares | none |
 
 ### Derivation Paths
 
@@ -135,7 +146,7 @@ Read-only tests skip gracefully when `PLATFORM_MNEMONIC` is unset.
 - **`1-Identities-and-Names/`** — identity registration, top-up, key management, DPNS name registration/lookup
 - **`2-Contracts-and-Documents/`** — data contract variants (minimal, indexed, binary, timestamps, history, NFT), document CRUD, NFT operations
 - **`3-Tokens/`** — token contract registration, info queries, minting, burning, and transfers
-- **`test/`** — test runner, assertions, read-only and read-write test suites
+- **`test/`** — test runner, assertions, tutorial suites (read-only, read-write), and repo-invariant suites (platform version, lite SDK versions)
 - **`docs/`** — HTML/JS interactive tutorial runner (separate from Node tutorials)
 - **`example-apps/`** — Standalone applications (Vite + React + TypeScript) that consume the tutorial SDK code. Each has its own `package.json`, tsconfig, and toolchain — the conventions in this file (Node16 modules, `airbnb-base`, etc.) describe the **root** tutorial code only and do not apply inside `example-apps/`. See each app's local `CLAUDE.md` for its conventions.
 

--- a/README.md
+++ b/README.md
@@ -108,8 +108,11 @@ required — tests use the Node.js built-in test runner.
 Ensure your `.env` file is configured (see [`.env.example`](./.env.example)) before running tests.
 
 ```shell
-# Read-only tests (default) — safe to run, no credits consumed
+# Default — safe to run, no credits consumed
 npm test
+
+# Just the tutorial suite
+npm run test:read-only
 
 # Write tests — registers identities/contracts/documents (consumes testnet credits)
 npm run test:read-write
@@ -117,6 +120,11 @@ npm run test:read-write
 # All tests
 npm run test:all
 ```
+
+Alongside the tutorial suite, `npm test` checks a couple of repository invariants that need no
+credits: that the SDK client negotiates the platform protocol version rather than using a hardcoded
+pin, and that each standalone `*-lite.html` page imports the same Evo SDK version as its companion
+app.
 
 ### Importing an existing wallet
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,10 @@ setup instructions and dependencies but share repository-level SDK client helper
 Tests run each tutorial as a subprocess and validate its output. No test framework dependencies are
 required — tests use the Node.js built-in test runner.
 
-Ensure your `.env` file is configured (see [`.env.example`](./.env.example)) before running tests.
+`npm test` needs no wallet credentials. The tutorial suites do: configure your `.env` file (see
+[`.env.example`](./.env.example)) before running `test:read-only` or `test:read-write` — without a
+`PLATFORM_MNEMONIC` the read-only suite skips the tutorials that need one, and the write suite
+cannot run at all.
 
 ```shell
 # Default — safe to run, no credits consumed

--- a/example-apps/dashmint-lab/public/dashmint-lite.html
+++ b/example-apps/dashmint-lab/public/dashmint-lite.html
@@ -119,7 +119,7 @@
     // package and serves it as a browser-native ES module. Pinned to the same
     // version the React app at ../package.json depends on so both UIs behave
     // identically against the same testnet contract.
-    import { EvoSDK } from 'https://esm.sh/@dashevo/evo-sdk@4.0.0';
+    import { EvoSDK } from 'https://esm.sh/@dashevo/evo-sdk@4.1.0';
 
     // The token-enabled "card" data contract is already published on testnet by
     // the React app. Anyone querying with the same contract id hits the same

--- a/example-apps/dashmint-lab/public/dashmint-lite.html
+++ b/example-apps/dashmint-lab/public/dashmint-lite.html
@@ -131,12 +131,11 @@
     // nodes — no node URL or config needed. connect() does the gRPC handshake
     // + initial sync. No identity or signing is required for read-only queries.
     //
-    // Workaround: pin the platform protocol version for evo-sdk dev.6 so the
-    // SDK doesn't ask testnet for a newer protocol it can't decode. Mirrors
-    // PLATFORM_VERSION_OVERRIDE in setupDashClient-core.mjs. Remove once a
-    // fixed SDK release lands.
+    // The platform protocol version is left unset on purpose: the SDK negotiates
+    // it with the network. Passing `version` pins it and disables that, so a
+    // hardcoded value silently goes stale at the next network upgrade.
     async function connectSdk() {
-      const sdk = EvoSDK.testnetTrusted({ version: 11 });
+      const sdk = EvoSDK.testnetTrusted();
       await sdk.connect();
       return sdk;
     }

--- a/example-apps/dashnote-starter/src/dash/createNote.ts
+++ b/example-apps/dashnote-starter/src/dash/createNote.ts
@@ -4,7 +4,6 @@
  * SDK method: sdk.documents.create({ document, identityKey, signer })
  */
 import type { Logger } from "../lib/logger";
-import { PLATFORM_VERSION_OVERRIDE } from "../../../../platformVersion.mjs";
 import { loadSdkModule } from "./sdkModule";
 import type { DashKeyManager, DashSdk } from "./types";
 
@@ -47,7 +46,7 @@ export async function createNote({
 
   const json =
     typeof document.toJSON === "function"
-      ? (document.toJSON(PLATFORM_VERSION_OVERRIDE) as Record<string, unknown>)
+      ? (document.toJSON(sdk.version()) as Record<string, unknown>)
       : {};
   const noteId = String(json.$id ?? json.id ?? "");
   if (!noteId) {

--- a/example-apps/dashnote-starter/src/dash/types.ts
+++ b/example-apps/dashnote-starter/src/dash/types.ts
@@ -22,6 +22,8 @@ export interface DashDocumentLike {
 }
 
 export interface DashSdk {
+  /** Platform protocol version negotiated with the network. */
+  version(): number;
   contracts: {
     fetch(contractId: string): Promise<{
       toJSON?: () => Record<string, unknown>;

--- a/example-apps/dashnote/public/dashnote-lite.html
+++ b/example-apps/dashnote/public/dashnote-lite.html
@@ -129,7 +129,7 @@
     // package and serves it as a browser-native ES module. Pinned to the same
     // version the React app at ../package.json depends on so both UIs behave
     // identically against the same testnet contract.
-    import { EvoSDK } from 'https://esm.sh/@dashevo/evo-sdk@4.0.0';
+    import { EvoSDK } from 'https://esm.sh/@dashevo/evo-sdk@4.1.0';
 
     // The "note" data contract is already published on testnet by the React app.
     // Anyone querying with the same contract id hits the same documents.

--- a/example-apps/dashnote/src/dash/createNote.ts
+++ b/example-apps/dashnote/src/dash/createNote.ts
@@ -4,7 +4,6 @@
  * SDK method: sdk.documents.create({ document, identityKey, signer })
  */
 import type { Logger } from "../lib/logger";
-import { PLATFORM_VERSION_OVERRIDE } from "../../../../platformVersion.mjs";
 import { loadSdkModule } from "./sdkModule";
 import type { DashKeyManager, DashSdk } from "./types";
 
@@ -47,7 +46,7 @@ export async function createNote({
 
   const json =
     typeof document.toJSON === "function"
-      ? (document.toJSON(PLATFORM_VERSION_OVERRIDE) as Record<string, unknown>)
+      ? (document.toJSON(sdk.version()) as Record<string, unknown>)
       : {};
   const noteId = String(json.$id ?? json.id ?? "");
   if (!noteId) {

--- a/example-apps/dashnote/src/dash/types.ts
+++ b/example-apps/dashnote/src/dash/types.ts
@@ -22,6 +22,8 @@ export interface DashDocumentLike {
 }
 
 export interface DashSdk {
+  /** Platform protocol version negotiated with the network. */
+  version(): number;
   contracts: {
     fetch(contractId: string): Promise<{
       toJSON?: () => Record<string, unknown>;

--- a/example-apps/dashnote/test/dash.test.ts
+++ b/example-apps/dashnote/test/dash.test.ts
@@ -33,6 +33,7 @@ function makeKeyManager() {
 describe("createNote", () => {
   it("creates a note with a trimmed title", async () => {
     const sdk = {
+      version: () => 13,
       documents: {
         create: vi.fn().mockResolvedValue(undefined),
       },
@@ -61,6 +62,7 @@ describe("createNote", () => {
   it("omits a blank title for body-only notes", async () => {
     mockDocumentConstructor.mockReset();
     const sdk = {
+      version: () => 13,
       documents: {
         create: vi.fn().mockResolvedValue(undefined),
       },

--- a/example-apps/dashproof-lab/public/dashproof-lite.html
+++ b/example-apps/dashproof-lab/public/dashproof-lite.html
@@ -120,7 +120,7 @@
     // package and serves it as a browser-native ES module. Pinned to the same
     // version the React app at ../package.json depends on so both UIs behave
     // identically against the same testnet contract.
-    import { EvoSDK } from 'https://esm.sh/@dashevo/evo-sdk@4.0.0';
+    import { EvoSDK } from 'https://esm.sh/@dashevo/evo-sdk@4.1.0';
 
     // The "anchor" data contract is already published on testnet by the React app.
     // Anyone querying with the same contract id hits the same documents.

--- a/example-apps/dashrate/public/dashrate-lite.html
+++ b/example-apps/dashrate/public/dashrate-lite.html
@@ -138,7 +138,7 @@
     // The rest of the file (DOM wiring, render helpers) is plumbing.
     // ============================================================================
 
-    import { EvoSDK } from 'https://esm.sh/@dashevo/evo-sdk@4.0.0';
+    import { EvoSDK } from 'https://esm.sh/@dashevo/evo-sdk@4.1.0';
 
     const CONTRACT_ID = 'BdgTqaTAPYMyhp1WdeWdcvYSgoD7AuJ7tVCaCSXyQgyP';
     const DOC_TYPE = 'review';

--- a/example-apps/dashrate/src/dash/review.ts
+++ b/example-apps/dashrate/src/dash/review.ts
@@ -7,7 +7,6 @@
  *   sdk.documents.get(...)
  *   sdk.documents.replace(...)
  */
-import { PLATFORM_VERSION_OVERRIDE } from "../../../../platformVersion.mjs";
 import type { Logger } from "../lib/logger";
 import { loadSdkModule } from "./sdkModule";
 import { findMyReviewForResource } from "./queries";
@@ -67,10 +66,7 @@ export async function saveReview({
     await sdk.documents.create({ document, identityKey, signer });
     const json =
       typeof document.toJSON === "function"
-        ? (document.toJSON(PLATFORM_VERSION_OVERRIDE) as Record<
-            string,
-            unknown
-          >)
+        ? (document.toJSON(sdk.version()) as Record<string, unknown>)
         : {};
     const reviewId = String(json.$id ?? json.id ?? "");
     if (!reviewId) throw new Error("Created review returned no ID.");

--- a/example-apps/dashrate/src/dash/types.ts
+++ b/example-apps/dashrate/src/dash/types.ts
@@ -27,6 +27,8 @@ export type DashReviewQueryResults =
   | Record<string, DashReviewQueryDocument | undefined>;
 
 export interface DashSdk {
+  /** Platform protocol version negotiated with the network. */
+  version(): number;
   contracts: {
     fetch(contractId: string): Promise<{
       toJSON?: () => Record<string, unknown>;

--- a/example-apps/dashrate/test/review.test.ts
+++ b/example-apps/dashrate/test/review.test.ts
@@ -43,6 +43,7 @@ function makeKeyManager(): DashKeyManager {
 
 function makeSdk(overrides: Partial<DashSdk["documents"]> = {}): DashSdk {
   return {
+    version: () => 13,
     documents: {
       create: vi.fn().mockResolvedValue(undefined),
       replace: vi.fn().mockResolvedValue(undefined),

--- a/package.json
+++ b/package.json
@@ -6,10 +6,10 @@
   "scripts": {
     "fmt": "prettier --write '**/*.{js,mjs}'",
     "lint": "tsc",
-    "test": "node --test --test-timeout=120000 test/read-only.test.mjs test/platform-version.test.mjs test/lite-sdk-versions.test.mjs",
+    "test": "node --test --test-timeout=120000 test/read-only.test.mjs test/platform-version.test.mjs test/platform-version-config.test.mjs test/lite-sdk-versions.test.mjs",
     "test:read-only": "node --test --test-timeout=120000 test/read-only.test.mjs",
     "test:read-write": "node --test --test-timeout=300000 --test-concurrency=1 test/read-write.test.mjs",
-    "test:all": "node --test --test-timeout=300000 --test-concurrency=1 test/read-only.test.mjs test/platform-version.test.mjs test/lite-sdk-versions.test.mjs test/read-write.test.mjs",
+    "test:all": "node --test --test-timeout=300000 --test-concurrency=1 test/read-only.test.mjs test/platform-version.test.mjs test/platform-version-config.test.mjs test/lite-sdk-versions.test.mjs test/read-write.test.mjs",
     "test:setup": "mocha --slow 500 test/setupDashClient.test.mjs --exit",
     "walkthrough:dashmint-lab": "node scripts/walkthroughs/record.mjs dashmint-lab",
     "walkthrough:dashnote": "node scripts/walkthroughs/record.mjs dashnote",

--- a/package.json
+++ b/package.json
@@ -6,10 +6,10 @@
   "scripts": {
     "fmt": "prettier --write '**/*.{js,mjs}'",
     "lint": "tsc",
-    "test": "node --test --test-timeout=120000 test/read-only.test.mjs",
+    "test": "node --test --test-timeout=120000 test/read-only.test.mjs test/platform-version.test.mjs test/lite-sdk-versions.test.mjs",
     "test:read-only": "node --test --test-timeout=120000 test/read-only.test.mjs",
     "test:read-write": "node --test --test-timeout=300000 --test-concurrency=1 test/read-write.test.mjs",
-    "test:all": "node --test --test-timeout=300000 --test-concurrency=1 test/read-only.test.mjs test/read-write.test.mjs",
+    "test:all": "node --test --test-timeout=300000 --test-concurrency=1 test/read-only.test.mjs test/platform-version.test.mjs test/lite-sdk-versions.test.mjs test/read-write.test.mjs",
     "test:setup": "mocha --slow 500 test/setupDashClient.test.mjs --exit",
     "walkthrough:dashmint-lab": "node scripts/walkthroughs/record.mjs dashmint-lab",
     "walkthrough:dashnote": "node scripts/walkthroughs/record.mjs dashnote",

--- a/platformVersion.d.mts
+++ b/platformVersion.d.mts
@@ -1,1 +1,0 @@
-export declare const PLATFORM_VERSION_OVERRIDE: number;

--- a/platformVersion.mjs
+++ b/platformVersion.mjs
@@ -1,4 +1,0 @@
-// TODO: Remove this pin once dashpay/platform#3809 lands in the consumed
-// @dashevo/evo-sdk release; unpinned clients should then auto-detect the
-// network protocol version safely.
-export const PLATFORM_VERSION_OVERRIDE = 12;

--- a/setupDashClient-core.d.mts
+++ b/setupDashClient-core.d.mts
@@ -200,8 +200,6 @@ export declare class AddressKeyManager {
 
 export declare const KEY_SPECS: readonly unknown[];
 
-export declare const PLATFORM_VERSION_OVERRIDE: number;
-
 export declare function dip13KeyPath(
   network: string,
   identityIndex: number,

--- a/setupDashClient-core.mjs
+++ b/setupDashClient-core.mjs
@@ -25,7 +25,6 @@ import {
   SecurityLevel,
   wallet,
 } from '@dashevo/evo-sdk';
-import { PLATFORM_VERSION_OVERRIDE } from './platformVersion.mjs';
 
 /** @typedef {import('@dashevo/evo-sdk').Identity} Identity */
 /** @typedef {import('@dashevo/evo-sdk').IdentityPublicKey} IdentityPublicKey */
@@ -103,21 +102,25 @@ export async function dip13KeyPath(network, identityIndex, keyIndex) {
 // SDK client helpers
 // ---------------------------------------------------------------------------
 
-export { PLATFORM_VERSION_OVERRIDE };
-
 /**
  * Create and connect an EvoSDK client for the selected network.
+ *
+ * The platform protocol version is deliberately left unset so the SDK
+ * negotiates it with the network: it starts from a conservative version and
+ * ratchets up to whatever the network reports, capped at the newest version
+ * the SDK itself understands. Pinning it via the `version` option disables
+ * that negotiation outright, so a hardcoded value silently goes stale the
+ * next time the network upgrades. Use `sdk.version()` when you need the
+ * negotiated value.
  *
  * @param {string} [network='testnet']
  * @returns {Promise<EvoSDK>}
  */
 export async function createClient(network = 'testnet') {
   const factories = /** @type {Record<string, () => EvoSDK>} */ ({
-    testnet: () =>
-      EvoSDK.testnetTrusted({ version: PLATFORM_VERSION_OVERRIDE }),
-    mainnet: () =>
-      EvoSDK.mainnetTrusted({ version: PLATFORM_VERSION_OVERRIDE }),
-    local: () => EvoSDK.localTrusted({ version: PLATFORM_VERSION_OVERRIDE }),
+    testnet: () => EvoSDK.testnetTrusted(),
+    mainnet: () => EvoSDK.mainnetTrusted(),
+    local: () => EvoSDK.localTrusted(),
   });
 
   const factory = factories[network];

--- a/test/lite-sdk-versions.test.mjs
+++ b/test/lite-sdk-versions.test.mjs
@@ -1,0 +1,42 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { describe, it } from 'node:test';
+
+const litePages = [
+  ['dashmint-lab', 'dashmint-lite.html'],
+  ['dashnote', 'dashnote-lite.html'],
+  ['dashrate', 'dashrate-lite.html'],
+  ['dashproof-lab', 'dashproof-lite.html'],
+];
+
+describe('Standalone lite SDK versions', () => {
+  for (const [appName, pageName] of litePages) {
+    it(`${appName} matches its companion app`, () => {
+      const appDirectory = new URL(
+        `../example-apps/${appName}/`,
+        import.meta.url,
+      );
+      const packageJson = JSON.parse(
+        readFileSync(new URL('package.json', appDirectory), 'utf8'),
+      );
+      const page = readFileSync(
+        new URL(`public/${pageName}`, appDirectory),
+        'utf8',
+      );
+      const expectedImport =
+        `https://esm.sh/@dashevo/evo-sdk@` +
+        packageJson.dependencies['@dashevo/evo-sdk'];
+      const sdkImports = [
+        ...page.matchAll(
+          /from\s+['"](https:\/\/esm\.sh\/@dashevo\/evo-sdk@[^'"]+)['"]/g,
+        ),
+      ].map((match) => match[1]);
+
+      assert.deepEqual(
+        sdkImports,
+        [expectedImport],
+        `${pageName} must import exactly the SDK version from ${appName}/package.json`,
+      );
+    });
+  }
+});

--- a/test/platform-version-config.test.mjs
+++ b/test/platform-version-config.test.mjs
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { EvoSDK } from '@dashevo/evo-sdk';
+import { createClient } from '../setupDashClient-core.mjs';
+
+const trustedFactories = [
+  ['testnet', 'testnetTrusted'],
+  ['mainnet', 'mainnetTrusted'],
+  ['local', 'localTrusted'],
+];
+
+describe('Platform protocol version configuration', () => {
+  for (const [network, factoryName] of trustedFactories) {
+    it(`${network} leaves the SDK version unpinned`, async (t) => {
+      const sdk = { connect: t.mock.fn(async () => {}) };
+      const factory = t.mock.method(EvoSDK, factoryName, () => sdk);
+
+      assert.equal(await createClient(network), sdk);
+      assert.equal(factory.mock.callCount(), 1);
+      assert.deepEqual(factory.mock.calls[0].arguments, []);
+      assert.equal(sdk.connect.mock.callCount(), 1);
+    });
+  }
+});

--- a/test/platform-version.test.mjs
+++ b/test/platform-version.test.mjs
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import dotenv from 'dotenv';
+import { EvoSDK } from '@dashevo/evo-sdk';
+import { createClient } from '../setupDashClient-core.mjs';
+
+dotenv.config();
+
+// DPNS — a system contract, so it exists on every network and needs no fixture.
+const DPNS_CONTRACT_ID = 'GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec';
+
+describe('Platform protocol version', () => {
+  // Regression guard for #112: createClient() must leave the protocol version
+  // unpinned so the SDK negotiates it. A hardcoded pin disables negotiation
+  // silently — no error, no warning — and the client stays on the old version
+  // forever once the network upgrades.
+  it('negotiates the version instead of using a hardcoded pin', async () => {
+    const network = process.env.NETWORK || 'testnet';
+    const sdk = await createClient(network);
+
+    // status() hands back a WASM handle — the fields are only reachable
+    // through toJSON().
+    const status = (await sdk.system.status()).toJSON();
+    const networkVersion = Number(status.version.protocol.drive.current);
+    const sdkNewestKnown = await EvoSDK.getLatestVersionNumber();
+
+    // A proof-bearing read is what carries the network's version back to the
+    // client; the negotiated value is only settled after the first one.
+    await sdk.contracts.fetch(DPNS_CONTRACT_ID);
+
+    // The client should land on the network's active version, except when the
+    // network has moved past what this SDK release understands — then it stays
+    // at its own ceiling. Asserting against the min() of the two keeps this
+    // test honest without turning every network upgrade into a red build.
+    assert.equal(
+      sdk.version(),
+      Math.min(networkVersion, sdkNewestKnown),
+      `client settled on protocol version ${sdk.version()}, but the network ` +
+        `is on ${networkVersion} and this SDK understands up to ` +
+        `${sdkNewestKnown} — check for a reintroduced version pin`,
+    );
+  });
+});

--- a/test/platform-version.test.mjs
+++ b/test/platform-version.test.mjs
@@ -1,10 +1,7 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
-import dotenv from 'dotenv';
 import { EvoSDK } from '@dashevo/evo-sdk';
 import { createClient } from '../setupDashClient-core.mjs';
-
-dotenv.config();
 
 // DPNS — a system contract, so it exists on every network and needs no fixture.
 const DPNS_CONTRACT_ID = 'GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec';

--- a/test/platform-version.test.mjs
+++ b/test/platform-version.test.mjs
@@ -14,30 +14,31 @@ describe('Platform protocol version', () => {
   // unpinned so the SDK negotiates it. A hardcoded pin disables negotiation
   // silently — no error, no warning — and the client stays on the old version
   // forever once the network upgrades.
-  it('negotiates the version instead of using a hardcoded pin', async () => {
-    const network = process.env.NETWORK || 'testnet';
-    const sdk = await createClient(network);
+  for (const network of ['testnet', 'mainnet']) {
+    it(`${network} negotiates the version instead of using a hardcoded pin`, async () => {
+      const sdk = await createClient(network);
 
-    // status() hands back a WASM handle — the fields are only reachable
-    // through toJSON().
-    const status = (await sdk.system.status()).toJSON();
-    const networkVersion = Number(status.version.protocol.drive.current);
-    const sdkNewestKnown = await EvoSDK.getLatestVersionNumber();
+      // status() hands back a WASM handle — the fields are only reachable
+      // through toJSON().
+      const status = (await sdk.system.status()).toJSON();
+      const networkVersion = Number(status.version.protocol.drive.current);
+      const sdkNewestKnown = await EvoSDK.getLatestVersionNumber();
 
-    // A proof-bearing read is what carries the network's version back to the
-    // client; the negotiated value is only settled after the first one.
-    await sdk.contracts.fetch(DPNS_CONTRACT_ID);
+      // A proof-bearing read is what carries the network's version back to the
+      // client; the negotiated value is only settled after the first one.
+      await sdk.contracts.fetch(DPNS_CONTRACT_ID);
 
-    // The client should land on the network's active version, except when the
-    // network has moved past what this SDK release understands — then it stays
-    // at its own ceiling. Asserting against the min() of the two keeps this
-    // test honest without turning every network upgrade into a red build.
-    assert.equal(
-      sdk.version(),
-      Math.min(networkVersion, sdkNewestKnown),
-      `client settled on protocol version ${sdk.version()}, but the network ` +
-        `is on ${networkVersion} and this SDK understands up to ` +
-        `${sdkNewestKnown} — check for a reintroduced version pin`,
-    );
-  });
+      // The client should land on the network's active version, except when the
+      // network has moved past what this SDK release understands — then it stays
+      // at its own ceiling. Asserting against the min() of the two keeps this
+      // test honest without turning every network upgrade into a red build.
+      assert.equal(
+        sdk.version(),
+        Math.min(networkVersion, sdkNewestKnown),
+        `client settled on protocol version ${sdk.version()}, but ${network} ` +
+          `is on ${networkVersion} and this SDK understands up to ` +
+          `${sdkNewestKnown} — check for a reintroduced version pin`,
+      );
+    });
+  }
 });

--- a/test/read-only.test.mjs
+++ b/test/read-only.test.mjs
@@ -1,11 +1,7 @@
-import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
 import { describe, it } from 'node:test';
 import dotenv from 'dotenv';
-import { EvoSDK } from '@dashevo/evo-sdk';
 import { runTutorial } from './run-tutorial.mjs';
 import { assertTutorialSuccess } from './assertions.mjs';
-import { createClient } from '../setupDashClient-core.mjs';
 
 dotenv.config();
 
@@ -82,79 +78,4 @@ describe('Read-only tutorials', () => {
       assertTutorialSuccess(result, entry);
     });
   }
-});
-
-const litePages = [
-  ['dashmint-lab', 'dashmint-lite.html'],
-  ['dashnote', 'dashnote-lite.html'],
-  ['dashrate', 'dashrate-lite.html'],
-  ['dashproof-lab', 'dashproof-lite.html'],
-];
-
-describe('Standalone lite SDK versions', () => {
-  for (const [appName, pageName] of litePages) {
-    it(`${appName} matches its companion app`, () => {
-      const appDirectory = new URL(
-        `../example-apps/${appName}/`,
-        import.meta.url,
-      );
-      const packageJson = JSON.parse(
-        readFileSync(new URL('package.json', appDirectory), 'utf8'),
-      );
-      const page = readFileSync(
-        new URL(`public/${pageName}`, appDirectory),
-        'utf8',
-      );
-      const expectedImport =
-        `https://esm.sh/@dashevo/evo-sdk@` +
-        packageJson.dependencies['@dashevo/evo-sdk'];
-      const sdkImports = [
-        ...page.matchAll(
-          /from\s+['"](https:\/\/esm\.sh\/@dashevo\/evo-sdk@[^'"]+)['"]/g,
-        ),
-      ].map((match) => match[1]);
-
-      assert.deepEqual(
-        sdkImports,
-        [expectedImport],
-        `${pageName} must import exactly the SDK version from ${appName}/package.json`,
-      );
-    });
-  }
-});
-
-// DPNS — a system contract, so it exists on every network and needs no fixture.
-const DPNS_CONTRACT_ID = 'GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec';
-
-describe('Platform protocol version', () => {
-  // Regression guard for #112: createClient() must leave the protocol version
-  // unpinned so the SDK negotiates it. A hardcoded pin disables negotiation
-  // silently — no error, no warning — and the client stays on the old version
-  // forever once the network upgrades.
-  it('negotiates the version instead of using a hardcoded pin', async () => {
-    const network = process.env.NETWORK || 'testnet';
-    const sdk = await createClient(network);
-
-    // status() hands back a WASM handle — the fields are only reachable
-    // through toJSON().
-    const status = (await sdk.system.status()).toJSON();
-    const networkVersion = Number(status.version.protocol.drive.current);
-    const sdkNewestKnown = await EvoSDK.getLatestVersionNumber();
-
-    // A proof-bearing read is what carries the network's version back to the
-    // client; the negotiated value is only settled after the first one.
-    await sdk.contracts.fetch(DPNS_CONTRACT_ID);
-
-    // The client should land on the network's active version, except when the
-    // network has moved past what this SDK release understands — then it stays
-    // at its own ceiling. Asserting against the min() of the two keeps this
-    // test honest without turning every network upgrade into a red build.
-    assert.equal(
-      sdk.version(),
-      Math.min(networkVersion, sdkNewestKnown),
-      `client settled on protocol version ${sdk.version()}, but the network ` +
-        `is on ${networkVersion} and this SDK understands up to ` +
-        `${sdkNewestKnown} — check for a reintroduced version pin`,
-    );
-  });
 });

--- a/test/read-only.test.mjs
+++ b/test/read-only.test.mjs
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
 import { describe, it } from 'node:test';
 import dotenv from 'dotenv';
 import { EvoSDK } from '@dashevo/evo-sdk';
@@ -79,6 +80,45 @@ describe('Read-only tutorials', () => {
         timeoutMs: entry.timeoutMs,
       });
       assertTutorialSuccess(result, entry);
+    });
+  }
+});
+
+const litePages = [
+  ['dashmint-lab', 'dashmint-lite.html'],
+  ['dashnote', 'dashnote-lite.html'],
+  ['dashrate', 'dashrate-lite.html'],
+  ['dashproof-lab', 'dashproof-lite.html'],
+];
+
+describe('Standalone lite SDK versions', () => {
+  for (const [appName, pageName] of litePages) {
+    it(`${appName} matches its companion app`, () => {
+      const appDirectory = new URL(
+        `../example-apps/${appName}/`,
+        import.meta.url,
+      );
+      const packageJson = JSON.parse(
+        readFileSync(new URL('package.json', appDirectory), 'utf8'),
+      );
+      const page = readFileSync(
+        new URL(`public/${pageName}`, appDirectory),
+        'utf8',
+      );
+      const expectedImport =
+        `https://esm.sh/@dashevo/evo-sdk@` +
+        packageJson.dependencies['@dashevo/evo-sdk'];
+      const sdkImports = [
+        ...page.matchAll(
+          /from\s+['"](https:\/\/esm\.sh\/@dashevo\/evo-sdk@[^'"]+)['"]/g,
+        ),
+      ].map((match) => match[1]);
+
+      assert.deepEqual(
+        sdkImports,
+        [expectedImport],
+        `${pageName} must import exactly the SDK version from ${appName}/package.json`,
+      );
     });
   }
 });

--- a/test/read-only.test.mjs
+++ b/test/read-only.test.mjs
@@ -1,7 +1,10 @@
+import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import dotenv from 'dotenv';
+import { EvoSDK } from '@dashevo/evo-sdk';
 import { runTutorial } from './run-tutorial.mjs';
 import { assertTutorialSuccess } from './assertions.mjs';
+import { createClient } from '../setupDashClient-core.mjs';
 
 dotenv.config();
 
@@ -78,4 +81,40 @@ describe('Read-only tutorials', () => {
       assertTutorialSuccess(result, entry);
     });
   }
+});
+
+// DPNS — a system contract, so it exists on every network and needs no fixture.
+const DPNS_CONTRACT_ID = 'GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec';
+
+describe('Platform protocol version', () => {
+  // Regression guard for #112: createClient() must leave the protocol version
+  // unpinned so the SDK negotiates it. A hardcoded pin disables negotiation
+  // silently — no error, no warning — and the client stays on the old version
+  // forever once the network upgrades.
+  it('negotiates the version instead of using a hardcoded pin', async () => {
+    const network = process.env.NETWORK || 'testnet';
+    const sdk = await createClient(network);
+
+    // status() hands back a WASM handle — the fields are only reachable
+    // through toJSON().
+    const status = (await sdk.system.status()).toJSON();
+    const networkVersion = Number(status.version.protocol.drive.current);
+    const sdkNewestKnown = await EvoSDK.getLatestVersionNumber();
+
+    // A proof-bearing read is what carries the network's version back to the
+    // client; the negotiated value is only settled after the first one.
+    await sdk.contracts.fetch(DPNS_CONTRACT_ID);
+
+    // The client should land on the network's active version, except when the
+    // network has moved past what this SDK release understands — then it stays
+    // at its own ceiling. Asserting against the min() of the two keeps this
+    // test honest without turning every network upgrade into a red build.
+    assert.equal(
+      sdk.version(),
+      Math.min(networkVersion, sdkNewestKnown),
+      `client settled on protocol version ${sdk.version()}, but the network ` +
+        `is on ${networkVersion} and this SDK understands up to ` +
+        `${sdkNewestKnown} — check for a reintroduced version pin`,
+    );
+  });
 });


### PR DESCRIPTION
Closes #112.

## The problem

`PLATFORM_VERSION_OVERRIDE` was pinned to `12` while testnet has been running protocol version 13 since late July. A pin is not a floor — in `rs-sdk` the version ratchet returns early when `version_pinned` is set, so a pinned client stays on the old version **silently**: no error, no warning, no matter what the network reports.

The constant's own TODO said to remove it once dashpay/platform#3809 landed in the consumed SDK. That condition is now met.

## Why remove rather than bump to 13

Bumping re-arms the identical trap for protocol version 14 and leaves the failure mode intact — invisible, and (before this PR) unobservable in CI. Removing the pin is what the TODO prescribed, and auto-detection is verified working in the consumed release.

Measured against `@dashevo/evo-sdk@4.1.0` and live testnet:

| client config | `sdk.version()` after `connect()` | after first proof-bearing read |
| --- | :---: | :---: |
| unpinned | 12 | **13** |
| `{ version: 12 }` | 12 | 12 |
| `{ version: 13 }` | 13 | 13 |

Testnet reports `protocol.drive.current = 13`; the SDK's own ceiling (`EvoSDK.getLatestVersionNumber()`) is 13. So an unpinned client negotiates up to the network's active version, capped at what the SDK understands — exactly the #3809 behavior.

## Changes

- **Remove the pin.** `createClient()` no longer passes `version` to `testnetTrusted` / `mainnetTrusted` / `localTrusted`.
- **Delete `platformVersion.mjs` / `.d.mts`.** The module existed only to hold this constant.
- **Example apps pass `sdk.version()`** to `document.toJSON(...)` instead of the constant (dashnote, dashnote-starter, dashrate). That reflects the negotiated version and cannot go stale. `DashSdk` in each app gains `version(): number`.
- **Standalone lite pages are aligned with SDK 4.1.0.** `dashmint-lite.html` carried the same defect independently — pinned to `11`, with a comment pointing back at this constant — so it is unpinned. DashMint, Dashnote, DashRate, and DashProof lite pages now import the same Evo SDK version as their companion apps.
- **Focused regression suites run in PR CI.** `test:read-only` remains tutorial-only; `npm test` adds separate protocol-negotiation, factory-configuration, and lite-page SDK-version checks.

## Regression coverage

The pin was invisible to CI before this PR: pull requests ran only `test:read-only`, and that suite passed against a PV-13 testnet with the client stuck on 12 the whole time. Nothing asserted the negotiated version.

The coverage is split by concern so `test/read-only.test.mjs` remains strictly a tutorial suite:

- `test/platform-version.test.mjs` performs a proof-bearing DPNS read on **both testnet and mainnet**, then asserts that each client settles on `min(network active version, SDK ceiling)`. This accommodates a network upgrading ahead of the installed SDK without hiding a stale pin. The testnet case was also verified to fail with `{ version: 12 }` restored.
- `test/platform-version-config.test.mjs` spies on `testnetTrusted`, `mainnetTrusted`, and `localTrusted` and asserts that every factory is called with zero arguments. This directly catches any reintroduced `{ version: ... }` option even while a pin happens to equal the network's current version.
- `test/lite-sdk-versions.test.mjs` checks that every standalone lite page imports exactly the Evo SDK version declared by its companion app.

`npm test` runs these focused checks alongside the read-only tutorials, and the PR workflow now calls that aggregate. None of the new checks needs credentials or funds; the live negotiation fixture is the DPNS system contract.

## Validation

All against Node 22.22.0, matching the `.nvmrc` 22.22 release line and package engine constraint.

| gate | result |
| --- | --- |
| `npm run lint` (tsc) | pass |
| `npm test` | 18 passed, including live testnet + mainnet negotiation and all three no-pin factory guards |
| `npm run test:setup` | 47 passing |
| `prettier --check` (changed files) | clean |
| dashnote `build` + `test` + `lint` | build ok, 346 passed |
| dashrate `build` + `test` + `lint` | build ok, 160 passed |
| dashnote-starter `build` + `lint` | pass (no test suite by design) |
| dashmint-lab production build | pass |
| dashproof-lab production build | pass |
| standalone lite SDK-version regression | 4/4 pass; built pages contain the 4.1.0 import |
| `scripts/check-shared-auth-parity.sh` | byte-identical |
| dashnote load-anchor check | no static `evo-sdk` import in entry chunk |

`node connect.mjs` drives the real path end-to-end and reports `drive: 4.1.0` on testnet.

## Not verified

- **The write path.** `test:read-write` is destructive and consumes testnet credits, and no funded `PLATFORM_MNEMONIC` was available here, so it was not run. This PR does not claim to have settled the open question in #112 about whether a version-12-pinned client behaved differently for state transitions — it removes the pin so the question stops mattering. A `workflow_dispatch` run of the read-write suite would still be worth doing before this merges.
- **Standalone lite pages in a browser.** No browser-level CDN fetch was performed. Their exact source and production-build import URLs are covered statically, while the live root regression verifies SDK 4.1.0 protocol negotiation against both testnet and mainnet.

## Follow-ups, deliberately out of scope

- Pre-existing and untouched here: 3 `react-hooks/set-state-in-effect` lint errors in dashnote (`LoginModal.tsx`, `NotesWorkspace.tsx`) and a Prettier warning on `dashrate/public/dashrate-lite.html`.
- #112 also suggests running the read-write suite on a schedule, since a version-sensitive regression is currently only observable by manual dispatch.

Tracker: thepastaclaw/tracker#2594 (remains open pending review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SDK connections now automatically negotiate the supported protocol version for testnet, mainnet, and local environments.
  * Updated example applications to use Evo SDK 4.1.0.

* **Bug Fixes**
  * Improved note and review serialization to use the negotiated protocol version.

* **Tests**
  * Added coverage for protocol negotiation and SDK version consistency across standalone Lite applications.
  * Expanded the default test suite to include these checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
